### PR TITLE
feat(adapters): migrate to jest

### DIFF
--- a/packages/orm/adapters/.mocharc.js
+++ b/packages/orm/adapters/.mocharc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  ...require('@tsed/mocha-config')(),
-  spec: ["{src,test}/**/*.spec.ts"],
-  exclude: [],
-};

--- a/packages/orm/adapters/jest.config.js
+++ b/packages/orm/adapters/jest.config.js
@@ -1,0 +1,14 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  ...require("@tsed/jest-config")(__dirname, "adapters"),
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70
+    }
+  }
+};

--- a/packages/orm/adapters/package.json
+++ b/packages/orm/adapters/package.json
@@ -8,7 +8,7 @@
   "typings": "./lib/index.d.ts",
   "scripts": {
     "build": "tsc --build tsconfig.compile.json",
-    "test": "cross-env NODE_ENV=test nyc mocha"
+    "test": "cross-env NODE_ENV=test yarn jest"
   },
   "dependencies": {
     "@types/lowdb": "1.0.9",

--- a/packages/orm/adapters/src/adapters/FileSyncAdapter.spec.ts
+++ b/packages/orm/adapters/src/adapters/FileSyncAdapter.spec.ts
@@ -1,7 +1,6 @@
 import {Adapter, Adapters, FileSyncAdapter} from "@tsed/adapters";
 import {PlatformTest} from "@tsed/common";
 import {Property} from "@tsed/schema";
-import {expect} from "chai";
 import * as faker from "faker";
 
 class Client {
@@ -25,11 +24,11 @@ describe("FileSyncAdapter", () => {
       });
     });
 
-    after(async () => {
+    afterAll(async () => {
       await adapter.deleteMany({});
     });
 
-    describe("create()", async () => {
+    describe("create()", () => {
       it("should create a new instance", async () => {
         const base = {
           name: faker.name.title()
@@ -37,9 +36,9 @@ describe("FileSyncAdapter", () => {
 
         const client = await adapter.create(base);
 
-        expect(client).to.be.instanceOf(Client);
-        expect(client._id).to.be.a("string");
-        expect(client.name).to.equal(base.name);
+        expect(client).toBeInstanceOf(Client);
+        expect(typeof client._id).toBe("string");
+        expect(client.name).toBe(base.name);
       });
     });
 
@@ -52,9 +51,9 @@ describe("FileSyncAdapter", () => {
         const client = await adapter.create(base);
         const result = await adapter.findById(client._id);
 
-        expect(result).to.be.instanceOf(Client);
-        expect(result?._id).to.equal(client._id);
-        expect(result?.name).to.equal(base.name);
+        expect(result).toBeInstanceOf(Client);
+        expect(result?._id).toBe(client._id);
+        expect(result?.name).toBe(base.name);
       });
     });
 
@@ -70,9 +69,9 @@ describe("FileSyncAdapter", () => {
           name: base.name
         });
 
-        expect(result).to.be.instanceOf(Client);
-        expect(result?._id).to.equal(client._id);
-        expect(result?.name).to.equal(base.name);
+        expect(result).toBeInstanceOf(Client);
+        expect(result?._id).toBe(client._id);
+        expect(result?.name).toBe(base.name);
       });
     });
   });
@@ -89,11 +88,11 @@ describe("FileSyncAdapter", () => {
       });
     });
 
-    after(async () => {
+    afterAll(async () => {
       await adapter.deleteMany({});
     });
 
-    describe("create()", async () => {
+    describe("create()", () => {
       it("should create a new instance", async () => {
         const base = {
           name: faker.name.title()
@@ -101,9 +100,9 @@ describe("FileSyncAdapter", () => {
 
         const client = await adapter.create(base);
 
-        expect(client).to.be.instanceOf(Client);
-        expect(client._id).to.be.a("string");
-        expect(client.name).to.equal(base.name);
+        expect(client).toBeInstanceOf(Client);
+        expect(typeof client._id).toBe("string");
+        expect(client.name).toBe(base.name);
       });
     });
 
@@ -116,9 +115,9 @@ describe("FileSyncAdapter", () => {
         const client = await adapter.create(base);
         const result = await adapter.findById(client._id);
 
-        expect(result).to.be.instanceOf(Client);
-        expect(result?._id).to.equal(client._id);
-        expect(result?.name).to.equal(base.name);
+        expect(result).toBeInstanceOf(Client);
+        expect(result?._id).toBe(client._id);
+        expect(result?.name).toBe(base.name);
       });
     });
 
@@ -134,9 +133,9 @@ describe("FileSyncAdapter", () => {
           name: base.name
         });
 
-        expect(result).to.be.instanceOf(Client);
-        expect(result?._id).to.equal(client._id);
-        expect(result?.name).to.equal(base.name);
+        expect(result).toBeInstanceOf(Client);
+        expect(result?._id).toBe(client._id);
+        expect(result?.name).toBe(base.name);
       });
     });
   });

