### PR TITLE
OIDC

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -28,6 +28,6 @@
   "check-coverage": true,
   "lines": 99.89,
   "statements": 99.87,
-  "functions": 99.83,
-  "branches": 88.66
+  "functions": 99.79,
+  "branches": 88.9
 }

--- a/docs/tutorials/oidc.md
+++ b/docs/tutorials/oidc.md
@@ -52,6 +52,10 @@ Then we need to follow these steps:
 - Create the Interactions controller,
 - Create our first Login interaction and views,
 
+::: tip
+Select "OpenID Connect provider" upon initialization with the Ts.ED CLI and the following will be automatically generated.
+:::
+
 ## Configuration
 
 To use oidc-provider with Ts.ED it requires some other Ts.ED features to work properly. 
@@ -78,23 +82,19 @@ export const rootDir = __dirname;
     Adapter: FileSyncAdapter
   },
   oidc: {
-    path: "/oidc",
-    issuer: "https://localhost:8443/oidc/",
-    proxy: true,
-    jwksPath: join(__dirname, "..", "keys", "jwks.json"),
-    Accounts: Accounts, // Injectable service to manage your accounts
-    clients: [ // statics clients
+    // path: "/oidc",
+    Accounts: Accounts,
+    jwksPath: join(__dirname, "..", "..", "keys", "jwks.json"),
+    clients: [
       {
-        client_id: 'foo',
-        client_secret: "secret",
-        grant_types: [
-          "authorization_code",
-          "implicit"
-        ],
+        client_id: "client_id",
+        client_secret: "client_secret",
         redirect_uris: [
-            'https://localhost:8080/cb' // Assuming your frontend application runs at port 8080
+          "http://localhost:3000"
         ],
-        token_endpoint_auth_method: 'none'
+        response_types: ["id_token"],
+        grant_types: ["implicit"],
+        token_endpoint_auth_method: "none"
       }
     ],
     claims: {
@@ -247,13 +247,7 @@ Now, we need to add the Views to display our login page. Create a views director
 The login page is ready to be displayed. To test it, open the following link:
 
 ```
-https://localhost:8443/oidc/auth?response_type=code%20id_token
-&client_id=foo
-&scope=openid
-&redirect_uri=https%3A%2F%2Flocalhost%3A8080%2Fcb
-&code_challenge=NiC_lkZ0dlkh64vlvbXVIc0t4cTOrNrQGsdD1E-TJ5Y
-&code_challenge_method=S256
-&nonce=8973498723498723423
+http://localhost:8083/auth?client_id=client_id&response_type=id_token&scope=openid&nonce=foobar&redirect_uri=http://localhost:3000
 
 ```
 

--- a/packages/oidc-provider/package.json
+++ b/packages/oidc-provider/package.json
@@ -6,16 +6,24 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "private": false,
+  "contributors": [
+    {
+      "name" : "romakita"
+    },
+    {
+      "name" : "stefanvanherwijnen"
+    }
+  ],
   "scripts": {
     "build": "tsc --build tsconfig.compile.json",
     "start": "ts-node -r tsconfig-paths/register test/app/index.ts"
   },
   "dependencies": {
     "@tsed/adapters": "6.63.1",
-    "@types/lowdb": "1.0.9",
-    "@types/oidc-provider": "^7.1.1",
-    "@types/uuid": "8.3.0",
+    "express-urlrewrite": "^1.4.0",
     "jose2": "npm:jose@^2.0.4",
+    "koa-mount": "^4.0.0",
+    "koa-rewrite": "^3.0.1",
     "lowdb": "1.0.0",
     "tslib": "2.2.0",
     "uuid": "8.3.2"
@@ -25,6 +33,9 @@
     "@tsed/core": "6.63.1",
     "@tsed/di": "6.63.1",
     "@tsed/exceptions": "6.63.1",
+    "@types/lowdb": "1.0.9",
+    "@types/oidc-provider": "^7.1.1",
+    "@types/uuid": "8.3.0",
     "oidc-provider": "^7.3.0"
   },
   "peerDependencies": {

--- a/packages/oidc-provider/src/OidcModule.spec.ts
+++ b/packages/oidc-provider/src/OidcModule.spec.ts
@@ -1,0 +1,118 @@
+import {PlatformTest} from "@tsed/common";
+import {expect} from "chai";
+import proxyquire from "proxyquire";
+import Sinon from "sinon";
+import {OidcProvider} from "./services/OidcProvider";
+
+const expressRewrite = Sinon.spy(require("express-urlrewrite"));
+const koaRewrite = Sinon.spy(require("koa-rewrite"));
+const koaMount = Sinon.spy(require("koa-mount"));
+
+const {OidcModule} = proxyquire.noCallThru()("./OidcModule", {
+  "express-urlrewrite": expressRewrite,
+  "koa-rewrite": koaRewrite,
+  "koa-mount": koaMount
+});
+
+describe("OidcModule", () => {
+  describe("with express", () => {
+    beforeEach(() =>
+      PlatformTest.create({
+        PLATFORM_NAME: "express",
+        oidc: {
+          path: "/oidc"
+        }
+      })
+    );
+
+    afterEach(() => PlatformTest.reset());
+    describe('when path "/oidc"', () => {
+      it("should register the appropriate rewrite middleware", async () => {
+        const mdl = await PlatformTest.invoke(OidcModule);
+
+        Sinon.stub(mdl.app, "use");
+
+        await mdl.$onRoutesInit();
+
+        expect(expressRewrite).to.have.been.calledWithExactly("/.well-known/*", "/oidc/.well-known/$1");
+        expect(mdl.app.use).to.have.been.calledWithExactly(Sinon.match.func);
+      });
+      it("should mount the oidc provider server to application", async () => {
+        const provider = {
+          app: "app",
+          callback: Sinon.stub().returns("callback")
+        };
+        const oidcProvider = {
+          hasConfiguration: Sinon.stub().returns(true),
+          get: Sinon.stub().returns(provider),
+          create: Sinon.stub()
+        };
+        const mdl = await PlatformTest.invoke(OidcModule, [
+          {
+            token: OidcProvider,
+            use: oidcProvider
+          }
+        ]);
+
+        Sinon.stub(mdl.app, "use");
+
+        await mdl.$afterRoutesInit();
+
+        expect(mdl.app.use).to.have.been.calledWithExactly("/oidc", "callback");
+      });
+    });
+  });
+  describe("with koa", () => {
+    beforeEach(() =>
+      PlatformTest.create({
+        PLATFORM_NAME: "koa",
+        oidc: {
+          path: "/oidc"
+        }
+      })
+    );
+
+    afterEach(() => {
+      PlatformTest.reset();
+      expressRewrite.resetHistory();
+      koaRewrite.resetHistory();
+      koaMount.resetHistory();
+    });
+    describe('when path "/oidc"', () => {
+      it("should register the appropriate rewrite middleware", async () => {
+        const mdl = await PlatformTest.invoke(OidcModule);
+
+        Sinon.stub(mdl.app, "use");
+
+        await mdl.$onRoutesInit();
+
+        expect(koaRewrite).to.have.been.calledWithExactly("/.well-known/(.*)", "/oidc/.well-known/$1");
+        expect(mdl.app.use).to.have.been.calledWithExactly(Sinon.match.func);
+      });
+      it("should mount the oidc provider server to application", async () => {
+        const provider = {
+          app: "app",
+          callback: Sinon.stub().returns("callback")
+        };
+        const oidcProvider = {
+          hasConfiguration: Sinon.stub().returns(true),
+          get: Sinon.stub().returns(provider),
+          create: Sinon.stub()
+        };
+        const mdl = await PlatformTest.invoke(OidcModule, [
+          {
+            token: OidcProvider,
+            use: oidcProvider
+          }
+        ]);
+
+        Sinon.stub(mdl.app, "use");
+
+        await mdl.$afterRoutesInit();
+
+        expect(koaMount).to.have.been.calledWithExactly("/oidc", "app");
+        expect(mdl.app.use).to.have.been.calledWithExactly(Sinon.match.func);
+      });
+    });
+  });
+});

--- a/packages/oidc-provider/src/domain/OidcSettings.ts
+++ b/packages/oidc-provider/src/domain/OidcSettings.ts
@@ -5,6 +5,10 @@ import {OidcAccountsMethods} from "./OidcAccountsMethods";
 
 export interface OidcSettings extends Configuration {
   /**
+   * Path on which the oidc-provider instance is mounted.
+   */
+  path?: string;
+  /**
    * Issuer URI. By default Ts.ED create issuer with http://localhost:${httpPort}
    */
   issuer?: string;

--- a/packages/oidc-provider/test/oidc.integration.spec.ts
+++ b/packages/oidc-provider/test/oidc.integration.spec.ts
@@ -8,6 +8,9 @@ import {rootDir} from "../../platform-express/test/app/Server";
 import {InteractionsCtrl} from "./app/controllers/oidc/InteractionsCtrl";
 import {Server} from "./app/Server";
 
+import {join} from "path";
+import {Accounts} from "./app/services/Accounts";
+
 const utils = PlatformTestUtils.create({
   rootDir,
   platform: PlatformExpress,
@@ -95,4 +98,132 @@ describe("OIDC", () => {
 
     expect(confirmResponse.headers.location).to.contain("http://localhost:3000#id_token=");
   });
+
+  it("should display the discovery page on /.well-known/openid-configuration", async () => {
+    const res = await request
+      .get("/.well-known/openid-configuration")
+      .set({
+        "Origin": "http://0.0.0.0:8081",
+        "Host": "0.0.0.0:8081"
+      });
+    expect(JSON.parse(res.text).authorization_endpoint).to.be.equal("http://0.0.0.0:8081/auth")
+  })
+});
+
+describe("OIDC on a different path", () => {
+  let request: SuperTest.SuperTest<SuperTest.Test>;
+
+  async function followRedirection(response: any, headers: any = {}) {
+    if (response.headers.location) {
+      const url = response.headers.location.replace("http://0.0.0.0:8081", "");
+      return request.get(url)
+        .set("Origin", "http://0.0.0.0:8081")
+        .set("Host", "0.0.0.0:8081")
+        .set(headers);
+    }
+
+    return response;
+  }
+
+  beforeEach(utils.bootstrap({
+    mount: {
+      "/": [InteractionsCtrl]
+    },
+    oidc: {
+      path: "/oidc",
+      Accounts: Accounts,
+      jwksPath: join(__dirname, "..", "..", "keys", "jwks.json"),
+      clients: [
+        {
+          client_id: "client_id",
+          client_secret: "client_secret",
+          redirect_uris: [
+            "http://localhost:3000"
+          ],
+          response_types: ["id_token"],
+          grant_types: ["implicit"],
+          token_endpoint_auth_method: "none"
+        }
+      ],
+      claims: {
+        openid: ["sub"],
+        email: ["email", "email_verified"]
+      },
+      features: {
+        // disable the packaged interactions
+        devInteractions: {enabled: false},
+        encryption: {enabled: true},
+        introspection: {enabled: true},
+        revocation: {enabled: true}
+      }
+    },
+    adapters: {
+      Adapter: MemoryAdapter
+    }
+  }));
+  beforeEach(() => {
+    request = SuperTest.agent(PlatformTest.callback());
+  });
+
+  afterEach(() => PlatformTest.reset());
+
+  it("should display the OIDC login page then login", async () => {
+    const authRes = await request
+      .get("/oidc/auth?client_id=client_id&response_type=id_token&scope=openid+email&nonce=foobar&prompt=login&redirect_uri=http://localhost:3000")
+      .set({
+        "Origin": "http://0.0.0.0:8081",
+        "Host": "0.0.0.0:8081"
+      });
+
+    const [, , id] = authRes.headers.location.replace("http://0.0.0.0:8081", "").split("/");
+
+    const response = await followRedirection(authRes);
+
+    expect(response.text).to.includes("Sign-in");
+
+    const postResponse = await request
+      .post(`${authRes.headers.location}/login`)
+      .set({
+        "Origin": "http://0.0.0.0:8081",
+        "Host": "0.0.0.0:8081",
+        "Upgrade-Insecure-Requests": "1",
+        "referer": `http://0.0.0.0:8081/interaction/${id}`
+      })
+      .send("email=test%40test.com&password=admin");
+
+    expect(postResponse.headers.location).to.equal(`http://0.0.0.0:8081/oidc/auth/${id}`);
+
+    const headers = {
+      "Origin": "http://0.0.0.0:8081",
+      "Host": "0.0.0.0:8081",
+      "Upgrade-Insecure-Requests": "1",
+      "referer": `http://0.0.0.0:8081/interaction/${id}`
+    };
+
+    const consentResponse = await followRedirection(await followRedirection(postResponse, headers), headers);
+
+    const matches = consentResponse.text.match(/action="(.*)" /gi)
+    const interactionUrl = matches[0].split('"')[1]
+
+    const confirmResponse = await followRedirection(await request
+      .post(interactionUrl)
+      .set({
+        "Origin": "http://0.0.0.0:8081",
+        "Host": "0.0.0.0:8081",
+        "Upgrade-Insecure-Requests": "1",
+        "referer": `http://0.0.0.0:8081/interaction/${id}`
+      }), headers);
+
+    expect(confirmResponse.headers.location).to.contain("http://localhost:3000#id_token=");
+  });
+
+  it("should display the discovery page on /.well-known/openid-configuration", async () => {
+    const res = await request
+      .get("/.well-known/openid-configuration")
+      .set({
+        "Origin": "http://0.0.0.0:8081",
+        "Host": "0.0.0.0:8081"
+      });
+    expect(JSON.parse(res.text).authorization_endpoint).to.be.equal("http://0.0.0.0:8081/oidc/auth")
+  })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6558,6 +6558,13 @@ db-errors@^0.2.3:
   resolved "https://registry.yarnpkg.com/db-errors/-/db-errors-0.2.3.tgz#a6a38952e00b20e790f2695a6446b3c65497ffa2"
   integrity sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng==
 
+debug@*:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -7789,6 +7796,14 @@ express-session@1.17.1:
     parseurl "~1.3.3"
     safe-buffer "5.2.0"
     uid-safe "~2.1.5"
+
+express-urlrewrite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/express-urlrewrite/-/express-urlrewrite-1.4.0.tgz#985ee022773bac7ed32126f1cf9ec8ee48e1290a"
+  integrity sha512-PI5h8JuzoweS26vFizwQl6UTF25CAHSggNv0J25Dn/IKZscJHWZzPrI5z2Y2jgOzIaw2qh8l6+/jUcig23Z2SA==
+  dependencies:
+    debug "*"
+    path-to-regexp "^1.0.3"
 
 express@4.17.1, express@^4.17.1:
   version "4.17.1"
@@ -11090,12 +11105,28 @@ koa-is-json@^1.0.0:
   resolved "https://registry.yarnpkg.com/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"
   integrity sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=
 
+koa-mount@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/koa-mount/-/koa-mount-4.0.0.tgz#e0265e58198e1a14ef889514c607254ff386329c"
+  integrity sha512-rm71jaA/P+6HeCpoRhmCv8KVBIi0tfGuO/dMKicbQnQW/YJntJ6MnnspkodoA4QstMVEZArsCphmd0bJEtoMjQ==
+  dependencies:
+    debug "^4.0.1"
+    koa-compose "^4.1.0"
+
 koa-override@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/koa-override/-/koa-override-3.0.0.tgz#a14fa84975bab08c5730a43788883164f4f81a1c"
   integrity sha512-w2rWCfapbQUZ8TrRBarj6iwryCTooEcdw9lr1hYC1q4FnaCZcAOhpjB1VpqtbODALVMgY3JGlzLSeYRXc5Ky0Q==
   dependencies:
     methods "^1.1.2"
+
+koa-rewrite@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/koa-rewrite/-/koa-rewrite-3.0.1.tgz#37c2ae31f31a7af98cc1b028020b321d75a7d294"
+  integrity sha512-KIGvmurKl2TwfceZEWzHWEmHHyJbkTKUZ2ebpa8G2Ywet0jc3zRhPwi8yxG/tEUra0wFAPDh9Ph8ln7okPcyEg==
+  dependencies:
+    debug "^3.1.0"
+    path-to-regexp "^2.1.0"
 
 koa-send@5.0.1:
   version "5.0.1"
@@ -14473,12 +14504,17 @@ path-to-regexp@3.2.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.2.0.tgz#fa7877ecbc495c601907562222453c43cc204a5f"
   integrity sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==
 
-path-to-regexp@^1.7.0:
+path-to-regexp@^1.0.3, path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
 
 path-to-regexp@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
A few points:
- Because oidc-provider is a koa app with a catch-all route, mounting it at `/` intervenes with the TSed exception handler. This is fixed by mounting it at `/oidc` and rewriting the route for the discovery documentation.
- For Koa, oidc needs to be mounted differently which now works correctly (previously all requests would be handled by both the TSed and oidc-provider koa instance)
- There are no type declarations for koa-rewrite, which results in `test/app` not compiling. I couldn't figure out how to fix this.
- I cleaned the documentation and embedded the files from the `test/app` directory.
- I added documentation for a TLS proxy using Caddy.

I couldn't directly test the app/documentation as it does not compile, so if you know a fix that would be great. Because the code is now embedded in the docs, if the test app works the documentation is also correct.

The CLI plugin is almost finished, but I want to make sure everything is consistent along all documentation.
For example, the CLI initializes an app with default port 8083, and the documentation used 8081. I'd like to make sure that the CLI automates the steps in the documentation without modifications.