### PR TITLE
Fixed wrong field name on LogIncomingRequestMiddleware at minimalRequ…

### DIFF
--- a/packages/common/src/server/components/LogIncomingRequestMiddleware.ts
+++ b/packages/common/src/server/components/LogIncomingRequestMiddleware.ts
@@ -113,10 +113,10 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
    * @returns {Object}
    */
   protected minimalRequestPicker(request: Req): any {
-    const {fields = LogIncomingRequestMiddleware.DEFAULT_FIELDS} = this.injector.settings.logger;
+    const {requestFields = LogIncomingRequestMiddleware.DEFAULT_FIELDS} = this.injector.settings.logger;
     const info = this.requestToObject(request);
 
-    return fields.reduce((acc: any, key: string) => {
+    return requestFields.reduce((acc: any, key: string) => {
       acc[key] = info[key];
 
       return acc;


### PR DESCRIPTION
Fixed wrong field name on LogIncomingRequestMiddleware at minimalRequestPicker function. Changed "fields" to "requestFields", now the configuration on Server Settings will work

related to issue #570

<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
Fix | No

****

## Description
Fixing field name error on LogIncomingRequest