### PR TITLE
feat(graphql): Add instance and schema to servers map

### DIFF
--- a/docs/tutorials/graphql.md
+++ b/docs/tutorials/graphql.md
@@ -69,7 +69,7 @@ export class UsersService implements AfterRoutesInit {
     }
 
     $afterRoutesInit() {
-        this.server = this.graphQLService.get("server1");
+        this.server = this.graphQLService.get("server1").instance;
     }
 }
 ```

--- a/packages/graphql/src/interfaces/IGraphQLServer.ts
+++ b/packages/graphql/src/interfaces/IGraphQLServer.ts
@@ -1,0 +1,7 @@
+import {ApolloServer} from "apollo-server-express";
+import {GraphQLSchema} from "graphql";
+
+export interface IGraphQLServer {
+  instance: ApolloServer;
+  schema: GraphQLSchema;
+}

--- a/packages/graphql/src/services/GraphQLService.ts
+++ b/packages/graphql/src/services/GraphQLService.ts
@@ -27,7 +27,7 @@ export class GraphQLService {
 
   /**
    *
-   * @returns {Promise<"mongoose".Connection>}
+   * @returns {Promise<ApolloServer>}
    */
   async createServer(id: string, settings: IGraphQLSettings): Promise<any> {
     const {
@@ -92,7 +92,7 @@ export class GraphQLService {
 
   /**
    * Get an instance of ApolloServer from his id
-   * @returns {"mongoose".Connection}
+   * @returns ApolloServer
    */
   get(id: string = "default"): ApolloServer | undefined {
     return this._servers.get(id)!.instance;
@@ -100,7 +100,7 @@ export class GraphQLService {
 
   /**
    * Get an instance of GraphQL schema from his id
-   * @returns {"mongoose".Connection}
+   * @returns GraphQLSchema
    */
   getSchema(id: string = "default"): GraphQLSchema | undefined {
     return this._servers.get(id)!.schema;

--- a/packages/graphql/src/services/GraphQLService.ts
+++ b/packages/graphql/src/services/GraphQLService.ts
@@ -1,6 +1,7 @@
-import {Constant, ExpressApplication, HttpServer, Inject, InjectorService, Provider, Service} from "@tsed/common";
+import {Constant, ExpressApplication, HttpServer, InjectorService, Provider, Service} from "@tsed/common";
 import {Type} from "@tsed/core";
 import {ApolloServer} from "apollo-server-express";
+import {GraphQLSchema} from "graphql";
 import {$log} from "ts-log-debug";
 import {buildSchema, BuildSchemaOptions, useContainer} from "type-graphql";
 import {IGraphQLServer} from "../interfaces/IGraphQLServer";
@@ -40,7 +41,7 @@ export class GraphQLService {
     } = settings;
 
     if (this.has(id)) {
-      return await this.get(id)!.instance;
+      return await this.get(id)!;
     }
 
     $log.info(`Create server with apollo-server-express for: ${id}`);
@@ -93,8 +94,16 @@ export class GraphQLService {
    * Get an instance of ApolloServer from his id
    * @returns {"mongoose".Connection}
    */
-  get(id: string = "default"): IGraphQLServer | undefined {
-    return this._servers.get(id);
+  get(id: string = "default"): ApolloServer | undefined {
+    return this._servers.get(id)!.instance;
+  }
+
+  /**
+   * Get an instance of GraphQL schema from his id
+   * @returns {"mongoose".Connection}
+   */
+  getSchema(id: string = "default"): GraphQLSchema | undefined {
+    return this._servers.get(id)!.schema;
   }
 
   /**


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
Feature | Yes

****

## Description
GraphQLService allows to get ApolloServer instance only and it's impossible to get a generated Schema. I changed `_instances` map to object that contains 2 properties currently:

* instance
* schema

Is this fine? Because I'm not sure if it's the best option and maybe there's a better way to do it :)

## Todos

- [x] Tests
- [x] Coverage
- [x] Example