### PR TITLE
fix: Bump @tsed/logger to 5.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   ],
   "dependencies": {
     "@nuxtjs/opencollective": "0.3.2",
-    "@tsed/logger": "^5.12.1",
+    "@tsed/logger": "^5.16.0",
     "axios": "0.21.1",
     "ajv": "8.6.0",
     "change-case": "4.1.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,7 +50,7 @@
     "@tsed/di": "6.59.2",
     "@tsed/exceptions": "6.59.2",
     "@tsed/json-mapper": "6.59.2",
-    "@tsed/logger": "^5.12.1",
+    "@tsed/logger": "^5.16.0",
     "@tsed/schema": "6.59.2",
     "@types/cache-manager": "^3.4.0",
     "@types/json-schema": "7.0.7",

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -16,10 +16,10 @@
     "build": "tsc --build tsconfig.compile.json"
   },
   "devDependencies": {
-    "@tsed/logger": "^5.14.0"
+    "@tsed/logger": "^5.16.0"
   },
   "peerDependencies": {
     "@tsed/core": "^6.55.2",
-    "@tsed/logger": "^5.14.0"
+    "@tsed/logger": "^5.16.0"
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -45,7 +45,7 @@
     "@tsed/di": "^6.55.2",
     "@tsed/exceptions": "^6.55.2",
     "@tsed/json-mapper": "^6.55.2",
-    "@tsed/logger": "^5.14.0",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.55.2",
     "@tsed/schema": "^6.55.2",
     "apollo-datasource": "^0.7.3",

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -37,7 +37,7 @@
     "@tsed/core": "6.55.2",
     "@tsed/di": "6.55.2",
     "@tsed/exceptions": "6.55.2",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "6.55.2",
     "@tsed/schema": "6.55.2",
     "mongoose": "^5.12.2"

--- a/packages/objection/package.json
+++ b/packages/objection/package.json
@@ -33,7 +33,7 @@
     "@tsed/di": "^6.48.6",
     "@tsed/exceptions": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "knex": "^0.21.5",

--- a/packages/oidc-provider/package.json
+++ b/packages/oidc-provider/package.json
@@ -33,7 +33,7 @@
     "@tsed/di": "^6.48.6",
     "@tsed/exceptions": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "oidc-provider": "^7.3.0"

--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -34,7 +34,7 @@
     "@tsed/core": "^6.48.6",
     "@tsed/di": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "passport": "^0.4.1",

--- a/packages/platform-aws/package.json
+++ b/packages/platform-aws/package.json
@@ -62,7 +62,7 @@
     "@tsed/core": "^6.48.6",
     "@tsed/di": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "aws-serverless-express": "^3.4.0"

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -73,7 +73,7 @@
     "@tsed/core": "^6.48.6",
     "@tsed/di": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "@types/multer": "^1.4.5",

--- a/packages/platform-koa/package.json
+++ b/packages/platform-koa/package.json
@@ -77,7 +77,7 @@
     "@tsed/core": "^6.48.6",
     "@tsed/di": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "koa": "2.13.0",

--- a/packages/seq/package.json
+++ b/packages/seq/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --build tsconfig.compile.json"
   },
   "dependencies": {
-    "@tsed/logger-seq": "^5.13.3",
+    "@tsed/logger-seq": "^5.16.0",
     "tslib": "2.2.0"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "@tsed/core": "^6.48.6",
     "@tsed/di": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6"
   }

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -36,7 +36,7 @@
     "@tsed/core": "^6.48.6",
     "@tsed/di": "^6.48.6",
     "@tsed/json-mapper": "^6.48.6",
-    "@tsed/logger": "^5.13.3",
+    "@tsed/logger": "^5.16.0",
     "@tsed/openspec": "^6.48.6",
     "@tsed/schema": "^6.48.6",
     "socket.io": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,36 +2690,25 @@
     fs-extra "^10.0.0"
     tslib "2.2.0"
 
-"@tsed/logger-seq@^5.13.3":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@tsed/logger-seq/-/logger-seq-5.15.0.tgz#b22985b79f1a05474c606cfa5bd40028f60d77fa"
-  integrity sha512-alU5BMhzSS+/htc6Xjhnhz7lSlo4AgTqO12CVyi68IoHq5ue/Mby2rqjU1eK2oLV/Gnt0WV3iKZUOspa2fXhXw==
+"@tsed/logger-seq@^5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@tsed/logger-seq/-/logger-seq-5.16.0.tgz#6acb97544dde323dca525ffc279388d0cde69715"
+  integrity sha512-XdJxhueUM/AkJNiHTQy8LCYse7tlrFlIuCyw2ujeWctAWJJO2b2KeJND8+WEZh4hcWuGVqCQBZJbzmnkeXqKlw==
   dependencies:
     seq-logging "0.5.0"
+    tslib "2.3.0"
 
-"@tsed/logger@^5.12.1":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-5.12.1.tgz#c0aaa55b337f0e42f1badafa6975352814df60bb"
-  integrity sha512-sZ3bN1qrix6cwk6IgfmSqS2mGaHsyqipIG+8Dwjgjzmpkfswg9WSph1T1T39gEYioBfYTNPy2HXbMzls2ocwBg==
+"@tsed/logger@^5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-5.16.0.tgz#0ae28a771a1682bc2931cbe7839d62a70ff299bd"
+  integrity sha512-ikoyUYe9LXEICCk0j+u+87I+sX+QyFNsnRTQpC48DRJXYP0xR0nDU0zABov+M0uYY5KWcr9nRpJBA9HVJzobow==
   dependencies:
     colors "^1.3.3"
     date-format "^3.0.0"
     lodash "^4.17.21"
     semver "^7.3.2"
     streamroller "^1.0.3"
-    tslib "2.1.0"
-
-"@tsed/logger@^5.14.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-5.15.0.tgz#ae9506d684adad1b05c2b00db4708cf96dc4cca5"
-  integrity sha512-3LaPh41/FheKzOfjGK5wq/wlLLz2Pz3Dy4rTzRDWsJLYX4M6bm+v5TFMmh9qgwrlk4xxiSTGzS3U2j4iSNzxpA==
-  dependencies:
-    colors "^1.3.3"
-    date-format "^3.0.0"
-    lodash "^4.17.21"
-    semver "^7.3.2"
-    streamroller "^1.0.3"
-    tslib "2.1.0"
+    tslib "2.3.0"
 
 "@tsed/monorepo-utils@1.18.4":
   version "1.18.4"
@@ -17876,15 +17865,15 @@ tslib@2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
+tslib@2.3.0, tslib@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tsscmp@1.0.6, tsscmp@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature/Fix/Doc/Chore | Yes/No

****

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