--- a/packages/orm/adapters/src/adapters/MemoryAdapter.spec.ts
+++ b/packages/orm/adapters/src/adapters/MemoryAdapter.spec.ts
@@ -2,7 +2,6 @@ import {Adapter, Adapters, MemoryAdapter} from "@tsed/adapters";
 import {PlatformTest} from "@tsed/common";
 import {deserialize} from "@tsed/json-mapper";
 import {Format, Name, Property} from "@tsed/schema";
-import {expect} from "chai";
 import * as faker from "faker";
 
 class BaseClient {
@@ -42,10 +41,10 @@ describe("MemoryAdapter", () => {
 
       const client = await adapter.create(base);
 
-      expect(client).to.be.instanceOf(Client);
-      expect(client._id).to.be.a("string");
-      expect(client.name).to.equal(base.name);
-      expect(client.createdAt).to.deep.equal(base.createdAt);
+      expect(client).toBeInstanceOf(Client);
+      expect(typeof client._id).toBe("string");
+      expect(client.name).toBe(base.name);
+      expect(client.createdAt).toEqual(base.createdAt);
     });
 
     it("should create a new instance with expireAt", async () => {
@@ -55,9 +54,9 @@ describe("MemoryAdapter", () => {
 
       const client = await adapter.create(base, new Date());
 
-      expect(client).to.be.instanceOf(Client);
-      expect(client._id).to.be.a("string");
-      expect(client.name).to.equal(base.name);
+      expect(client).toBeInstanceOf(Client);
+      expect(typeof client._id).toBe("string");
+      expect(client.name).toBe(base.name);
     });
   });
 
@@ -69,9 +68,9 @@ describe("MemoryAdapter", () => {
 
       const client = await adapter.upsert(base._id, base);
 
-      expect(client).to.be.instanceOf(Client);
-      expect(client._id).to.be.a("string");
-      expect(client.name).to.equal(base.name);
+      expect(client).toBeInstanceOf(Client);
+      expect(typeof client._id).toBe("string");
+      expect(client.name).toBe(base.name);
     });
 
     it("should update instance if exists", async () => {
@@ -82,9 +81,9 @@ describe("MemoryAdapter", () => {
       const client = await adapter.upsert(base._id, base);
       const client2 = await adapter.upsert(client._id, client);
 
-      expect(client2).to.be.instanceOf(Client);
-      expect(client2._id).to.be.a("string");
-      expect(client2.name).to.equal(base.name);
+      expect(client2).toBeInstanceOf(Client);
+      expect(typeof client2._id).toBe("string");
+      expect(client2.name).toBe(base.name);
     });
   });
 
@@ -103,10 +102,10 @@ describe("MemoryAdapter", () => {
 
       const client2 = await adapter.updateOne({_id: client._id}, update);
 
-      expect(client2).to.be.instanceOf(Client);
-      expect(client2?._id).to.be.a("string");
-      expect(client2?.name).to.not.equal(base.name);
-      expect(client2?.name).to.equal(update.name);
+      expect(client2).toBeInstanceOf(Client);
+      expect(typeof client2?._id).toBe("string");
+      expect(client2?.name).not.toBe(base.name);
+      expect(client2?.name).toBe(update.name);
     });
     it("should return undefined", async () => {
       const base = {
@@ -115,7 +114,7 @@ describe("MemoryAdapter", () => {
 
       const client = await adapter.updateOne({_id: faker.random.uuid()}, base);
 
-      expect(client).to.equal(undefined);
+      expect(client).toBeUndefined();
     });
   });
 
@@ -128,9 +127,9 @@ describe("MemoryAdapter", () => {
       const client = await adapter.create(base);
       const result = await adapter.findById(client._id);
 
-      expect(result).to.be.instanceOf(Client);
-      expect(result?._id).to.equal(client._id);
-      expect(result?.name).to.equal(base.name);
+      expect(result).toBeInstanceOf(Client);
+      expect(result?._id).toBe(client._id);
+      expect(result?.name).toBe(base.name);
     });
   });
 
