### PR TITLE
Fix documentation for 404 ResourceNotFound

### DIFF
--- a/docs/docs/snippets/exceptions/resource-not-found-filter.ts
+++ b/docs/docs/snippets/exceptions/resource-not-found-filter.ts
@@ -11,14 +11,10 @@ export class ResourceNotFoundFilter implements ExceptionFilterMethods {
       url: exception.url
     };
     // Json response
-    response
-      .status(exception.status)
-      .body(obj);
+    response.status(exception.status).body(obj);
 
     // Or with ejs/handlers/etc...
-    await html = response.render("404.ejs", obj);
-    response
-      .status(exception.status)
-      .body(html)
+    const html = await response.render("404.ejs", obj);
+    response.status(exception.status).body(html);
   }
 }

--- a/docs/docs/snippets/exceptions/resource-not-found-filter.ts
+++ b/docs/docs/snippets/exceptions/resource-not-found-filter.ts
@@ -16,8 +16,9 @@ export class ResourceNotFoundFilter implements ExceptionFilterMethods {
       .body(obj);
 
     // Or with ejs/handlers/etc...
-    await response
+    await html = response.render("404.ejs", obj);
+    response
       .status(exception.status)
-      .render("404.ejs", obj);
+      .body(html)
   }
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Doc | No

****

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
