### PR TITLE
Added flag to indicate not to switch file extensions

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -87,7 +87,8 @@ module.exports = {
               {link: "/tutorials/templating.html", text: "Templating"},
               {link: "/tutorials/throw-http-exceptions.html", text: "Throw HTTP exceptions"},
               {link: "/tutorials/not-found-page.html", text: "Customize 404"},
-              {link: "/tutorials/aws.html", text: "AWS project"}
+              {link: "/tutorials/aws.html", text: "AWS project"},
+              {link: "/tutorials/jest.html", text: "Jest"}
             ]
           },
           {text: "4.x", link: "http://v4.tsed.io"}
@@ -156,7 +157,8 @@ module.exports = {
               "templating",
               "throw-http-exceptions",
               "not-found-page",
-              "aws"
+              "aws",
+              "jest"
             ]
           }]
         },
@@ -177,6 +179,7 @@ module.exports = {
           "/tutorials/throw-http-exceptions",
           "/tutorials/not-found-page",
           "/tutorials/aws",
+          "/tutorials/jest",
           "/tutorials/seq",
           "/docs/controllers",
           "/docs/providers",

--- a/docs/tutorials/jest.md
+++ b/docs/tutorials/jest.md
@@ -1,0 +1,73 @@
+---
+meta:
+ - name: description
+   content: Use Jest with Ts.ED framework. Jest is a testing framework.
+ - name: keywords
+   content: ts.ed express typescript mongoose node.js javascript decorators
+---
+# Jest <Badge text="beta" type="warn"/> <Badge text="Contributors are welcome" />
+
+<Banner src="https://camo.githubusercontent.com/b5639de5cfa97c51598b60b13a1061498afe2acb/68747470733a2f2f64337676366c703535716a6171632e636c6f756466726f6e742e6e65742f6974656d732f3244324b343533313278304d31713243306133502f6a6573742d6c6f676f2e737667" href="https://jestjs.io/" height="128" />
+
+## Installation
+
+To begin, install Ts.ED testing module:
+
+```bash
+npm i -D @tsed/testing
+```
+
+Then install `jest`:
+
+```bash
+npm i -D jest ts-jest @types/jest
+```
+
+## Configuration
+
+Now you need to configure `jest` to work with Typescript.
+To do that crate a new file in your project root called `jest.config.js` and put the following configuration in it:
+
+```js
+module.exports = {
+    preset: "ts-jest",
+    globals: {
+        "ts-jest": {
+            tsConfig: "tsconfig.json"
+        }
+    },
+    verbose: true,
+    collectCoverage: true,
+    moduleFileExtensions: ["ts", "js", "json"],
+    testMatch: ["**/tests/**/*.test.ts"],
+    testEnvironment: "node",
+    testPathIgnorePatterns: [
+        "<rootDir>/node_modules/",
+        "<rootDir>/out/"
+    ],
+    modulePathIgnorePatterns: [
+        "<rootDir>/node_modules/",
+        "<rootDir>/out/"
+    ],
+    coverageDirectory: "tests/result",
+    collectCoverageFrom: [
+        "src/controllers/**/*.ts",
+        "src/middlewares/**/*.ts",
+        "src/services/**/*.ts",
+        "!**/*.d.ts"
+    ]
+};
+```
+
+### **Important!!!**
+
+The DI will not work unless you set the `TS_TEST` environment variable to `true` like this:
+
+```json
+{
+    "scripts": {
+        "test": "TS_TEST=true jest",
+        "test:w": "TS_TEST=true jest --watch"
+    }
+}
+```

--- a/packages/common/src/server/utils/cleanGlobPatterns.ts
+++ b/packages/common/src/server/utils/cleanGlobPatterns.ts
@@ -6,7 +6,7 @@ export function cleanGlobPatterns(files: string | string[], excludes: string[]):
   return []
     .concat(files as any)
     .map((file: string) => {
-      if (!require.extensions[".ts"]) {
+      if (!require.extensions[".ts"] && !process.env["TS_TEST"]) {
         file = file.replace(/\.ts$/i, ".js");
       }
 

--- a/packages/common/test/server/utils/cleanGlobPatterns.spec.ts
+++ b/packages/common/test/server/utils/cleanGlobPatterns.spec.ts
@@ -41,4 +41,15 @@ describe("cleanGlobPatterns()", () => {
       expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.ts");
     });
   });
+  describe("when using ts-jest", () => {
+    before(() => {
+      // process.env["TS_TEST"] = "true";
+    });
+    after(() => {
+      delete process.env["TS_TEST"];
+    });
+    it("should return file.ts", () => {
+      expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.ts");
+    });
+  });
 });

--- a/packages/common/test/server/utils/cleanGlobPatterns.spec.ts
+++ b/packages/common/test/server/utils/cleanGlobPatterns.spec.ts
@@ -25,6 +25,18 @@ describe("cleanGlobPatterns()", () => {
     it("should return file.ts.js and manipulate only the file extension", () => {
       expect(cleanGlobPatterns("file.ts.ts", ["!**.spec.ts"])[0]).to.contains("file.ts.js");
     });
+
+    describe("when using ts-jest", () => {
+      it("should return file.ts", () => {
+        process.env["TS_TEST"] = "true";
+        expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.ts");
+        delete process.env["TS_TEST"];
+      });
+
+      it("should return file.js", () => {
+        expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.js");
+      });
+    });
   });
   describe("when have typescript compiler", () => {
     let compiler: any;
@@ -36,17 +48,6 @@ describe("cleanGlobPatterns()", () => {
     after(() => {
       delete require.extensions[".ts"];
       require.extensions[".ts"] = compiler;
-    });
-    it("should return file.ts", () => {
-      expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.ts");
-    });
-  });
-  describe("when using ts-jest", () => {
-    before(() => {
-      process.env["TS_TEST"] = "true";
-    });
-    after(() => {
-      delete process.env["TS_TEST"];
     });
     it("should return file.ts", () => {
       expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.ts");

--- a/packages/common/test/server/utils/cleanGlobPatterns.spec.ts
+++ b/packages/common/test/server/utils/cleanGlobPatterns.spec.ts
@@ -43,7 +43,7 @@ describe("cleanGlobPatterns()", () => {
   });
   describe("when using ts-jest", () => {
     before(() => {
-      // process.env["TS_TEST"] = "true";
+      process.env["TS_TEST"] = "true";
     });
     after(() => {
       delete process.env["TS_TEST"];


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
fixes #477 

****

## Description
When using `jest` and `ts-jest`, the `require.extensions['.ts']` compiler is not set.
Easy solution, for now, could be to pass an environment variable that will prevent the file extension change.

## Todos

- [x] Tests
- [ ] Coverage
- [x] Documentation
