### PR TITLE
feat(graphql): add support for component scanned dataSources

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,8 +5,9 @@
   "main": "./src/index.js",
   "typings": "./src/index.ts",
   "dependencies": {
-    "tslib": "^1.9.3",
+    "apollo-datasource": "^0.5.0",
     "apollo-server-express": "^2.4.2",
+    "tslib": "^1.9.3",
     "type-graphql": "^0.16.0"
   },
   "peerDependencies": {

--- a/packages/graphql/src/decorators/dataSourceService.ts
+++ b/packages/graphql/src/decorators/dataSourceService.ts
@@ -1,0 +1,10 @@
+import {DataSource} from "apollo-datasource";
+import {registerDataSourceService} from "../registries/DataSourceServiceRegistry";
+
+export function DataSourceService(): ClassDecorator;
+export function DataSourceService(...args: any[]): ClassDecorator {
+  return <TFunction extends Function>(target: TFunction): void => {
+    DataSource.apply(this, args)(target);
+    registerDataSourceService(target);
+  };
+}

--- a/packages/graphql/src/decorators/dataSourceService.ts
+++ b/packages/graphql/src/decorators/dataSourceService.ts
@@ -1,10 +1,8 @@
-import {DataSource} from "apollo-datasource";
 import {registerDataSourceService} from "../registries/DataSourceServiceRegistry";
+import {ProviderScope} from "@tsed/common";
 
-export function DataSourceService(): ClassDecorator;
-export function DataSourceService(...args: any[]): ClassDecorator {
+export function DataSourceService(): ClassDecorator {
   return <TFunction extends Function>(target: TFunction): void => {
-    DataSource.apply(this, args)(target);
-    registerDataSourceService(target);
+    registerDataSourceService({provide: target, scope: ProviderScope.INSTANCE});
   };
 }

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -9,6 +9,8 @@ declare module "@tsed/common" {
 
 export * from "./interfaces/IGraphQLSettings";
 export * from "./decorators/resolverService";
+export * from "./decorators/dataSourceService";
 export * from "./services/GraphQLService";
 export * from "./registries/ResolverServiceRegistry";
+export * from "./registries/DataSourceServiceRegistry";
 export * from "./GraphQLModule";

--- a/packages/graphql/src/interfaces/IGraphQLSettings.ts
+++ b/packages/graphql/src/interfaces/IGraphQLSettings.ts
@@ -5,6 +5,7 @@ export interface IGraphQLSettings {
   // Basic options
   path: string;
   resolvers?: (Function | string)[];
+  dataSources?: Function;
 
   // apollo-server-express options
   // See options descriptions on https://www.apollographql.com/docs/apollo-server/api/apollo-server.html

--- a/packages/graphql/src/registries/DataSourceServiceRegistry.ts
+++ b/packages/graphql/src/registries/DataSourceServiceRegistry.ts
@@ -1,0 +1,49 @@
+/**
+ *
+ * @type {Registry<Provider<any>, IProvider<any>>}
+ */
+import {GlobalProviders, Provider, TypedProvidersRegistry} from "@tsed/common";
+
+export const PROVIDER_TYPE_DATASOURCE_SERVICE = "graphQLDataSourceService";
+
+/**
+ *
+ * @type {Registry<Provider<any>, IProvider<any>>}
+ */
+// tslint:disable-next-line: variable-name
+export const DataSourceServiceRegistry: TypedProvidersRegistry = GlobalProviders.createRegistry(
+  PROVIDER_TYPE_DATASOURCE_SERVICE,
+  Provider,
+  {
+    injectable: true
+  }
+);
+/**
+ * Add a new service in the `ProviderRegistry`. This service will be built when `InjectorService` will be loaded.
+ *
+ * #### Example
+ *
+ * ```typescript
+ * import {registerDataSourceService, InjectorService} from "@tsed/graphql";
+ *
+ * export default class MyFooService {
+ *     constructor(){}
+ *     getFoo() {
+ *         return "test";
+ *     }
+ * }
+ *
+ * registerDataSourceService({provide: MyFooService});
+ * // or
+ * registerDataSourceService(MyFooService);
+ *
+ * const injector = new InjectorService();
+ * injector.load();
+ *
+ * const myFooService = injector.get<MyFooService>(MyFooService);
+ * myFooService.getFoo(); // test
+ * ```
+ *
+ * @param provider Provider configuration.
+ */
+export const registerDataSourceService = GlobalProviders.createRegisterFn(PROVIDER_TYPE_DATASOURCE_SERVICE);

--- a/packages/graphql/test/services/GraphQLService.spec.ts
+++ b/packages/graphql/test/services/GraphQLService.spec.ts
@@ -35,6 +35,7 @@ describe("GraphQLService", () => {
       before(inject([GraphQLService], (_service_: any) => {
         service = _service_;
         sandbox.stub(_service_, "createSchema");
+        sandbox.stub(_service_, "createDataSources");
         sandbox.stub(ApolloServer.prototype, "applyMiddleware");
       }));
 
@@ -44,8 +45,10 @@ describe("GraphQLService", () => {
       });
 
       it("should create a server", async () => {
+        const noop = () => ({});
         // GIVEN
         service.createSchema.returns({"schema": "schema"});
+        service.createDataSources.returns(noop);
         // WHEN
 
         const result1 = await service.createServer("key", {
@@ -54,7 +57,7 @@ describe("GraphQLService", () => {
         const result2 = await service.createServer("key", {path: "/path"} as any);
 
         result2.should.deep.eq(result1);
-        result1.args.should.deep.eq([{schema: {schema: "schema"}}]);
+        result1.args.should.deep.eq([{schema: {schema: "schema"}, dataSources: noop}]);
         service.createSchema.should.have.been.calledOnceWithExactly({resolvers: []});
         result1.applyMiddleware.should.have.been.calledOnceWithExactly(Sinon.match({
           app: Sinon.match.func,
@@ -69,6 +72,7 @@ describe("GraphQLService", () => {
       before(inject([GraphQLService], (_service_: any) => {
         service = _service_;
         sandbox.stub(_service_, "createSchema");
+        sandbox.stub(_service_, "createDataSources");
         sandbox.stub(ApolloServer.prototype, "applyMiddleware");
         sandbox.stub(ApolloServer.prototype, "installSubscriptionHandlers");
       }));
@@ -79,8 +83,10 @@ describe("GraphQLService", () => {
       });
 
       it("should create a custom server", async () => {
+        const noop = () => ({});
         // GIVEN
         service.createSchema.returns({"schema": "schema"});
+        service.createDataSources.returns(noop);
 
         // WHEN
         const result = await service.createServer("key", {
@@ -92,7 +98,7 @@ describe("GraphQLService", () => {
         } as any);
 
 
-        result.args.should.deep.eq([{schema: {schema: "schema"}}]);
+        result.args.should.deep.eq([{schema: {schema: "schema"}, dataSources: noop}]);
         service.createSchema.should.have.been.calledOnceWithExactly({resolvers: []});
 
         result.applyMiddleware.should.have.been.calledOnceWithExactly(Sinon.match({


### PR DESCRIPTION
## Informations

for #577  

Type
Feature

****

## Description
Add a DataSource decorator registry that enables component scanning for Apollo DataSources to be added to the server config automatically (and with DI).

## Usage example

Just tag the services and make sure they are in the component scanning config.
```
import {DataSourceService} from "@tsed/graphql";
import { RESTDataSource } from 'apollo-datasource-rest';

@DataSourceService()
export class MyDataSource extends RESTDataSource {
  constructor() {
    super();
    this.baseURL = 'https://awesome-api.example.com';
  }

  willSendRequest(request) {
    request.headers.set('Authorization', this.context.token);
  }

  getMyData(id: string) {
    return this.get(`/v1/my_rest_data/${id}`);
  }
}
```

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
