### PR TITLE
chore: change terminus values store to fix undefined issue

### DIFF
--- a/packages/third-parties/terminus/src/decorators/shutdown.ts
+++ b/packages/third-parties/terminus/src/decorators/shutdown.ts
@@ -4,7 +4,7 @@ function register(name: string) {
   return <Function>(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<Function>) => {
     if (descriptor.value) {
       const store = Store.from(target);
-      const values = store.get(name, []);
+      const values = store.get(name) || [];
 
       store.merge(name, [...values, descriptor.value]);
     }


### PR DESCRIPTION
## Information

Fix | Not a breaking change

Currently the @tsed/terminus returns an undefined store, this causes crashes when terminus decorators are used in an application. This is fixed so that an empty store is returned.

****

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
