### PR TITLE
fix(mongoose): Discriminator key can be serialized by json-mapper

### DIFF
--- a/packages/orm/mongoose/src/decorators/discriminatorKey.ts
+++ b/packages/orm/mongoose/src/decorators/discriminatorKey.ts
@@ -1,8 +1,10 @@
-import {Store} from "@tsed/core";
+import {Store, useDecorators} from "@tsed/core";
 import {MONGOOSE_SCHEMA_OPTIONS} from "../constants";
+import {SchemaIgnore} from "./schemaIgnore";
+import {Property} from "@tsed/schema";
 
 export function DiscriminatorKey(): PropertyDecorator {
-  return (target: any, propertyKey: string) => {
+  return useDecorators(Property(), SchemaIgnore(), (target: any, propertyKey: string) => {
     Store.from(target).merge(MONGOOSE_SCHEMA_OPTIONS, {discriminatorKey: propertyKey});
-  };
+  });
 }

--- a/packages/orm/mongoose/src/utils/createModel.ts
+++ b/packages/orm/mongoose/src/utils/createModel.ts
@@ -22,6 +22,7 @@ export function getModelToken(target: Type<any>, options: any) {
  * @param collection (optional, induced from model name)
  * @param skipInit whether to skip initialization (defaults to false)
  * @param connection
+ * @param discriminatorValue
  * @returns {Model<T extends Document>}
  */
 export function createModel<T>(


### PR DESCRIPTION
Closes: #1568
