### PR TITLE
fix(di): Filter .d.ts from imported file automatically

### DIFF
--- a/packages/di/src/utils/cleanGlobPatterns.spec.ts
+++ b/packages/di/src/utils/cleanGlobPatterns.spec.ts
@@ -22,6 +22,10 @@ describe("cleanGlobPatterns()", () => {
       expect(cleanGlobPatterns("file.ts", ["!**.spec.ts"])[0]).to.contains("file.js");
     });
 
+    it("should return file.js", () => {
+      expect(cleanGlobPatterns("file{.ts,.js}", ["!**.spec.ts"])[0]).to.contains("file.js");
+    });
+
     it("should return file.ts.js and manipulate only the file extension", () => {
       expect(cleanGlobPatterns("file.ts.ts", ["!**.spec.ts"])[0]).to.contains("file.ts.js");
     });

--- a/packages/di/src/utils/cleanGlobPatterns.ts
+++ b/packages/di/src/utils/cleanGlobPatterns.ts
@@ -16,7 +16,7 @@ function mapExcludes(excludes: string[]) {
 
 function mapExtensions(file: string): string {
   if (!isTsEnv()) {
-    file = file.replace(/\.ts$/i, ".js");
+    file = file.replace(/\.ts$/i, ".js").replace(/{\.ts,\.js}$/i, ".js");
   }
 
   return file;

--- a/packages/di/src/utils/importFiles.ts
+++ b/packages/di/src/utils/importFiles.ts
@@ -6,8 +6,11 @@ export async function importFiles(patterns: string | string[], exclude: string[]
   const symbols: any[] = [];
 
   for (const file of files) {
-    const exports = await import(file);
-    Object.keys(exports).forEach((key) => symbols.push(exports[key]));
+    if (!file.endsWith(".d.ts")) {
+      // prevent .d.ts import if the global pattern isn't correctly configured
+      const exports = await import(file);
+      Object.keys(exports).forEach((key) => symbols.push(exports[key]));
+    }
   }
 
   return symbols;

--- a/packages/passport/readme.md
+++ b/packages/passport/readme.md
@@ -33,7 +33,7 @@ const rootDir = __dirname;
 
 @Configuration({
   componentsScan: [
-     `${rootDir}/protocols/*{.ts,.js}` // scan protocols directory
+     `${rootDir}/protocols/*.ts` // scan protocols directory
   ],
   passport: {
     


### PR DESCRIPTION
Prevent `.d.ts` import if the global pattern isn't correctly configured
