### PR TITLE
feat(mongoose): Added DynamicRef decorator to support mongoose dynamic ref. Issue #567

### DIFF
--- a/docs/tutorials/mongoose.md
+++ b/docs/tutorials/mongoose.md
@@ -127,6 +127,14 @@ Be wary of circular dependencies. Direct references must be declared after the r
 
 <<< @/docs/tutorials/snippets/mongoose/virtual-references.ts
 
+### Dynamic References
+
+`@tsed/mongoose` supports `mongoose` dynamic references between defined models.
+
+This works by having a field with the referenced object model's name and a field with the referenced field.
+
+<<< @/docs/tutorials/snippets/mongoose/dynamic-references.ts
+
 ## Register hook
 
 Mongoose allows the developer to add pre and post [hooks / middlewares](http://mongoosejs.com/docs/middleware.html) to the schema. 

--- a/docs/tutorials/snippets/mongoose/dynamic-references.ts
+++ b/docs/tutorials/snippets/mongoose/dynamic-references.ts
@@ -1,0 +1,11 @@
+import {Model, Ref, DynamicRef} from "@tsed/mongoose";
+import {Enum, Required} from "@tsed/common"
+
+@Model()
+export class DynamicRef {
+    @DynamicRef('type')
+    dynamicRef: Ref<ModelA | ModelB>
+
+    @Enum(['Mode lA', 'ModelB']) 
+    type: string // This field has to match the referenced model's name
+}

--- a/packages/mongoose/src/decorators/dynamicRef.ts
+++ b/packages/mongoose/src/decorators/dynamicRef.ts
@@ -1,0 +1,54 @@
+import {Property, Schema} from "@tsed/common";
+import {applyDecorators, Store, StoreFn, StoreMerge} from "@tsed/core";
+import {Schema as MongooseSchema} from "mongoose";
+import {MONGOOSE_SCHEMA} from "../constants";
+
+/**
+ * Define a property as mongoose reference to other Model (decorated with @Model).
+ *
+ * ### Example
+ *
+ * ```typescript
+ *
+ * @Model()
+ * class FooModel {
+ *
+ *    @DynamicRef('type')
+ *    field: Ref<OtherFooModel | OtherModel>
+ *
+ *    @Enum(['OtherFooModel', 'OtherModel'])
+ *    type: string
+ * }
+ *
+ * @Model()
+ * class OtherFooModel {
+ * }
+ *
+ * @Model()
+ * class OtherModel {
+ * }
+ * ```
+ *
+ * @param type
+ * @returns {Function}
+ * @decorator
+ * @mongoose
+ * @property
+ */
+export function DynamicRef(refPath: string) {
+  return applyDecorators(
+    Property({use: String}),
+    Schema({
+      type: String,
+      example: "5ce7ad3028890bd71749d477",
+      description: "Mongoose Ref ObjectId"
+    }),
+    StoreFn((store: Store) => {
+      delete store.get("schema").$ref;
+    }),
+    StoreMerge(MONGOOSE_SCHEMA, {
+      type: MongooseSchema.Types.ObjectId,
+      refPath
+    })
+  );
+}

--- a/packages/mongoose/src/decorators/index.ts
+++ b/packages/mongoose/src/decorators/index.ts
@@ -10,3 +10,4 @@ export * from "./select";
 export * from "./unique";
 export * from "./virtualRef";
 export * from "./objectID";
+export * from "./dynamicRef";


### PR DESCRIPTION
feat(mongoose): Added DynamicRef decorator to support mongoose dynamic ref. Issue #567

<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
Feature|No

****

## Description
Added a new decorator called DynamicRef to add dynamic refs via refPath property as documented in https://mongoosejs.com/docs/populate.html#dynamic-ref.

## Usage example

```
import {DynamicRef, Model, Enum} from "@tsed/mongoose";

@Model()
class MyModel {
    @DynamicRef('model') // The parameter here is the name of the field which will contain the name of the model for mongoose to populate
    entity: Ref<OtherModel | FooModel>

    @Enum(['OtherModel', 'FooModel'])
    model: string
}
```

Then, you can simply populate by the ref field:

```
const myModel = this.MyModel.findById('5d001194df1e1a18ac52bc86').populate('entity') // The entity field will come populated
```

## Todos

- [ ] Tests
- [X] Example
- [x] Documentation

I am not used to do tests and documentations, so I will leave them for someone else.