### PR TITLE
fix(platform-serverless): Add application/json when the response is s…

### DIFF
--- a/packages/platform/platform-serverless/src/builder/PlatformServerless.spec.ts
+++ b/packages/platform/platform-serverless/src/builder/PlatformServerless.spec.ts
@@ -55,7 +55,8 @@ describe("PlatformServerless", () => {
 
     expect(response.statusCode).toEqual(200);
     expect(response.headers).toEqual({
-      "x-request-id": "requestId"
+      "x-request-id": "requestId",
+      "content-type": "application/json"
     });
     expect(JSON.parse(response.body)).toEqual({
       endDate: "2020-01-10T00:00:00.000Z",
@@ -77,7 +78,8 @@ describe("PlatformServerless", () => {
 
     expect(response.statusCode).toEqual(200);
     expect(response.headers).toEqual({
-      "x-request-id": "request-id"
+      "x-request-id": "request-id",
+      "content-type": "application/json"
     });
     expect(JSON.parse(response.body)).toEqual({
       endDate: "2020-01-10T00:00:00.000Z",

--- a/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.spec.ts
+++ b/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.spec.ts
@@ -51,7 +51,9 @@ describe("PlatformServerlessHandler", () => {
 
     expect(result).toEqual({
       body: '{"value":"test"}',
-      headers: {},
+      headers: {
+        "content-type": "application/json"
+      },
       isBase64Encoded: false,
       statusCode: 200
     });

--- a/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.ts
+++ b/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.ts
@@ -62,6 +62,7 @@ export class PlatformServerlessHandler {
     let body: any = $ctx.response.getBody();
 
     if (shouldBeSerialized(body)) {
+      $ctx.response.set("content-type", "application/json");
       body = JSON.stringify(body);
     }
 

--- a/packages/platform/platform-serverless/test/body.integration.spec.ts
+++ b/packages/platform/platform-serverless/test/body.integration.spec.ts
@@ -1,7 +1,7 @@
 import "@tsed/ajv";
-import {Injectable} from "@tsed/di";
-import {BodyParams, Patch, PlatformServerlessTest, Post, Put} from "@tsed/platform-serverless";
-import {MinLength, Property, Returns} from "@tsed/schema";
+import { Injectable } from "@tsed/di";
+import { BodyParams, Patch, PlatformServerlessTest, Post, Put } from "@tsed/platform-serverless";
+import { MinLength, Property, Returns } from "@tsed/schema";
 
 class Model {
   @Property()
@@ -64,7 +64,11 @@ describe("Body params", () => {
         "id": "1",
         "name": "Test"
       });
-      expect(response.headers).toEqual({"x-test": "test", "x-request-id": "requestId"});
+      expect(response.headers).toEqual({
+        "x-test": "test",
+        "x-request-id": "requestId",
+        "content-type": "application/json"
+      });
     });
     it("should throw an error", async () => {
       const response = await PlatformServerlessTest.request.call("scenario2").put("/").body({

--- a/packages/platform/platform-serverless/test/response.integration.spec.ts
+++ b/packages/platform/platform-serverless/test/response.integration.spec.ts
@@ -1,6 +1,6 @@
-import {Injectable} from "@tsed/di";
-import {BodyParams, PlatformServerlessTest, Post} from "@tsed/platform-serverless";
-import {MinLength, Property} from "@tsed/schema";
+import { Injectable } from "@tsed/di";
+import { BodyParams, PlatformServerlessTest, Post } from "@tsed/platform-serverless";
+import { MinLength, Property } from "@tsed/schema";
 
 class Model {
   @Property()
@@ -41,8 +41,12 @@ describe("Response", () => {
       });
 
       expect(response.statusCode).toBe(216);
-      expect(JSON.parse(response.body)).toEqual({test: "hello"});
-      expect(response.headers).toEqual({"test-x": "id", "x-request-id": "requestId"});
+      expect(JSON.parse(response.body)).toEqual({ test: "hello" });
+      expect(response.headers).toEqual({
+        "test-x": "id",
+        "x-request-id": "requestId",
+        "content-type": "application/json"
+      });
     });
   });
 });


### PR DESCRIPTION
…erializable

## Information

Type | Breaking change
---|---
Feature/Fix/Doc/Chore | Yes/No

****

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
