### PR TITLE
Feat mongoose standalone

### DIFF
--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -20,7 +20,7 @@
     "src": "src"
   },
   "devDependencies": {
-    "@tsed/common": "6.6.3",
+    "@tsed/di": "6.6.3",
     "@tsed/core": "6.6.3",
     "@types/mongoose": "5.7.37",
     "mongoose": "^5.9.27"

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -11,8 +11,9 @@
     "tslib": "2.0.1"
   },
   "peerDependencies": {
-    "@types/mongoose": "^5.7.34",
-    "mongoose": "^5.9.27"
+    "@types/mongoose": "^5.7.37",
+    "mongoose": "^5.10.13",
+    "mongodb-memory-server": "^6.9.2"
   },
   "private": false,
   "directories": {

--- a/packages/mongoose/src/MongooseModule.ts
+++ b/packages/mongoose/src/MongooseModule.ts
@@ -1,4 +1,4 @@
-import {Module, OnDestroy} from "@tsed/common";
+import {Inject, Module, OnDestroy} from "@tsed/common";
 import {MONGOOSE_CONNECTIONS} from "./services/MongooseConnections";
 import {MongooseService} from "./services/MongooseService";
 
@@ -9,7 +9,8 @@ import {MongooseService} from "./services/MongooseService";
   imports: [MONGOOSE_CONNECTIONS]
 })
 export class MongooseModule implements OnDestroy {
-  constructor(private mongooseService: MongooseService) {}
+  @Inject()
+  private mongooseService: MongooseService;
 
   $onDestroy(): Promise<any> | void {
     return this.mongooseService.closeConnections();

--- a/packages/mongoose/src/decorators/postHook.ts
+++ b/packages/mongoose/src/decorators/postHook.ts
@@ -7,7 +7,7 @@ import {schemaOptions} from "../utils/schemaOptions";
  * define the hook function like you normally would in Mongoose.
  *
  * ```typescript
- * import {Ignore, Required} from "@tsed/common";
+ * import {Ignore, Required} from "@tsed/di";
  * import {PostHook, Model} from "@tsed/mongoose";
  *
  * @Model()

--- a/packages/mongoose/src/decorators/preHook.ts
+++ b/packages/mongoose/src/decorators/preHook.ts
@@ -14,7 +14,7 @@ export interface PreHookOptions {
  * define the hook function like you normally would in Mongoose.
  *
  * ```typescript
- * import {Ignore, Required} from "@tsed/common";
+ * import {Ignore, Required} from "@tsed/di";
  * import {PreHook, Model} from "@tsed/mongoose";
  *
  * @Model()

--- a/packages/mongoose/src/decorators/schema.ts
+++ b/packages/mongoose/src/decorators/schema.ts
@@ -1,4 +1,4 @@
-import {Property} from "@tsed/common";
+import {Property} from "@tsed/schema";
 import {applyDecorators, getDecoratorType, StoreMerge} from "@tsed/core";
 import {SchemaTypeOpts} from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";

--- a/packages/mongoose/src/decorators/virtualRef.spec.ts
+++ b/packages/mongoose/src/decorators/virtualRef.spec.ts
@@ -1,4 +1,4 @@
-import {getJsonSchema, Property} from "@tsed/common";
+import {getJsonSchema, Property} from "@tsed/schema";
 import {Store} from "@tsed/core";
 import {Model} from "@tsed/mongoose";
 import {expect} from "chai";

--- a/packages/mongoose/src/factory/mongooseFactory.spec.ts
+++ b/packages/mongoose/src/factory/mongooseFactory.spec.ts
@@ -1,0 +1,3 @@
+describe("MongooseFactory", () => {
+  it("should create a new injector and container", () => {});
+});

--- a/packages/mongoose/src/factory/mongooseFactory.ts
+++ b/packages/mongoose/src/factory/mongooseFactory.ts
@@ -1,0 +1,53 @@
+import {importProviders} from "@tsed/di";
+import {getValue} from "@tsed/core";
+import {createContainer, InjectorService, setLoggerLevel} from "@tsed/di";
+import {$log} from "@tsed/logger";
+import {MDBConnection} from "@tsed/mongoose";
+import {MongooseModule} from "../MongooseModule";
+
+export interface MongooseFactoryOptions extends Omit<TsED.Configuration, "mongoose"> {
+  databases: Omit<MDBConnection, "id"> | MDBConnection[];
+}
+
+$log.name = "TSED";
+
+/**
+ * Create injector and services for a mongoose application in standalone.
+ *
+ * @param settings
+ * @param container
+ */
+export async function mongooseFactory(settings: MongooseFactoryOptions, container = createContainer()): Promise<InjectorService> {
+  const injector = new InjectorService();
+  injector.logger = $log;
+
+  // @ts-ignore
+  injector.settings.set({
+    ...settings,
+    logger: {
+      ...getValue(settings, "logger", {}),
+      level: getValue(settings, "logger.level", "off")
+    },
+    mongoose: settings.databases
+  });
+
+  setLoggerLevel(this.injector);
+
+  await importProviders(this.injector);
+
+  // Clone all providers in the container
+  injector.addProviders(container);
+
+  // Resolve all configuration
+  injector.resolveConfiguration();
+
+  injector.settings.forEach((value, key) => {
+    injector.logger.debug(`settings.${key} =>`, value);
+  });
+
+  injector.invoke(MongooseModule);
+
+  await injector.load(container);
+
+  return injector;
+}

--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./interfaces";
 export * from "./registries/MongooseModelRegistry";
 export * from "./services/MongooseService";
+export * from "./services/MongooseTest";
 export * from "./MongooseModule";
 export * from "./utils";
 export * from "./decorators";

--- a/packages/mongoose/src/registries/MongooseModelRegistry.ts
+++ b/packages/mongoose/src/registries/MongooseModelRegistry.ts
@@ -1,8 +1,4 @@
-/**
- *
- * @type {Registry<Provider<any>, IProvider<any>>}
- */
-import {GlobalProviders, Provider, TypedProvidersRegistry} from "@tsed/common";
+import {GlobalProviders, Provider, TypedProvidersRegistry} from "@tsed/di";
 
 export const PROVIDER_TYPE_MONGOOSE_MODEL = "mongooseModel";
 // tslint:disable-next-line: variable-name
@@ -17,7 +13,7 @@ export const MongooseModelRegistry: TypedProvidersRegistry = GlobalProviders.cre
  * #### Example
  *
  * ```typescript
- * import {registerModel, InjectorService} from "@tsed/common";
+ * import {registerModel, InjectorService} from "@tsed/di";
  *
  * export default class MyModel {
  *     constructor(){}

--- a/packages/mongoose/src/services/MongooseConnections.ts
+++ b/packages/mongoose/src/services/MongooseConnections.ts
@@ -1,4 +1,4 @@
-import {Configuration, registerProvider} from "@tsed/common";
+import {Configuration, registerProvider} from "@tsed/di";
 import {isArray} from "@tsed/core";
 import {MDBConnection} from "../interfaces";
 import {MongooseService} from "../services/MongooseService";

--- a/packages/mongoose/src/services/MongooseService.ts
+++ b/packages/mongoose/src/services/MongooseService.ts
@@ -1,10 +1,14 @@
-import {$log, Service} from "@tsed/common";
+import {Inject, Service} from "@tsed/di";
+import {Logger} from "@tsed/logger";
 import * as Mongoose from "mongoose";
 
 @Service()
 export class MongooseService {
   readonly connections: Map<string, Mongoose.Connection> = new Map();
   private defaultConnection: string = "default";
+
+  @Inject()
+  logger: Logger;
 
   /**
    *
@@ -15,9 +19,9 @@ export class MongooseService {
       return await this.get(id)!;
     }
 
-    $log.info(`Connect to mongo database: ${id}`);
-    $log.debug(`Url: ${url}`);
-    $log.debug(`options: ${JSON.stringify(connectionOptions)}`);
+    this.logger.info(`Connect to mongo database: ${id}`);
+    this.logger.debug(`Url: ${url}`);
+    this.logger.debug(`options: ${JSON.stringify(connectionOptions)}`);
 
     try {
       const connection = await Mongoose.createConnection(url, connectionOptions);
@@ -30,7 +34,7 @@ export class MongooseService {
       return connection;
     } catch (er) {
       /* istanbul ignore next */
-      $log.error(er);
+      this.logger.error(er);
       /* istanbul ignore next */
       process.exit();
     }

--- a/packages/mongoose/src/services/MongooseTest.ts
+++ b/packages/mongoose/src/services/MongooseTest.ts
@@ -1,0 +1,119 @@
+import {getValue} from "@tsed/core";
+import {DITest} from "@tsed/di";
+import {MongoMemoryServer} from "mongodb-memory-server";
+import {resolve} from "path";
+import {MDBConnection} from "../interfaces/MDBConnection";
+import {MongooseService} from "./MongooseService";
+
+function getDatabasesSettings(settings: Partial<TsED.Configuration>): MDBConnection[] {
+  const databases = getValue<any[]>(settings, "mongoose", getValue(settings, "databases", [{id: "default"}]));
+  return ([] as any[]).concat(databases);
+}
+
+export class MongooseTest extends DITest {
+  static getDownloadDir() {
+    return resolve(`${require.resolve("mongodb-memory-server")}/../../.cache/mongodb-memory-server/mongodb-binaries`);
+  }
+
+  static getMongo(): MongoMemoryServer {
+    // @ts-ignore
+    return global.__MONGOD__;
+  }
+
+  static async install(settings: any = {}): Promise<MDBConnection[]> {
+    if (!MongooseTest.getMongo()) {
+      // @ts-ignore
+      global.__MONGOD__ = new MongoMemoryServer({
+        ...getValue(settings, "mongod", {}),
+        binary: {
+          ...getValue(settings, "mongod.binary", {}),
+          downloadDir: this.getDownloadDir()
+        }
+      });
+    }
+
+    const mongod = MongooseTest.getMongo();
+
+    // istanbul ignore next
+    if (!mongod.runningInstance) {
+      await mongod.start();
+    }
+
+    const mongooseOptions = await MongooseTest.getMongooseOptions();
+    const databases = getDatabasesSettings(settings);
+
+    return await Promise.all(
+      databases.map(async (item) => {
+        return {
+          ...item,
+          ...mongooseOptions,
+          connectionOptions: {
+            ...getValue(item, "connectionOptions", {}),
+            ...getValue(mongooseOptions, "connectionOptions", {})
+          }
+        };
+      })
+    );
+  }
+
+  /**
+   * Connect to the in-memory database.
+   */
+  static bootstrap(mod: any, settings: Partial<TsED.Configuration> = {}): () => Promise<void> {
+    return async function before(): Promise<void> {
+      const {PlatformTest} = await import("@tsed/common");
+      const mongooseSettings = await MongooseTest.install(settings);
+
+      const before = PlatformTest.bootstrap(mod, {
+        ...settings,
+        mongoose: mongooseSettings
+      });
+
+      await before();
+    };
+  }
+
+  static async create(settings: Partial<TsED.Configuration> = {}) {
+    const mongooseSettings = await MongooseTest.install(settings);
+
+    return DITest.create({
+      ...settings,
+      mongoose: mongooseSettings
+    });
+  }
+
+  /**
+   * Resets the test injector of the test context, so it won't pollute your next test. Call this in your `tearDown` logic.
+   */
+  static async reset() {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await DITest.reset();
+    await MongooseTest.getMongo().stop();
+  }
+
+  /**
+   *
+   */
+  static async clearDatabase() {
+    const mongooseService = DITest.get<MongooseService>(MongooseService);
+    const promises: any[] = [];
+
+    for (const connection of mongooseService.connections.values()) {
+      promises.push(...Object.values(connection.collections).map((collection) => collection.deleteMany({})));
+    }
+
+    await Promise.all(promises);
+  }
+
+  static async getMongooseOptions() {
+    const url = await MongooseTest.getMongo().getUri();
+
+    return {
+      url,
+      connectionOptions: {
+        useUnifiedTopology: true,
+        useNewUrlParser: true
+      }
+    };
+  }
+}

--- a/packages/mongoose/test/helpers/models/UserWorkspace.ts
+++ b/packages/mongoose/test/helpers/models/UserWorkspace.ts
@@ -1,4 +1,4 @@
-import {CollectionOf, Property, PropertyType} from "@tsed/common";
+import {CollectionOf, Property} from "@tsed/schema";
 import {Model, MongooseModel, ObjectID, Ref, Schema} from "@tsed/mongoose";
 import {Types} from "mongoose";
 

--- a/packages/mongoose/test/multiple-connection.integration.spec.ts
+++ b/packages/mongoose/test/multiple-connection.integration.spec.ts
@@ -35,27 +35,25 @@ class ProductData {
 describe("Mongoose", () => {
   describe("MultipleConnection", () => {
     beforeEach(async () => {
-      const config: any = await TestMongooseContext.install();
-
-      await PlatformTest.bootstrap(Server, {
+      const mongooseSettings: any = await TestMongooseContext.install({
         mongoose: [
           {
             id: "customer",
-            url: config.url,
             connectionOptions: {
-              ...config.connectionOptions,
               dbName: "customerDB"
             }
           },
           {
             id: "product",
-            url: config.url,
             connectionOptions: {
-              ...config.connectionOptions,
               dbName: "productDB"
             }
           }
         ]
+      });
+
+      await PlatformTest.bootstrap(Server, {
+        mongoose: mongooseSettings
       })();
     });
     afterEach(TestMongooseContext.clearDatabase);

--- a/packages/mongoose/test/multiple-connection.integration.spec.ts
+++ b/packages/mongoose/test/multiple-connection.integration.spec.ts
@@ -1,4 +1,5 @@
-import {PlatformTest, Property} from "@tsed/common/src";
+import {PlatformTest} from "@tsed/common";
+import {Property} from "@tsed/schema";
 import {TestMongooseContext} from "@tsed/testing-mongoose/src";
 import {expect} from "chai";
 import {MongooseService} from "../src";

--- a/packages/testing-mongoose/package.json
+++ b/packages/testing-mongoose/package.json
@@ -8,13 +8,13 @@
     "build": "tsc --build tsconfig.compile.json"
   },
   "dependencies": {
-    "mongodb-memory-server": "^6.3.3",
+    "mongodb-memory-server": "^6.9.2",
     "tslib": "2.0.1"
   },
   "private": false,
   "peerDependencies": {
-    "@types/mongoose": "^5.7.34",
-    "mongoose": "^5.9.27"
+    "@types/mongoose": "^5.7.37",
+    "mongoose": "^5.10.13"
   },
   "devDependencies": {
     "@tsed/common": "6.6.3",

--- a/packages/testing-mongoose/src/TestMongooseContext.ts
+++ b/packages/testing-mongoose/src/TestMongooseContext.ts
@@ -1,91 +1,21 @@
-import {PlatformTest} from "@tsed/common";
-import {MongooseService} from "@tsed/mongoose";
-import {MongoMemoryServer} from "mongodb-memory-server";
-import {resolve} from "path";
+import {DITest, InjectorService} from "@tsed/common";
+import {MongooseTest} from "@tsed/mongoose";
 
-const downloadDir = resolve(`${require.resolve("mongodb-memory-server")}/../../.cache/mongodb-memory-server/mongodb-binaries`);
-
-export class TestMongooseContext extends PlatformTest {
-  static getMongo(): MongoMemoryServer {
-    // @ts-ignore
-    return global.__MONGOD__;
-  }
-
-  static async install(options: any = {binary: {}}) {
-    if (!TestMongooseContext.getMongo()) {
-      // @ts-ignore
-      global.__MONGOD__ = new MongoMemoryServer({
-        ...options,
-        binary: {
-          ...(options.binary || {}),
-          downloadDir
-        }
-      });
-    }
-
-    return TestMongooseContext.getMongooseOptions();
-  }
-
-  /**
-   * Connect to the in-memory database.
-   */
-  static bootstrap(mod: any, options: Partial<TsED.Configuration> = {}): () => Promise<void> {
-    return async function before(): Promise<void> {
-      const config = await TestMongooseContext.install(options.mongod);
-      const mongod = TestMongooseContext.getMongo();
-
-      // istanbul ignore next
-      if (!mongod.runningInstance) {
-        await mongod.start();
+export class TestMongooseContext extends MongooseTest {
+  static inject<T>(targets: any[], func: (...args: any[]) => Promise<T> | T): () => Promise<T> {
+    return async (): Promise<T> => {
+      if (!DITest.hasInjector()) {
+        await MongooseTest.create();
       }
 
-      const before = PlatformTest.bootstrap(mod, {
-        ...options,
-        mongoose: config
-      });
+      const injector: InjectorService = DITest.injector;
+      const deps = [];
 
-      await before();
-    };
-  }
-
-  static async create(options: Partial<TsED.Configuration> = {}) {
-    options.mongoose = await TestMongooseContext.install(options.mongod);
-
-    return PlatformTest.create(options);
-  }
-
-  /**
-   * Resets the test injector of the test context, so it won't pollute your next test. Call this in your `tearDown` logic.
-   */
-  static async reset() {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    await PlatformTest.reset();
-    await TestMongooseContext.getMongo().stop();
-  }
-
-  /**
-   *
-   */
-  static async clearDatabase() {
-    const mongooseService = PlatformTest.get<MongooseService>(MongooseService);
-    const promises: any[] = [];
-
-    for (const connection of mongooseService.connections.values()) {
-      promises.push(...Object.values(connection.collections).map((collection) => collection.deleteMany({})));
-    }
-
-    await Promise.all(promises);
-  }
-
-  static async getMongooseOptions() {
-    const url = await TestMongooseContext.getMongo().getUri();
-
-    return {
-      url,
-      connectionOptions: {
-        useUnifiedTopology: true,
-        useNewUrlParser: true
+      for (const target of targets) {
+        deps.push(injector.has(target) ? injector.get(target) : await injector.invoke(target));
       }
+
+      return await func(...deps);
     };
   }
 }


### PR DESCRIPTION
<!-- For hacktoberfest PR: Unrelevant modification will be automatically closed and tagged as spam and invalid! -->

## Information

Type | Breaking change
---|---
Feature | No

****

## Description
This PR allow usage of "mongoose standalone". It means all decorators of `@tsed/schema` and `@tsed/mongoose` can be used without `@tsed/common`.

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {Configuration} from "@tsed/di";
import {mongooseFactory, MongooseService, MongooseDocument} from "@tsed/mongoose"; // import mongoose ts.ed module

const rootDir = __dirname;

export async function bootstrap(settings: MongooseFactoryOptions) {
  // Resolve DI, boostrap module, services, etc.. and create connections with database.
  const injector = await mongooseFactory(settings)
 
  // Get services and models 
  const mongooseService = injector.get<MongooseService>(MongooseService); // to get connections
  const myModel = injector.get<MongooseDocument<MyModel>>(MyModel); // get a mongoose model
  // do something

  // emit $onDestroy event and close connections.
  await injector.destroy()
}

boostrap({
  imports: [
    `${rootDir}/models/**/*.ts`,
    `${rootDir}/services/**/*.ts`
  ],
  databases: [ // alias of mongoose in Ts.ED framework
    {
       id: "default",
       url: "mongodb://127.0.0.1:27017/db1",
       connectionOptions: {}
     }
  ]
}).catch(er => console.error(er))

```

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
