### PR TITLE
docs: Correct spelling in Getting Started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,7 +131,7 @@ This behavior can be change by editing the [componentScan configuration](/config
 :::
 
 ::: tip
-In addiction, it also possible to use [node-config](https://www.npmjs.com/package/config) or [dotenv](https://www.npmjs.com/package/dotenv) to load your configuration from file:
+In addition, it also possible to use [node-config](https://www.npmjs.com/package/config) or [dotenv](https://www.npmjs.com/package/dotenv) to load your configuration from file:
 
 <<< @/docs/snippets/configuration/bootstrap-with-node-config.ts
 


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Doc | No

****

## Description

Correct spelling in the Getting Started guide 😄 