### PR TITLE
feat(common): Allow custom view engine registration

### DIFF
--- a/docs/docs/templating.md
+++ b/docs/docs/templating.md
@@ -1,66 +1,91 @@
 ---
 meta:
- - name: description
-   content: Use template engine with Ts.ED by using decorators. Ts.ED is built on top of Express/Koa and uses TypeScript language.
- - name: keywords
-   content: template engine consolidate ts.ed express typescript node.js javascript decorators
+- name: description
+  content: Use template engine with Ts.ED by using decorators. Ts.ED is built on top of Express/Koa and uses TypeScript language.
+- name: keywords
+  content: template engine tsed-engines ts.ed express typescript node.js javascript decorators
 ---
 # Templating
 
 @@View@@ is a decorator which can be used on a controller method (endpoint).
 This decorator will use the data returned by the method, and the configured view to create the response.
 
-<figure><img src="./../assets/templating-engine.png" style="max-height: 300px; padding:20px"></figure>
+<figure style="background:white"><img src="./../assets/templating-engine.png" style="max-height: 300px; padding:20px;"></figure>
 
 ## Configuration
 
-Ts.ED is using [consolidate](https://github.com/tj/consolidate.js) under the hood.
+Ts.ED is using by default [consolidate](https://github.com/tj/consolidate.js) under the hood.
+
 The default template engine installed with Ts.ED is [EJS](https://ejs.co/).
 If you want to use another engine, please refer to the engine documentation and [consolidate](https://github.com/tj/consolidate.js) to install the engine correctly.
 
 <<< @/docs/snippets/templating/configuration.ts
 
 ::: tip
-See [supported engines is available here](https://github.com/tj/consolidate.js#supported-template-engines).
+Supported engines is available [here](https://github.com/tsedio/tsed-engines/blob/production/packages/engines/readme.md#supported-template-engines).
 :::
+
+::: warning
+Ts.ED v7 will switch on [`@tsed/engines`](https://github.com/tsedio/tsed-engines) implementation. Consolidate will be removed from dependencies.
+:::
+
+### Use @tsed/engines
+
+To enable the new view engine feature, you have to install the `@tsed/engines` packages:
+
+```
+npm install @tsed/engines
+```
 
 ## Options
 
 ```typescript
 export interface PlatformViewsSettings {
- /**
-  * Views directory.
-  */
-  root?: string;
-  /**
-   * Enable cache. Ts.ED enables cache in PRODUCTION profile by default.
-   */
-  cache?: boolean;
- /**
-  * Provide extensions mapping to match the expected engines.
-  */
-  extensions?: Partial<PlatformViewsExtensionsTypes>;
- /**
-  * Default view engine extension. 
-  * Allow omitting extension when using View decorator or render method.
-  */
-  viewEngine?: string;
- /**
-  * Options mapping for each engine.
-  */
-  options?: Partial<PlatformViewsEngineOptions>;
+   /**
+    * Views directory.
+    */
+   root?: string;
+   /**
+    * Enable cache. Ts.ED enables cache in PRODUCTION profile by default.
+    */
+   cache?: boolean;
+   /**
+    * Provide extensions mapping to match the expected engines.
+    */
+   extensions?: Partial<PlatformViewsExtensionsTypes>;
+   /**
+    * Default view engine extension.
+    * Allow omitting extension when using View decorator or render method.
+    */
+   viewEngine?: string;
+   /**
+    * Options mapping for each engine.
+    */
+   options?: Partial<PlatformViewsEngineOptions>;
 }
 ```
 
 ## Usage
 ## Template Engine Instances
+### With Consolidate (deprecated)
 
-Template engines are exposed via the `PlatformViews.consolidate.requires` object, but they are not instantiated until you've called the `PlatformViews.consolidate[engine].render()` method. You can instantiate them manually beforehand if you want to add filters, globals, mixins, or other engine features.
+Template engines are exposed via the `consolidate.requires` object, but they are not instantiated until you've called the `consolidate[engine].render()` method.
+You can instantiate them manually beforehand if you want to add filters, globals, mixins, or other engine features.
 
-::: tip Reference 
+::: tip Reference
 [Template Engine Instances](https://github.com/tj/consolidate.js#template-engine-instances).
 :::
 
+### With @tsed/engines
+
+Template engines are exposed via the `requires` Map, but they are not instantiated until you've called the `getEngine(engine).render()` method.
+You can instantiate them manually beforehand if you want to add filters, globals, mixins, or other engine features.
+
+::: tip Reference
+[Template Engine Instances](https://github.com/tsedio/tsed-engines/blob/production/packages/engines/readme.md#template-engine-instances).
+:::
+
+### Nunjucks
 ```typescript
 import { Configuration } from "@tsed/common";
 import nunjucks from "nunjucks";
@@ -95,12 +120,12 @@ Here is an example of a controller using the @@View@@ decorator:
 
 <Tabs class="-code">
   <Tab label="EventCtrl.ts">
-  
+
 <<< @/docs/snippets/templating/response-templating.ts
 
   </Tab>
   <Tab label="event.ejs">
-  
+
 ```html
 <h1><%- name %></h1>
 <div>
@@ -113,7 +138,7 @@ Here is an example of a controller using the @@View@@ decorator:
 
 ::: tip
 
-Like Express.js or Koa.js, @@View@@ decorator uses `express.response.locals` or `koa.context.state` to populate data before 
+Like Express.js or Koa.js, @@View@@ decorator uses `express.response.locals` or `koa.context.state` to populate data before
 rendering the template. See [Locals](/docs/controllers.html#locals) decorator usage for more information.
 
 :::
@@ -124,12 +149,12 @@ It's also possible to render a view by injecting and using @@PlatformResponse@@ 
 
 <Tabs class="-code">
   <Tab label="EventCtrl.ts">
-  
+
 <<< @/docs/snippets/templating/template-platform-api.ts
 
   </Tab>
   <Tab label="event.ejs">
-  
+
 ```html
 <h1><%- name %></h1>
 <div>
@@ -150,7 +175,7 @@ It is useful if you want to render a template from a service.
 ## Caching
 
 To enable caching, simply pass `{ cache: true }` to the @@View@@ decorator.
-All engines that consolidate.js implements I/O for, will cache the file contents, ideal for production environments.
+All engines that `consolidate.js` / [`@tsed/engines`](https://github.com/tsedio/tsed-engines) implements I/O for, will cache the file contents, ideal for production environments.
 
 <<< @/docs/snippets/templating/template-cache.ts
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -63,8 +63,11 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
+    "@tsed/engines": "1.1.2",
     "@types/consolidate": "0.14.0",
     "rxjs": "^6.5.2"
   },
-  "peerDependencies": {}
+  "peerDependencies": {
+    "@tsed/engines": "^1.1.1"
+  }
 }

--- a/packages/common/src/config/interfaces/PlatformViewsSettings.ts
+++ b/packages/common/src/config/interfaces/PlatformViewsSettings.ts
@@ -1,53 +1,64 @@
-export type PlatformViewsSupportedEngines =
-  | "arc-templates"
-  | "atpl"
-  | "bracket"
-  | "dot"
-  | "dust"
-  | "eco"
-  | "ejs"
-  | "ect"
-  | "haml"
-  | "haml-coffee"
-  | "hamlet"
-  | "handlebars"
-  | "hogan"
-  | "htmling"
-  | "jade"
-  | "jazz"
-  | "jqtpl"
-  | "just"
-  | "liquid"
-  | "liquor"
-  | "lodash"
-  | "marko"
-  | "mote"
-  | "mustache"
-  | "nunjucks"
-  | "plates"
-  | "pug"
-  | "qejs"
-  | "ractive"
-  | "razor"
-  | "react"
-  | "slm"
-  | "squirrelly"
-  | "swig"
-  | "teacup"
-  | "templayed"
-  | "toffee"
-  | "twig"
-  | "underscore"
-  | "vash"
-  | "velocityjs"
-  | "walrus"
-  | "whiskers";
+import {PlatformContext} from "../../platform/domain/PlatformContext";
 
-export type PlatformViewsExtensionsTypes = {[key: string]: string};
-
-export type PlatformViewsEngineOptions = {
-  [engine in PlatformViewsSupportedEngines]: any;
+export const PLATFORM_VIEWS_EXTENSIONS = {
+  atpl: "atpl",
+  bracket: "bracket",
+  dot: "dot",
+  dust: "dust",
+  ect: "ect",
+  ejs: "ejs",
+  haml: "haml",
+  "haml-coffee": "haml-coffee",
+  hamlet: "hamlet",
+  hbs: "handlebars",
+  handlebars: "handlebars",
+  hogan: "hogan",
+  htmling: "htmling",
+  jazz: "jazz",
+  jqtpl: "jqtpl",
+  just: "just",
+  kernel: "kernel",
+  liquid: "liquid",
+  liquor: "liquor",
+  lodash: "lodash",
+  mote: "mote",
+  mustache: "mustache",
+  nunjucks: "nunjucks",
+  plates: "plates",
+  pug: "pug",
+  qejs: "qejs",
+  ractive: "ractive",
+  razor: "razor",
+  jsx: "react",
+  slm: "slm",
+  squirelly: "squirelly",
+  swig: "swig",
+  teacup: "teacup",
+  templayed: "templayed",
+  toffee: "toffee",
+  twig: "twig",
+  underscore: "underscore",
+  vash: "vash",
+  velocityjs: "velocityjs",
+  walrus: "walrus",
+  whiskers: "whiskers"
 };
+
+export type PlatformViewsExtensionsTypes = Record<string, string>;
+
+export interface PlatformViewsEngineOptions extends Record<string, unknown> {
+  requires?: any;
+}
+
+export interface PlatformRenderOptions extends Record<string, unknown> {
+  $ctx: PlatformContext;
+}
+
+export interface PlatformViewEngine {
+  options: PlatformViewsEngineOptions;
+
+  render(path: string, options: PlatformRenderOptions): Promise<string>;
+}
 
 export interface PlatformViewsSettings {
   /**
@@ -70,5 +81,5 @@ export interface PlatformViewsSettings {
   /**
    * Options mapping for each engine.
    */
-  options?: Partial<PlatformViewsEngineOptions>;
+  options?: Record<string, PlatformViewsEngineOptions>;
 }

--- a/packages/common/src/platform/services/PlatformViews.spec.ts
+++ b/packages/common/src/platform/services/PlatformViews.spec.ts
@@ -23,22 +23,22 @@ describe("PlatformViews", () => {
     })
   );
   afterEach(() => {
-    const platformViews = PlatformTest.get<PlatformViews>(PlatformViews);
-
-    delete platformViews.consolidate.requires.ejs;
+    delete require("consolidate").requires.ejs;
+    require("@tsed/engines").requires.delete("ejs");
   });
   afterEach(() => PlatformTest.reset());
   afterEach(() => sandbox.restore());
   describe("render()", () => {
     it("should render a template with given extension", async () => {
       const platformViews = PlatformTest.get<PlatformViews>(PlatformViews);
+      const engine = platformViews.getEngine("ejs")!;
 
-      sandbox.stub(platformViews.consolidate, "ejs").resolves("HTML");
+      sandbox.stub(engine, "render").resolves("HTML");
 
       const result = await platformViews.render("views.ejs");
 
       expect(result).to.equal("HTML");
-      expect(platformViews.consolidate.ejs).to.have.been.calledWithExactly("views.ejs", {
+      expect(engine.render).to.have.been.calledWithExactly("views.ejs", {
         cache: false,
         global: "global",
         requires: "requires"
@@ -46,13 +46,14 @@ describe("PlatformViews", () => {
     });
     it("should render a template without extension", async () => {
       const platformViews = PlatformTest.get<PlatformViews>(PlatformViews);
+      const engine = platformViews.getEngine("ejs")!;
 
-      sandbox.stub(platformViews.consolidate, "ejs").resolves("HTML");
+      sandbox.stub(engine, "render").resolves("HTML");
 
       const result = await platformViews.render("views", {test: "test"});
 
       expect(result).to.equal("HTML");
-      expect(platformViews.consolidate.ejs).to.have.been.calledWithExactly("views.ejs", {
+      expect(engine.render).to.have.been.calledWithExactly("views.ejs", {
         cache: false,
         global: "global",
         test: "test",
@@ -61,22 +62,19 @@ describe("PlatformViews", () => {
     });
     it("should render a template without extension", async () => {
       const platformViews = PlatformTest.get<PlatformViews>(PlatformViews);
+      const engine = platformViews.getEngine("ejs")!;
 
-      sandbox.stub(platformViews.consolidate, "ejs").resolves("HTML");
+      sandbox.stub(engine, "render").resolves("HTML");
 
       let error: any;
+
       try {
         await platformViews.render("views.toto", {test: "test"});
       } catch (er) {
         error = er;
       }
 
-      expect(error.message).to.equal('Engine not found for the ".toto" file extension');
-    });
-    it("should load engine requires", async () => {
-      const platformViews = PlatformTest.get<PlatformViews>(PlatformViews);
-
-      expect(platformViews.consolidate.requires.ejs).to.equal("requires");
+      expect(error.message).to.equal('Engine not found to render the following "views.toto"');
     });
   });
 });

--- a/packages/common/src/platform/utils/renderView.spec.ts
+++ b/packages/common/src/platform/utils/renderView.spec.ts
@@ -40,6 +40,7 @@ describe("renderView", () => {
     await renderView(ctx.data, ctx);
 
     expect(ctx.response.render).to.have.been.calledWithExactly("view", {
+      $ctx: ctx,
       data: "data",
       options: "options"
     });

--- a/packages/common/src/platform/utils/renderView.ts
+++ b/packages/common/src/platform/utils/renderView.ts
@@ -4,13 +4,13 @@ import {PlatformContext} from "../domain/PlatformContext";
 /**
  * @ignore
  */
-export async function renderView(data: any, ctx: PlatformContext) {
-  const {response, endpoint} = ctx;
+export async function renderView(data: any, $ctx: PlatformContext) {
+  const {response, endpoint} = $ctx;
   try {
-    const {data} = ctx;
+    const {data} = $ctx;
     const {path, options} = endpoint.view;
 
-    return await response.render(path, {...options, ...data});
+    return await response.render(path, {...options, ...data, $ctx});
   } catch (err) {
     throw new TemplateRenderError(endpoint.targetName, endpoint.propertyKey, err);
   }

--- a/packages/di/src/registries/ProviderRegistry.spec.ts
+++ b/packages/di/src/registries/ProviderRegistry.spec.ts
@@ -82,5 +82,18 @@ describe("ProviderRegistry", () => {
         type: ProviderType.VALUE
       });
     });
+
+    it("should add provider (legacy)", () => {
+      const token = Symbol.for("CustomTokenValue2");
+
+      registerValue(token, "myValue");
+
+      expect(GlobalProviders.merge).to.have.been.calledWithExactly(token, {
+        provide: token,
+        useValue: "myValue",
+        scope: ProviderScope.SINGLETON,
+        type: ProviderType.VALUE
+      });
+    });
   });
 });

--- a/packages/di/src/registries/ProviderRegistry.ts
+++ b/packages/di/src/registries/ProviderRegistry.ts
@@ -98,7 +98,7 @@ export const registerFactory = registerProvider;
  *
  * const MyValue = Symbol.from("MyValue")
  *
- * registerValue(MyValue, "myValue");
+ * registerValue({token: MyValue, useValue: "myValue"});
  *
  * @Service()
  * export class OtherService {

--- a/packages/oidc-provider/test/app/Server.ts
+++ b/packages/oidc-provider/test/app/Server.ts
@@ -1,5 +1,6 @@
 import {FileSyncAdapter} from "@tsed/adapters";
 import "@tsed/ajv";
+import "@tsed/engines";
 import {Constant, PlatformApplication} from "@tsed/common";
 import {Configuration, Inject} from "@tsed/di";
 import "@tsed/oidc-provider";

--- a/packages/platform-express/src/components/PlatformExpress.ts
+++ b/packages/platform-express/src/components/PlatformExpress.ts
@@ -96,7 +96,7 @@ export class PlatformExpress extends PlatformBuilder<Express.Application, Expres
     const platformViews = this.injector.get<PlatformViews>(PlatformViews)!;
 
     platformViews.getEngines().forEach(({extension, engine}) => {
-      this.app.getApp().engine(extension, engine);
+      this.app.getApp().engine(extension, engine.render);
     });
 
     platformViews.viewEngine && this.app.getApp().set("view engine", platformViews.viewEngine);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,6 +1669,14 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsed/engines@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tsed/engines/-/engines-1.1.2.tgz#876bc66b11933091d003effbe04fde681e9ea432"
+  integrity sha512-U5aAcJdX473obCDYZ2QPodD/Dj8lbewAzgj5UUSOrjJDLmiGgWHbp7INq8OguNETq1uTVNqi1CEKNcClcSqkHQ==
+  dependencies:
+    fs-extra "^10.0.0"
+    tslib "2.2.0"
+
 "@tsed/logger-seq@^5.13.3":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@tsed/logger-seq/-/logger-seq-5.15.0.tgz#b22985b79f1a05474c606cfa5bd40028f60d77fa"
@@ -7332,6 +7340,15 @@ fs-extra@9.0.1, fs-extra@^9.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^1.0.0"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature/Fix/Doc/Chore | Yes/No

****

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
