### PR TITLE
Fixed 2 broken (404) linked from readme.md file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@
 <div align="center">
   <a href="https://tsed.io/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/getting-started.html">Getting started</a>
+  <a href="https://tsed.io/getting-started/">Getting started</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
@@ -129,7 +129,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-To customize the server settings see [Configure server with decorator](https://tsed.io/docs/configuration.md)
+To customize the server settings see [Configure server with decorator](https://tsed.io/docs/configuration.html)
 
 #### Controller example
 


### PR DESCRIPTION

## Information

Type

Doc: Fixed readme,md links for "getting-started" & "configuration"

These issues were found with tool:
https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

****

<!--
## Usage example

doc
```
-->


- [ ] Tests
- [ ] Coverage
- [ ] Example
- [X ] Documentation
