### PR TITLE
fix(schema): Avoid forwarding groups to children Model

### DIFF
--- a/packages/schema/src/decorators/common/groups.spec.ts
+++ b/packages/schema/src/decorators/common/groups.spec.ts
@@ -1,6 +1,14 @@
-import {getJsonSchema, getSpec, In, Name, OperationPath, Path, Property, Required, Returns, SpecTypes} from "@tsed/schema";
+import {CollectionOf, getJsonSchema, getSpec, In, Name, OperationPath, Path, Property, Required, Returns, SpecTypes} from "@tsed/schema";
 import {expect} from "chai";
 import {Groups} from "./groups";
+
+class ChildModel {
+  @Groups("!creation")
+  id: string;
+
+  @Required()
+  prop1: string;
+}
 
 class MyModel {
   @Groups("!creation")
@@ -17,6 +25,9 @@ class MyModel {
   @Property()
   @Required()
   prop3: string;
+
+  @CollectionOf(ChildModel)
+  prop4: ChildModel[];
 }
 
 describe("@Groups", () => {
@@ -27,6 +38,21 @@ describe("@Groups", () => {
       });
 
       expect(spec).to.deep.equal({
+        definitions: {
+          ChildModel: {
+            properties: {
+              id: {
+                type: "string"
+              },
+              prop1: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["prop1"],
+            type: "object"
+          }
+        },
         properties: {
           id: {
             type: "string"
@@ -34,6 +60,12 @@ describe("@Groups", () => {
           prop3: {
             minLength: 1,
             type: "string"
+          },
+          prop4: {
+            items: {
+              $ref: "#/definitions/ChildModel"
+            },
+            type: "array"
           }
         },
         required: ["prop3"],
@@ -45,6 +77,21 @@ describe("@Groups", () => {
       const spec = getJsonSchema(MyModel);
 
       expect(spec).to.deep.equal({
+        definitions: {
+          ChildModel: {
+            properties: {
+              id: {
+                type: "string"
+              },
+              prop1: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["prop1"],
+            type: "object"
+          }
+        },
         properties: {
           id: {
             type: "string"
@@ -52,6 +99,12 @@ describe("@Groups", () => {
           prop3: {
             minLength: 1,
             type: "string"
+          },
+          prop4: {
+            items: {
+              $ref: "#/definitions/ChildModel"
+            },
+            type: "array"
           }
         },
         required: ["prop3"],
@@ -65,6 +118,21 @@ describe("@Groups", () => {
       });
 
       expect(spec).to.deep.equal({
+        definitions: {
+          ChildModel: {
+            properties: {
+              id: {
+                type: "string"
+              },
+              prop1: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["prop1"],
+            type: "object"
+          }
+        },
         properties: {
           id: {
             type: "string"
@@ -76,6 +144,12 @@ describe("@Groups", () => {
           prop3: {
             minLength: 1,
             type: "string"
+          },
+          prop4: {
+            items: {
+              $ref: "#/definitions/ChildModel"
+            },
+            type: "array"
           }
         },
         required: ["prop1", "prop3"],
@@ -89,10 +163,31 @@ describe("@Groups", () => {
       });
 
       expect(spec).to.deep.equal({
+        definitions: {
+          ChildModel: {
+            properties: {
+              id: {
+                type: "string"
+              },
+              prop1: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["prop1"],
+            type: "object"
+          }
+        },
         properties: {
           prop3: {
             minLength: 1,
             type: "string"
+          },
+          prop4: {
+            items: {
+              $ref: "#/definitions/ChildModel"
+            },
+            type: "array"
           }
         },
         required: ["prop3"],
@@ -106,6 +201,21 @@ describe("@Groups", () => {
       });
 
       expect(spec).to.deep.equal({
+        definitions: {
+          ChildModel: {
+            properties: {
+              id: {
+                type: "string"
+              },
+              prop1: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["prop1"],
+            type: "object"
+          }
+        },
         properties: {
           id: {
             type: "string"
@@ -121,6 +231,12 @@ describe("@Groups", () => {
           prop3: {
             minLength: 1,
             type: "string"
+          },
+          prop4: {
+            items: {
+              $ref: "#/definitions/ChildModel"
+            },
+            type: "array"
           }
         },
         required: ["prop1", "prop2", "prop3"],
@@ -150,6 +266,19 @@ describe("@Groups", () => {
       expect(spec).to.deep.equal({
         components: {
           schemas: {
+            ChildModel: {
+              properties: {
+                id: {
+                  type: "string"
+                },
+                prop1: {
+                  minLength: 1,
+                  type: "string"
+                }
+              },
+              required: ["prop1"],
+              type: "object"
+            },
             MyModel: {
               properties: {
                 id: {
@@ -158,6 +287,12 @@ describe("@Groups", () => {
                 prop3: {
                   minLength: 1,
                   type: "string"
+                },
+                prop4: {
+                  items: {
+                    $ref: "#/components/schemas/ChildModel"
+                  },
+                  type: "array"
                 }
               },
               required: ["prop3"],
@@ -168,6 +303,12 @@ describe("@Groups", () => {
                 prop3: {
                   minLength: 1,
                   type: "string"
+                },
+                prop4: {
+                  items: {
+                    $ref: "#/components/schemas/ChildModel"
+                  },
+                  type: "array"
                 }
               },
               required: ["prop3"],
@@ -189,6 +330,12 @@ describe("@Groups", () => {
                 prop3: {
                   minLength: 1,
                   type: "string"
+                },
+                prop4: {
+                  items: {
+                    $ref: "#/components/schemas/ChildModel"
+                  },
+                  type: "array"
                 }
               },
               required: ["prop1", "prop2", "prop3"],
@@ -259,6 +406,123 @@ describe("@Groups", () => {
                     }
                   },
                   description: "Success"
+                }
+              },
+              tags: ["MyController"]
+            }
+          }
+        },
+        tags: [
+          {
+            name: "MyController"
+          }
+        ]
+      });
+    });
+    it("should display fields when a group match with (array - OS3)", () => {
+      @Path("/")
+      class MyController {
+        @OperationPath("POST", "/")
+        @(Returns(201, Array).Of(MyModel).Groups("group.*"))
+        async createWithArray(@In("body") @Groups("creation") @CollectionOf(MyModel) payload: MyModel[]) {
+          return [new MyModel()];
+        }
+      }
+
+      const spec = getSpec(MyController, {specType: SpecTypes.OPENAPI});
+
+      expect(spec).to.deep.equal({
+        components: {
+          schemas: {
+            ChildModel: {
+              properties: {
+                id: {
+                  type: "string"
+                },
+                prop1: {
+                  minLength: 1,
+                  type: "string"
+                }
+              },
+              required: ["prop1"],
+              type: "object"
+            },
+            MyModelCreation: {
+              properties: {
+                prop3: {
+                  minLength: 1,
+                  type: "string"
+                },
+                prop4: {
+                  items: {
+                    $ref: "#/components/schemas/ChildModel"
+                  },
+                  type: "array"
+                }
+              },
+              required: ["prop3"],
+              type: "object"
+            },
+            MyModelGroup: {
+              properties: {
+                id: {
+                  type: "string"
+                },
+                prop1: {
+                  minLength: 1,
+                  type: "string"
+                },
+                prop2: {
+                  minLength: 1,
+                  type: "string"
+                },
+                prop3: {
+                  minLength: 1,
+                  type: "string"
+                },
+                prop4: {
+                  items: {
+                    $ref: "#/components/schemas/ChildModel"
+                  },
+                  type: "array"
+                }
+              },
+              required: ["prop1", "prop2", "prop3"],
+              type: "object"
+            }
+          }
+        },
+        paths: {
+          "/": {
+            post: {
+              operationId: "myControllerCreateWithArray",
+              parameters: [],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      items: {
+                        $ref: "#/components/schemas/MyModelCreation"
+                      },
+                      type: "array"
+                    }
+                  }
+                },
+                required: false
+              },
+              responses: {
+                "201": {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        items: {
+                          $ref: "#/components/schemas/MyModelGroup"
+                        },
+                        type: "array"
+                      }
+                    }
+                  },
+                  description: "Created"
                 }
               },
               tags: ["MyController"]

--- a/packages/schema/src/utils/serializeJsonSchema.ts
+++ b/packages/schema/src/utils/serializeJsonSchema.ts
@@ -19,7 +19,7 @@ const IGNORES = ["name", "$required", "$hooks", "_nestedGenerics", SpecTypes.OPE
  * @ignore
  */
 const IGNORES_OPENSPEC = ["const"];
-const IGNORES_OS2 = [, "writeOnly", "readOnly"];
+const IGNORES_OS2 = ["writeOnly", "readOnly"];
 
 /**
  * @ignore
@@ -143,7 +143,8 @@ export function serializeObject(input: any, options: JsonSchemaOptions) {
   return Object.entries(input).reduce<any>(
     (obj, [key, value]: any[]) => {
       if (options.withIgnoredProps !== false && !alterIgnore(value, ctx)) {
-        obj[key] = serializeItem(value, options);
+        // remove groups to avoid bad schema generation over children models
+        obj[key] = serializeItem(value, {...options, groups: undefined});
       }
 
       return obj;


### PR DESCRIPTION
When we using groups and Ref decorators, an issue can occurs because groups options generate wrong children models.

Now the groups are only applied on the current model (parent model only).
