### PR TITLE
Stop outputting the settings

### DIFF
--- a/packages/common/src/server/components/ServerLoader.ts
+++ b/packages/common/src/server/components/ServerLoader.ts
@@ -398,6 +398,10 @@ export abstract class ServerLoader implements IServerLifecycle {
     await this.callHook("$beforeInit");
     await this.callHook("$onInit");
 
+    this.settings.forEach((value, key) => {
+      this.injector.logger.debug(`settings.${key} =>`, value);
+    });
+
     this.injector.logger.info("Build providers");
 
     await loadInjector(this.injector);

--- a/packages/common/src/server/components/ServerLoader.ts
+++ b/packages/common/src/server/components/ServerLoader.ts
@@ -398,10 +398,6 @@ export abstract class ServerLoader implements IServerLifecycle {
     await this.callHook("$beforeInit");
     await this.callHook("$onInit");
 
-    this.settings.forEach((value, key) => {
-      this.injector.logger.info(`settings.${key} =>`, value);
-    });
-
     this.injector.logger.info("Build providers");
 
     await loadInjector(this.injector);


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
Fix |No

****

## Description
The idea of this commit is to remove the command to log out each configured setting. The reason for this is to improve security since TypeOrm - for example - settings are displayed in the logs; this includes passwords and username.

This should not be outputted since it provides an attacker with a way to identify the connections needed. These connection(s) could be access to a critical Production system therefore it should be up to the developer to decide if they wish to write data to the logs.

If needed, the settings object can be accessed from the Server object returned from `ServerLoader.bootstrap()` thus ensuring any decision is thought

Tests run, builds are good and code coverage are as follows:

Tests:  1217 passing (5s)

## Coverage summary 
Statements   : 100% ( 4119/4119 )
Branches     : 89.63% ( 1755/1958 )
Functions    : 99.82% ( 1113/1115 )
Lines        : 100% ( 3934/3934 )

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
