### PR TITLE
fix(typeorm): Prevent throwing error with the typeORM container when …

### DIFF
--- a/packages/orm/typeorm/src/TypeORMModule.ts
+++ b/packages/orm/typeorm/src/TypeORMModule.ts
@@ -1,5 +1,6 @@
+import {ancestorsOf, isClass} from "@tsed/core";
 import {Configuration, InjectorService, OnDestroy, registerProvider} from "@tsed/di";
-import {ConnectionOptions, ContainedType, getCustomRepository, useContainer} from "typeorm";
+import {ConnectionOptions, ContainedType, getCustomRepository, Repository, useContainer} from "typeorm";
 import {TypeORMService} from "./services/TypeORMService";
 
 export class TypeORMModule implements OnDestroy {
@@ -27,11 +28,13 @@ registerProvider({
     {
       deps: [TypeORMModule],
       get(type, options: any) {
-        try {
-          return getCustomRepository(type, options.connection || "default");
-        } catch (er) {
-          if (process.env.NODE_ENV !== "test") {
-            throw er;
+        if (isClass(type) && ancestorsOf(type).includes(Repository)) {
+          try {
+            return getCustomRepository(type, options.connection || "default");
+          } catch (er) {
+            if (process.env.NODE_ENV !== "test") {
+              throw er;
+            }
           }
         }
       }


### PR DESCRIPTION
…the token type isn't a repository

## Information

Type | Breaking change
---|---
Feature/Fix/Doc/Chore | Yes/No

****

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
