### PR TITLE
Allow configuring logger events

### DIFF
--- a/packages/common/src/config/interfaces/ILoggerSettings.ts
+++ b/packages/common/src/config/interfaces/ILoggerSettings.ts
@@ -20,6 +20,14 @@ export interface ILoggerSettings {
    */
   logRequest?: boolean;
   /**
+   * Log start of all incoming request. By default is true
+   */
+  logStart?: boolean;
+  /**
+   * Log end of all incoming request. By default is true
+   */
+  logEnd?: boolean;
+  /**
    * The number of space characters to use as white space in JSON output. Default is 2 (0 in production).
    */
   jsonIndentation?: number;

--- a/packages/common/src/server/components/LogIncomingRequestMiddleware.ts
+++ b/packages/common/src/server/components/LogIncomingRequestMiddleware.ts
@@ -29,7 +29,9 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
    * @param {e.Request} request
    */
   protected onLogStart(request: Req) {
-    const {debug, logRequest} = this.injector.settings.logger;
+    const {debug, logRequest, logStart} = this.injector.settings.logger;
+
+    if (logStart === false) return;
 
     if (request.log) {
       if (debug) {
@@ -50,7 +52,9 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
    * @param response
    */
   protected onLogEnd(request: Req, response: Res) {
-    const {debug, logRequest} = this.injector.settings.logger;
+    const {debug, logRequest, logEnd} = this.injector.settings.logger;
+
+    if (logEnd === false) return;
 
     if (request.log) {
       if (debug) {

--- a/packages/common/test/server/components/LogIncomingRequestMiddleware.spec.ts
+++ b/packages/common/test/server/components/LogIncomingRequestMiddleware.spec.ts
@@ -137,8 +137,7 @@ describe("LogIncomingRequestMiddleware", () => {
       middleware.$onResponse(request as any, response as any);
 
       // THEN
-      injector.logger.info.should.have.callCount(1);
-      injector.logger.debug.should.have.been.calledWithExactly(Sinon.match({
+      injector.logger.info.should.have.been.calledWithExactly(Sinon.match({
         event: "request.start",
         method: "GET",
         reqId: "id",
@@ -180,7 +179,6 @@ describe("LogIncomingRequestMiddleware", () => {
       middleware.$onResponse(request as any, response as any);
 
       // THEN
-      injector.logger.info.should.have.callCount(1);
       injector.logger.info.should.have.been.calledWithExactly(Sinon.match({
         event: "request.end",
         method: "GET",

--- a/packages/common/test/server/components/LogIncomingRequestMiddleware.spec.ts
+++ b/packages/common/test/server/components/LogIncomingRequestMiddleware.spec.ts
@@ -104,5 +104,92 @@ describe("LogIncomingRequestMiddleware", () => {
       injector.logger.debug.should.have.been.calledWithExactly(Sinon.match.has("duration", Sinon.match.number));
       injector.logger.debug.should.have.been.calledWithExactly(Sinon.match.has("time", Sinon.match.instanceOf(Date)));
     });
+    it("should configure request and create context logger (no debug, logRequest, logEnd)", () => {
+      // GIVEN
+      const injector = new InjectorService();
+      injector.settings.logger = {debug: false, logRequest: true, logEnd: false};
+      injector.logger = {
+        info: Sinon.stub(),
+        warn: Sinon.stub(),
+        debug: Sinon.stub(),
+        trace: Sinon.stub(),
+        error: Sinon.stub()
+      };
+
+      const middleware = new LogIncomingRequestMiddleware(injector);
+
+      const request = new FakeRequest();
+      request.method = "GET";
+      request.url = "url";
+      request.originalUrl = "originalUrl";
+      request.ctx.data = "test";
+
+      const response = new FakeResponse();
+      response.statusCode = 200;
+      // WHEN
+      middleware.use(request as any);
+
+      // THEN
+      request.log.should.instanceof(RequestLogger);
+      request.log.id.should.deep.equal(request.ctx.id);
+
+      // THEN
+      middleware.$onResponse(request as any, response as any);
+
+      // THEN
+      injector.logger.info.should.have.callCount(1);
+      injector.logger.debug.should.have.been.calledWithExactly(Sinon.match({
+        event: "request.start",
+        method: "GET",
+        reqId: "id",
+        url: "url"
+      }));
+      injector.logger.info.should.have.been.calledWithExactly(Sinon.match.has("duration", Sinon.match.number));
+      injector.logger.info.should.have.been.calledWithExactly(Sinon.match.has("time", Sinon.match.instanceOf(Date)));
+    });
+    it("should configure request and create context logger (no debug, logRequest, logStart)", () => {
+      // GIVEN
+      const injector = new InjectorService();
+      injector.settings.logger = {debug: false, logRequest: true, logStart: false};
+      injector.logger = {
+        info: Sinon.stub(),
+        warn: Sinon.stub(),
+        debug: Sinon.stub(),
+        trace: Sinon.stub(),
+        error: Sinon.stub()
+      };
+
+      const middleware = new LogIncomingRequestMiddleware(injector);
+
+      const request = new FakeRequest();
+      request.method = "GET";
+      request.url = "url";
+      request.originalUrl = "originalUrl";
+      request.ctx.data = "test";
+
+      const response = new FakeResponse();
+      response.statusCode = 200;
+      // WHEN
+      middleware.use(request as any);
+
+      // THEN
+      request.log.should.instanceof(RequestLogger);
+      request.log.id.should.deep.equal(request.ctx.id);
+
+      // THEN
+      middleware.$onResponse(request as any, response as any);
+
+      // THEN
+      injector.logger.info.should.have.callCount(1);
+      injector.logger.info.should.have.been.calledWithExactly(Sinon.match({
+        event: "request.end",
+        method: "GET",
+        reqId: "id",
+        url: "originalUrl",
+        status: 200
+      }));
+      injector.logger.info.should.have.been.calledWithExactly(Sinon.match.has("duration", Sinon.match.number));
+      injector.logger.info.should.have.been.calledWithExactly(Sinon.match.has("time", Sinon.match.instanceOf(Date)));
+    });
   });
 });


### PR DESCRIPTION
Allow configuring whether the "request.start" and "request.end" events show when logging requests

<!-- This template it's just here to help you for write your Pull Request -->

## Information

Type | Breaking change
---|---
Feature | No

****

## Description
Having both "request.start" and "request.end" inflates our logs too much.
This PR will allow us to reduce the logs by 50%.

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```ts
import { ServerLoader, ServerSettings } from '@tsed/common';

@ServerSettings({
    ...
    logger: {
        logRequest: true,
        logStart: false,
        logEnd: true
    }
    ...
})
export default class Server extends ServerLoader {}
```

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
