### PR TITLE
fix(swagger): Fix swagger generation handles pathPatterns, hidden and doc

### DIFF
--- a/packages/specs/swagger/src/services/SwaggerService.ts
+++ b/packages/specs/swagger/src/services/SwaggerService.ts
@@ -5,8 +5,8 @@ import {getSpec, mergeSpec, SpecSerializerOptions} from "@tsed/schema";
 import Fs from "fs";
 import {SwaggerOS2Settings, SwaggerOS3Settings, SwaggerSettings} from "../interfaces/SwaggerSettings";
 import {getSpecTypeFromSpec} from "../utils/getSpecType";
+import {includeRoute} from "../utils/includeRoute";
 import {mapOpenSpec} from "../utils/mapOpenSpec";
-import {matchPath} from "../utils/matchPath";
 
 @Injectable()
 export class SwaggerService {
@@ -44,7 +44,7 @@ export class SwaggerService {
       };
 
       this.platform.getMountedControllers().forEach(({route, provider}) => {
-        if (this.includeRoute(route, provider, conf)) {
+        if (includeRoute(route, provider, conf)) {
           const spec = this.buildRoutes(provider, {
             ...options,
             rootPath: route.replace(provider.path, "")
@@ -58,15 +58,6 @@ export class SwaggerService {
     }
 
     return this.#specs.get(conf.path);
-  }
-
-  includeRoute(route: string, provider: ControllerProvider, conf: SwaggerSettings) {
-    const hidden = provider.store.get("hidden");
-    const docs = provider.store.get("docs") || [];
-    const {doc} = conf;
-    const inDoc = (!doc && !hidden) || (doc && docs.indexOf(doc) > -1);
-
-    return inDoc || matchPath(route, conf.pathPatterns);
   }
 
   /**

--- a/packages/specs/swagger/src/utils/includeRoute.spec.ts
+++ b/packages/specs/swagger/src/utils/includeRoute.spec.ts
@@ -1,0 +1,105 @@
+import {ControllerProvider} from "@tsed/platform/common";
+import {Hidden} from "@tsed/specs/schema";
+import {expect} from "chai";
+import {Docs} from "..";
+import {includeRoute} from "./includeRoute";
+
+@Hidden()
+class HiddenCtrl {}
+
+@Docs("test")
+class DocsCtrl {}
+
+class PlainCtrl {}
+
+describe("includeRoute", () => {
+  it("should return false if controller has hidden decorator", () => {
+    const provider = new ControllerProvider(HiddenCtrl);
+    expect(
+      includeRoute("/test", provider, {
+        path: "/swagger"
+      })
+    ).to.be.false;
+  });
+
+  it("should return false if controller docs does not include doc", () => {
+    const provider = new ControllerProvider(DocsCtrl);
+    expect(
+      includeRoute("/test", provider, {
+        path: "/swagger",
+        doc: "notmatch"
+      })
+    ).to.be.false;
+  });
+
+  it("should return true if controller docs include doc", () => {
+    const provider = new ControllerProvider(DocsCtrl);
+    expect(
+      includeRoute("/test", provider, {
+        path: "/swagger",
+        doc: "test"
+      })
+    ).to.be.true;
+  });
+
+  it("should return true if patternMatch matches to route", () => {
+    const provider = new ControllerProvider(PlainCtrl);
+    expect(
+      includeRoute("/should/match", provider, {
+        path: "/swagger",
+        pathPatterns: ["/should/**"]
+      })
+    ).to.be.true;
+  });
+
+  it("should return false if patternMatch does not match to route", () => {
+    const provider = new ControllerProvider(PlainCtrl);
+    expect(
+      includeRoute("/shouldnot/match", provider, {
+        path: "/swagger",
+        pathPatterns: ["/notmatch/**"]
+      })
+    ).to.be.false;
+  });
+
+  it("should return false if patternMatch is negation and matches to route", () => {
+    const provider = new ControllerProvider(PlainCtrl);
+    expect(
+      includeRoute("/should/match", provider, {
+        path: "/swagger",
+        pathPatterns: ["!/should/**"]
+      })
+    ).to.be.false;
+  });
+
+  it("should return true if neither doc nor pathPattern is not defined", () => {
+    const provider = new ControllerProvider(PlainCtrl);
+    expect(
+      includeRoute("/test", provider, {
+        path: "/swagger"
+      })
+    ).to.be.true;
+  });
+
+  it("should return true if doc and pathPattern defined and only doc matches", () => {
+    const provider = new ControllerProvider(DocsCtrl);
+    expect(
+      includeRoute("/shouldnot/match", provider, {
+        path: "/swagger",
+        doc: "test",
+        pathPatterns: ["/notmatch/**"]
+      })
+    ).to.be.true;
+  });
+
+  it("should return true if doc and pathPattern defined and only pathPattern matches", () => {
+    const provider = new ControllerProvider(DocsCtrl);
+    expect(
+      includeRoute("/should/match", provider, {
+        path: "/swagger",
+        doc: "nomatch",
+        pathPatterns: ["/should/**"]
+      })
+    ).to.be.true;
+  });
+});

--- a/packages/specs/swagger/src/utils/includeRoute.ts
+++ b/packages/specs/swagger/src/utils/includeRoute.ts
@@ -1,0 +1,21 @@
+import {ControllerProvider} from "@tsed/common";
+import {matchPath} from ".";
+import {SwaggerSettings} from "..";
+
+export function includeRoute(route: string, provider: ControllerProvider, conf: SwaggerSettings): boolean {
+  const hidden = provider.store.get("hidden");
+  const docs = provider.store.get("docs") || [];
+  const {doc, pathPatterns} = conf;
+  const inDoc = doc && docs.indexOf(doc) > -1;
+  const pathPatternMatch = pathPatterns && matchPath(route, pathPatterns);
+
+  if (hidden) {
+    return false;
+  }
+
+  if (!doc && !pathPatterns) {
+    return true;
+  }
+
+  return !!(inDoc || pathPatternMatch);
+}


### PR DESCRIPTION
- Hidden decorator on controller will now always hide controller from swagger. 
- Controller will now included to swagger if either `doc` from swagger options matches to `Docs` decorator on controller or `pathPatterns` matches to controller route. 
- Also fixes issue when not matching doc is needed to get negative `pathPatterns` option to work.

## Information

Type | Breaking change
---|---
Fix | Yes

****

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