@@ -146,9 +145,9 @@ describe("MemoryAdapter", () => {
         name: base.name
       });
 
-      expect(result).to.be.instanceOf(Client);
-      expect(result?._id).to.equal(client._id);
-      expect(result?.name).to.equal(base.name);
+      expect(result).toBeInstanceOf(Client);
+      expect(result?._id).toBe(client._id);
+      expect(result?.name).toBe(base.name);
     });
   });
   describe("findAll()", () => {
@@ -163,8 +162,8 @@ describe("MemoryAdapter", () => {
         name: base.name
       });
 
-      expect(result[0]).to.be.instanceOf(Client);
-      expect(result[0].name).to.equal(base.name);
+      expect(result[0]).toBeInstanceOf(Client);
+      expect(result[0].name).toBe(base.name);
     });
   });
   describe("deleteById()", () => {
@@ -177,8 +176,8 @@ describe("MemoryAdapter", () => {
 
       const result = await adapter.deleteById(client._id);
 
-      expect(result).to.be.instanceOf(Client);
-      expect(result?.name).to.equal(base.name);
+      expect(result).toBeInstanceOf(Client);
+      expect(result?.name).toBe(base.name);
     });
   });
   describe("deleteMany()", () => {
@@ -198,8 +197,8 @@ describe("MemoryAdapter", () => {
 
       const result = await adapter.deleteMany(client);
 
-      expect(result[0]).to.be.instanceOf(Client);
-      expect(result[0]?.name).to.equal(base.name);
+      expect(result[0]).toBeInstanceOf(Client);
+      expect(result[0]?.name).toBe(base.name);
     });
   });
 });

--- a/packages/orm/adapters/src/decorators/indexed.spec.ts
+++ b/packages/orm/adapters/src/decorators/indexed.spec.ts
@@ -2,8 +2,6 @@ import {Adapter, Indexed} from "@tsed/adapters";
 import {PlatformTest} from "@tsed/common";
 import {Injectable} from "@tsed/di";
 import {Property} from "@tsed/schema";
-import {expect} from "chai";
-import Sinon from "sinon";
 import {MemoryAdapter} from "../adapters/MemoryAdapter";
 import {InjectAdapter} from "./injectAdapter";
 
