### PR TITLE
Docs: fix typo on prisma arguments

### DIFF
--- a/docs/tutorials/prisma.md
+++ b/docs/tutorials/prisma.md
@@ -327,7 +327,7 @@ export class UserRepository {
     return this.prisma.user.create(args);
   }
 
-  async update(args: Prisma.UserUpdateArg): Promise<User> {
+  async update(args: Prisma.UserUpdateArgs): Promise<User> {
     return this.prisma.user.update(args);
   }
 
@@ -366,7 +366,7 @@ export class PostsRepository {
     return this.prisma.post.create(args);
   }
 
-  async update(args: Prisma.PostUpdateArg): Promise<Post> {
+  async update(args: Prisma.PostUpdateArgs): Promise<Post> {
     return this.prisma.post.update(args);
   }
 


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Doc| No

****
This fixes compilation errors according to the docs on tsed/prisma. Not regarding premium package @tsedio/prisma (would give other compilation errors) which is expected from a paid package, on an open source project.
<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
