### PR TITLE
Mongoose ignore

### DIFF
--- a/packages/mongoose/src/decorators/index.ts
+++ b/packages/mongoose/src/decorators/index.ts
@@ -11,3 +11,4 @@ export * from "./unique";
 export * from "./virtualRef";
 export * from "./objectID";
 export * from "./dynamicRef";
+export * from "./schemaIgnore";

--- a/packages/mongoose/src/decorators/schemaIgnore.ts
+++ b/packages/mongoose/src/decorators/schemaIgnore.ts
@@ -1,0 +1,24 @@
+import {Schema} from "@tsed/mongoose";
+
+/**
+ * Do not apply this property to schema (create virtual property)
+ *
+ * ### Example
+ *
+ * ```typescript
+ * @Model()
+ * @SchemaIgnore()
+ * @Property()
+ * kind: string;
+ *
+ * ```
+ *
+ * @returns {Function}
+ * @decorator
+ * @mongoose
+ * @class
+ */
+
+export function SchemaIgnore(): Function {
+  return Schema({schemaIgnore: true});
+}

--- a/packages/mongoose/src/decorators/schemaIgnore.ts
+++ b/packages/mongoose/src/decorators/schemaIgnore.ts
@@ -1,4 +1,4 @@
-import {Schema} from "@tsed/mongoose";
+import {Schema} from "./schema";
 
 /**
  * Do not apply this property to schema (create virtual property)

--- a/packages/mongoose/src/utils/createSchema.ts
+++ b/packages/mongoose/src/utils/createSchema.ts
@@ -75,6 +75,10 @@ export function buildMongooseSchema(target: any): MongooseSchema {
       // Keeping the Mongoose Schema separate so it can overwrite everything once schema has been built.
       const schemaTypeOptions = propertyMetadata.store.get(MONGOOSE_SCHEMA) || {};
 
+      if (schemaTypeOptions.schemaIgnore) {
+        return;
+      }
+
       if (isVirtualRef(schemaTypeOptions)) {
         schemaTypeOptions.justOne = !propertyMetadata.isArray;
         schema.virtuals.set(key as string, schemaTypeOptions);

--- a/packages/mongoose/test/decorators/mongooseIgnore.spec.ts
+++ b/packages/mongoose/test/decorators/mongooseIgnore.spec.ts
@@ -1,0 +1,20 @@
+import {Store} from "@tsed/core";
+import {descriptorOf} from "@tsed/core";
+import {expect} from "chai";
+import {MONGOOSE_SCHEMA} from "../../src/constants";
+import {SchemaIgnore} from "../../src/decorators/schemaIgnore";
+
+describe("@SchemaIgnore()", () => {
+  class Test {}
+
+  before(() => {
+    SchemaIgnore()(Test, "test", descriptorOf(Test, "test"));
+    this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+  });
+
+  it("should set metadata", () => {
+    expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
+      schemaIgnore: true
+    });
+  });
+});

--- a/packages/mongoose/test/utils/createSchema.spec.ts
+++ b/packages/mongoose/test/utils/createSchema.spec.ts
@@ -15,6 +15,7 @@ import {Schema as SchemaMongoose} from "mongoose";
 import {OpenApiModelSchemaBuilder} from "../../../swagger/src/class/OpenApiModelSchemaBuilder";
 import {Model, ObjectID, Ref, Schema, VirtualRef} from "../../src/decorators";
 import {createSchema, getSchema} from "../../src/utils/createSchema";
+import {SchemaIgnore} from "../../src/decorators/schemaIgnore";
 
 describe("createSchema", () => {
   it("should create schema", () => {
@@ -574,5 +575,23 @@ describe("createSchema", () => {
 
     actualError.should.instanceof(Error);
     actualError.message.should.eq("Invalid collection type. Set is not supported.");
+  });
+  it("should not create schema property for ignored field", () => {
+      @Model()
+      class Test10 {
+          @Property()
+          field: string;
+          @Property()
+          @SchemaIgnore()
+          kind: string;
+      }
+
+      const testSchema = getSchema(Test10);
+      testSchema.obj.should.deep.eq({
+          field: {
+              required: false,
+              type: String
+          }
+      });
   });
 });


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
Feature | No

****
## Description
Add new decorator ```@SchemaIgnore``` to allow defining properties not entering into mongoose schema.
Useful for serializing virtual fields and mongoose/plugin generated fields.

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```
import {Model, SchemaIgnore} from '@tsed/mongoose';
import {Default, Format, Property, PropertyName} from '@tsed/common';

@Model({schemaOptions: {discriminatorKey: 'kind'}})
export class Event {
    @PropertyName('id')
    _id: string;

    @Format('date-time')
    @Default(Date.now)
    created: Date;

    @Property()
    @SchemaIgnore()
    kind: string;
}

```

## Todos
