### PR TITLE
chore: refuse to include source files into package

### DIFF
--- a/tasks/gulp/repo.js
+++ b/tasks/gulp/repo.js
@@ -138,7 +138,8 @@ module.exports = {
       .src([
         `${packagesDir}/**`,
         `${packagesDir}/**/.npmignore`,
-        `!${packagesDir}/**/src/**/*.{js,js.map,d.ts}`,
+        `!${packagesDir}/**/src/**`,
+        `!${packagesDir}/**/test/**`,
         `!${packagesDir}/**/package-lock.json`,
         `!${packagesDir}/**/yarn.lock`,
         `!${packagesDir}/**/node_modules/**`


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
Chore | No

****

## Description
There's no point in including source files into `npm` package. It not only affects on a package size, but also can lead to re-compile `.ts` files in `node_modules`.
