### PR TITLE
Added one more parameter to ref for defining the reference type

### DIFF
--- a/packages/mongoose/src/decorators/ref.ts
+++ b/packages/mongoose/src/decorators/ref.ts
@@ -2,6 +2,7 @@ import {Property, Schema} from "@tsed/common";
 import {applyDecorators, Store, StoreFn, StoreMerge} from "@tsed/core";
 import {Schema as MongooseSchema} from "mongoose";
 import {MONGOOSE_MODEL_NAME, MONGOOSE_SCHEMA} from "../constants";
+import {MongooseSchemaTypes} from "../interfaces/MongooseSchemaTypes";
 
 export type Ref<T> = T | string;
 
@@ -27,13 +28,14 @@ export type Ref<T> = T | string;
  * }
  * ```
  *
+ * @param model
  * @param type
  * @returns {Function}
  * @decorator
  * @mongoose
  * @property
  */
-export function Ref(type: string | any) {
+export function Ref(model: string | any, type: MongooseSchemaTypes = MongooseSchemaTypes.OBJECT_ID) {
   return applyDecorators(
     Property({use: String}),
     Schema({
@@ -45,8 +47,8 @@ export function Ref(type: string | any) {
       delete store.get("schema").$ref;
     }),
     StoreMerge(MONGOOSE_SCHEMA, {
-      type: MongooseSchema.Types.ObjectId,
-      ref: typeof type === "string" ? type : Store.from(type).get(MONGOOSE_MODEL_NAME)
+      type: MongooseSchema.Types[type],
+      ref: typeof model === "string" ? model : Store.from(model).get(MONGOOSE_MODEL_NAME)
     })
   );
 }

--- a/packages/mongoose/src/interfaces/MongooseSchemaTypes.ts
+++ b/packages/mongoose/src/interfaces/MongooseSchemaTypes.ts
@@ -1,0 +1,5 @@
+export enum MongooseSchemaTypes {
+  OBJECT_ID = "ObjectId",
+  STRING = "String",
+  NUMBER = "Number"
+}


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
Feature|No
Feature/Fix/Doc/Chore | Yes/No

****

## Description
Sometimes you may want to create refs which doesn't reference an object id, instead, you want to reference a string or a number. For this, I added a new parameter to the Ref decorator so anyone can choose the type of the field. If you don't specify any type, it will default to ObjectId, so this won't cause any breaking changes.

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```
import {Model, Ref} from "@tsed/mongoose";

@Model()
export class FooClass {
    @Ref(OtherClass, MongooseSchemaTypes.STRING)
    otherClass: Ref<OtherClass>
}

@Model({schemaOptions: {_id: false}})
export class OtherClass {
    @Indexed()
    @Required()
    @Unique()
    _id: string
}
```

## Todos

- [ ] Tests
- [ ] Coverage
- [x] Example
- [ ] Documentation
