### PR TITLE
Throw bad request error when property convert failed on Converter Service

### DIFF
--- a/packages/common/src/converters/services/ConverterService.ts
+++ b/packages/common/src/converters/services/ConverterService.ts
@@ -9,6 +9,7 @@ import {ConverterSerializationError} from "../errors/ConverterSerializationError
 import {RequiredPropertyError} from "../errors/RequiredPropertyError";
 import {UnknowPropertyError} from "../errors/UnknowPropertyError";
 import {IConverter, IConverterOptions, IDeserializer, ISerializer} from "../interfaces/index";
+import { BadRequest } from "ts-httpexceptions";
 
 @Service()
 export class ConverterService {
@@ -254,7 +255,11 @@ export class ConverterService {
     } catch (err) {
       /* istanbul ignore next */
       (() => {
-        const castedError: any = new Error("For " + String(propertyKey) + " with value " + propertyValue + " \n" + err.message);
+        const convertErrorMessage = `Error for ${propertyName} with value ${propertyValue} \n ${err.message}`;
+        if (err instanceof BadRequest) {
+          throw new BadRequest(convertErrorMessage);
+        }
+        const castedError: any = new Error(convertErrorMessage);
         castedError.stack = err.stack;
         castedError.origin = err;
 

--- a/packages/common/src/converters/services/ConverterService.ts
+++ b/packages/common/src/converters/services/ConverterService.ts
@@ -9,7 +9,7 @@ import {ConverterSerializationError} from "../errors/ConverterSerializationError
 import {RequiredPropertyError} from "../errors/RequiredPropertyError";
 import {UnknowPropertyError} from "../errors/UnknowPropertyError";
 import {IConverter, IConverterOptions, IDeserializer, ISerializer} from "../interfaces/index";
-import { BadRequest } from "ts-httpexceptions";
+import {BadRequest} from "ts-httpexceptions";
 
 @Service()
 export class ConverterService {
@@ -255,11 +255,11 @@ export class ConverterService {
     } catch (err) {
       /* istanbul ignore next */
       (() => {
-        const convertErrorMessage = `Error for ${propertyName} with value ${propertyValue} \n ${err.message}`;
+        const castedErrorMessage = `Error for ${propertyName} with value ${propertyValue} \n ${err.message}`;
         if (err instanceof BadRequest) {
-          throw new BadRequest(convertErrorMessage);
+          throw new BadRequest(castedErrorMessage);
         }
-        const castedError: any = new Error(convertErrorMessage);
+        const castedError: any = new Error(castedErrorMessage);
         castedError.stack = err.stack;
         castedError.origin = err;
 


### PR DESCRIPTION
ConvertService throws internal server error when it fails to convert a decorated property.
The expected behavior is to throw a bad request error.

example: 
When expecting to receive a body param of the following schema:
```
class User {
  @Required()
  id: number;
}
```

And the HTTP body request contains  
```
{ 
  id="sdn12nsf"
} 
```
 
The expected HTTP response is:
```
{
"status": 400,
"body": "Error for id with value sdn12nsf \nCast error. Expression value is not a number."
}
```

The current HTTP response is:
```
{
    "status": 500,
    "message": "Internal Server Error - Conversion failed for class \"User\" with object => {\"id\":\"sdn12nsf\"}.\nnewMessage is not defined"
}
```