@@ -16,8 +14,7 @@ describe("Indexed", () => {
       prop: string;
     }
 
-    const stub = Sinon.stub();
-
+    const stub = jest.fn();
     @Injectable()
     class Clients {
       @InjectAdapter("client", Client)
@@ -30,11 +27,11 @@ describe("Indexed", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
-    expect(stub).to.have.been.calledWithExactly();
-    expect(clients.adapter.collectionName).to.eq("client");
-    expect(clients.adapter.model).to.eq(Client);
-    expect(clients.adapter.indexes).to.deep.eq([
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
+    expect(stub).toHaveBeenCalledWith();
+    expect(clients.adapter.collectionName).toBe("client");
+    expect(clients.adapter.model).toBe(Client);
+    expect(clients.adapter.indexes).toEqual([
       {
         options: {},
         propertyKey: "prop"
@@ -47,7 +44,7 @@ describe("Indexed", () => {
       prop: string;
     }
 
-    const stub = Sinon.stub();
+    const stub = jest.fn();
 
     @Injectable()
     class Clients {
@@ -61,11 +58,11 @@ describe("Indexed", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
-    expect(stub).to.have.been.calledWithExactly();
-    expect(clients.adapter.collectionName).to.eq("Clients");
-    expect(clients.adapter.model).to.eq(Client);
-    expect(clients.adapter.indexes).to.deep.eq([
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
+    expect(stub).toHaveBeenCalledWith();
+    expect(clients.adapter.collectionName).toBe("Clients");
+    expect(clients.adapter.model).toBe(Client);
+    expect(clients.adapter.indexes).toEqual([
       {
         options: {},
         propertyKey: "prop"

--- a/packages/orm/adapters/src/decorators/injectAdapter.spec.ts
+++ b/packages/orm/adapters/src/decorators/injectAdapter.spec.ts
@@ -1,8 +1,6 @@
 import {Adapter} from "@tsed/adapters";
 import {PlatformTest} from "@tsed/common";
 import {Injectable} from "@tsed/di";
-import {expect} from "chai";
-import Sinon from "sinon";
 import {MemoryAdapter} from "../adapters/MemoryAdapter";
 import {InjectAdapter} from "./injectAdapter";
 
@@ -12,7 +10,7 @@ describe("InjectAdapter", () => {
   it("should inject adapter (model and collectionName)", async () => {
     class Client {}
 
-    const stub = Sinon.stub();
+    const stub = jest.fn();
 
     @Injectable()
     class Clients {
@@ -26,10 +24,10 @@ describe("InjectAdapter", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
-    expect(stub).to.have.been.calledWithExactly();
-    expect(clients.adapter.collectionName).to.eq("client");
-    expect(clients.adapter.model).to.eq(Client);
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
+    expect(stub).toHaveBeenCalledWith();
+    expect(clients.adapter.collectionName).toBe("client");
+    expect(clients.adapter.model).toBe(Client);
   });
   it("should inject adapter (model only)", async () => {
     class Client {}
@@ -42,9 +40,9 @@ describe("InjectAdapter", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
-    expect(clients.adapter.collectionName).to.eq("Clients");
-    expect(clients.adapter.model).to.eq(Client);
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
+    expect(clients.adapter.collectionName).toBe("Clients");
+    expect(clients.adapter.model).toBe(Client);
   });
   it("should inject adapter (model only 2)", async () => {
     class Entity {}
@@ -57,9 +55,9 @@ describe("InjectAdapter", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
-    expect(clients.adapter.collectionName).to.eq("Entities");
-    expect(clients.adapter.model).to.eq(Entity);
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
+    expect(clients.adapter.collectionName).toBe("Entities");
+    expect(clients.adapter.model).toBe(Entity);
   });
   it("should inject adapter (object)", async () => {
     class Client {}
@@ -72,9 +70,9 @@ describe("InjectAdapter", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
-    expect(clients.adapter.collectionName).to.eq("Clients");
-    expect(clients.adapter.model).to.eq(Client);
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
+    expect(clients.adapter.collectionName).toBe("Clients");
+    expect(clients.adapter.model).toBe(Client);
   });
   it("should inject adapter (without $onInit)", async () => {
     class Client {}
@@ -87,6 +85,6 @@ describe("InjectAdapter", () => {
 
     const clients = await PlatformTest.invoke<Clients>(Clients);
 
-    expect(clients.adapter).to.be.instanceOf(MemoryAdapter);
+    expect(clients.adapter).toBeInstanceOf(MemoryAdapter);
   });
 });

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -36,6 +36,7 @@ module.exports = (rootDir) => ({
     "^@tsed/testing-mongoose$": fixPath(join(packageDir, "orm/testing-mongoose/src")),
     "^@tsed/objection$": fixPath(join(packageDir, "orm/objection/src")),
     "^@tsed/typeorm$": fixPath(join(packageDir, "orm/typeorm/src")),
+    "^@tsed/adapters$": fixPath(join(packageDir, "orm/adapters/src")),
     "^@tsed/mongoose$": fixPath(join(packageDir, "orm/mongoose/src")),
     "^@tsed/components-scan$": fixPath(join(packageDir, "utils/components-scan/src"))
   },


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No


## Todos

- [x] Migrate all tests in package `orm/adapters` to support jest test runner.
- [x] Remove mocha config file
- [x] Update `tools/jest/jest.config.js` file to add adapters path resolution


