### PR TITLE
Prevent clearing decorator context after init

### DIFF
--- a/packages/specs/schema/src/domain/DecoratorContext.ts
+++ b/packages/specs/schema/src/domain/DecoratorContext.ts
@@ -89,8 +89,6 @@ export abstract class DecoratorContext<T = any> extends Map<string, any> {
     this.beforeInit();
     this.onInit(args, decorator);
     this.afterInit();
-
-    this.clear();
   }
 
   protected onInit(args: DecoratorParameters, decorator: any): void {


### PR DESCRIPTION
@Romakita Looks like I missed a clear function in my PR for fixing the returns decorator. :S