### PR TITLE
Make onInit stateless by removing call to clear()

### DIFF
--- a/packages/specs/schema/src/decorators/operations/returns.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.ts
@@ -301,7 +301,6 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
       default:
         throw new UnsupportedDecoratorType(Returns, args);
     }
-
   }
 
   protected map() {

--- a/packages/specs/schema/src/decorators/operations/returns.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.ts
@@ -302,7 +302,6 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
         throw new UnsupportedDecoratorType(Returns, args);
     }
 
-    this.clear();
   }
 
   protected map() {


### PR DESCRIPTION
## Information

Type | Bugfix
---|---
Fix | Yes

@Romakita looks like this solves the issue where Returns doesn't apply to classes. It also seems like this trips it up in other contexts. 

Not sure what else this will break. I guess we will see in the tests?
