### PR TITLE
Fix Scanning on Windows Paths

### DIFF
--- a/packages/common/src/server/utils/cleanGlobPatterns.ts
+++ b/packages/common/src/server/utils/cleanGlobPatterns.ts
@@ -10,7 +10,7 @@ export function cleanGlobPatterns(files: string | string[], excludes: string[]):
         file = file.replace(/\.ts$/i, ".js");
       }
 
-      return Path.resolve(file);
+      return Path.resolve(file).replace(/\\/g, '/');
     })
     .concat(excludes as any);
 }

--- a/packages/common/src/server/utils/cleanGlobPatterns.ts
+++ b/packages/common/src/server/utils/cleanGlobPatterns.ts
@@ -1,7 +1,7 @@
 import * as Path from "path";
 
 export function cleanGlobPatterns(files: string | string[], excludes: string[]): string[] {
-  excludes = excludes.map((s: string) => "!" + s.replace(/!/gi, ""));
+  excludes = excludes.map((s: string) => "!" + s.replace(/!/gi, "").replace(/\\/g, "/"));
 
   return []
     .concat(files as any)

--- a/packages/common/src/server/utils/cleanGlobPatterns.ts
+++ b/packages/common/src/server/utils/cleanGlobPatterns.ts
@@ -10,7 +10,7 @@ export function cleanGlobPatterns(files: string | string[], excludes: string[]):
         file = file.replace(/\.ts$/i, ".js");
       }
 
-      return Path.resolve(file).replace(/\\/g, '/');
+      return Path.resolve(file).replace(/\\/g, "/");
     })
     .concat(excludes as any);
 }


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->



Type | Breaking change
---|---
Fix| No

****

## Description
Regression of #603 due to globby dependency, causing build errors on windows as paths resolve with "\" rather than "/"

Currently failing one test need to know if this is the correct fix?
