### PR TITLE
Fixed #546

### DIFF
--- a/packages/mongoose/src/decorators/virtualRef.ts
+++ b/packages/mongoose/src/decorators/virtualRef.ts
@@ -1,5 +1,6 @@
 import {PropertyMetadata, PropertyRegistry} from "@tsed/common";
 import {MONGOOSE_SCHEMA} from "../constants";
+import {MongooseVirtualRefOptions} from "../interfaces/MongooseVirtualRefOptions";
 
 export type VirtualRef<T> = T | null;
 export type VirtualRefs<T> = T[];
@@ -38,12 +39,26 @@ export type VirtualRefs<T> = T[];
  * @decorator
  * @mongoose
  */
-export function VirtualRef(type: string, foreignField: string) {
+
+export function VirtualRef(type: string, foreignField: string): Function;
+export function VirtualRef(options: MongooseVirtualRefOptions): Function;
+
+export function VirtualRef(options: string | MongooseVirtualRefOptions, foreignField?: string): Function {
   return PropertyRegistry.decorate((propertyMetadata: PropertyMetadata) => {
-    propertyMetadata.store.merge(MONGOOSE_SCHEMA, {
-      ref: type,
-      localField: propertyMetadata.name,
-      foreignField
-    });
+    if (typeof options === "object") {
+      propertyMetadata.store.merge(MONGOOSE_SCHEMA, {
+        ref: options.type,
+        localField: options.localField || propertyMetadata.name,
+        foreignField: options.foreignField,
+        justOne: options.justOne || false,
+        options: options.options
+      });
+    } else {
+      propertyMetadata.store.merge(MONGOOSE_SCHEMA, {
+        ref: options,
+        localField: propertyMetadata.name,
+        foreignField
+      });
+    }
   });
 }

--- a/packages/mongoose/src/interfaces/MongooseVirtualRefOptions.ts
+++ b/packages/mongoose/src/interfaces/MongooseVirtualRefOptions.ts
@@ -1,0 +1,7 @@
+export interface MongooseVirtualRefOptions {
+  type: string;
+  foreignField: string;
+  localField?: string;
+  justOne?: boolean;
+  options?: object;
+}

--- a/packages/mongoose/test/decorators/virtualRef.spec.ts
+++ b/packages/mongoose/test/decorators/virtualRef.spec.ts
@@ -1,23 +1,75 @@
-import {Store} from "@tsed/core";
-import {descriptorOf} from "@tsed/core";
+import {descriptorOf, Store} from "@tsed/core";
 import {MONGOOSE_SCHEMA} from "../../src/constants";
 import {VirtualRef} from "../../src/decorators";
-import {expect} from "chai";
 
 describe("@VirtualRef()", () => {
-  class Test {}
-  class RefTest {}
+  describe("when type and foreign value are given", () => {
+    it("should set metadata", () => {
+      // GIVEN
+      class Test {
+      }
 
-  before(() => {
-    VirtualRef("RefTest", "foreign")(Test, "test", descriptorOf(Test, "test"));
-    this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+      const store = Store.from(Test, "test", descriptorOf(Test, "test"));
+      // WHEN
+      VirtualRef("RefTest", "foreign")(Test, "test", descriptorOf(Test, "test"));
+
+      // THEN
+      store.get(MONGOOSE_SCHEMA).should.deep.eq({
+        ref: "RefTest",
+        foreignField: "foreign",
+        localField: "test"
+      });
+    });
   });
 
-  it("should set metadata", () => {
-    expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
-      ref: "RefTest",
-      foreignField: "foreign",
-      localField: "test"
+  describe("when options is given with minimal fields", () => {
+    it("should set metadata", () => {
+      // GIVEN
+      class Test {
+      }
+
+      const store = Store.from(Test, "test", descriptorOf(Test, "test"));
+      const options = {type: "RefTest", foreignField: "foreign"};
+      // WHEN
+      VirtualRef(options)(Test, "test", descriptorOf(Test, "test"));
+
+      // THEN
+      store.get(MONGOOSE_SCHEMA).should.deep.eq({
+        ref: "RefTest",
+        localField: "test",
+        foreignField: "foreign",
+        justOne: false,
+        options: undefined
+      });
+
+    });
+  });
+
+  describe("when options is given with all fields", () => {
+    it("should set metadata", () => {
+      // GIVEN
+      class Test {
+      }
+
+      const store = Store.from(Test, "test", descriptorOf(Test, "test"));
+      const options = {
+        type: "RefTest",
+        foreignField: "foreign",
+        localField: "test_2",
+        justOne: true,
+        options: {}
+      };
+      // WHEN
+      VirtualRef(options)(Test, "test", descriptorOf(Test, "test"));
+
+      // THEN
+      store.get(MONGOOSE_SCHEMA).should.deep.eq({
+        ref: "RefTest",
+        localField: "test_2",
+        foreignField: "foreign",
+        justOne: true,
+        options: {}
+      });
     });
   });
 });


### PR DESCRIPTION
## Informations

Type | Breaking change
---|---
Fix | No

****

## Description
Fixed issue #546  

## Usage example
Now you can use both ways, passing an options object or two string parameters:

```
export class IAccountData {
    public _id?: ObjectId;

    @Required()
    public type?: String;

    @Required()
    public key?: String;

    @Required()
    @Default({})
    public value?: Object;

    @Ref(IAccount)
    @Required()
    public account_id?: Ref<IAccount>;

    @VirtualRef({type: 'Account', foreignField: '_id', localField: 'account_id', justOne: true})
    public account?: VirtualRef<IAccount>;
}
```

Or

```
export class IAccountData {
    public _id?: ObjectId;

    @Required()
    public type?: String;

    @Required()
    public key?: String;

    @Required()
    @Default({})
    public value?: Object;

    @Ref(IAccount)
    @Required()
    public account_id?: Ref<IAccount>;

    @VirtualRef('Account', '_id')
    public account?: VirtualRef<IAccount>;
}
```
Note that if you ommit "localField" from the options object, it will take from the property metadata name.

I didn't create a test case for it, but I just tested in my project and it works like a charm.
