### PR TITLE
feat(mongoose): Add count option for VirtualRef

### DIFF
--- a/docs/tutorials/snippets/mongoose/virtual-references.ts
+++ b/docs/tutorials/snippets/mongoose/virtual-references.ts
@@ -22,6 +22,16 @@ class Band {
     options: {} // Query options, see http://bit.ly/mongoose-query-options
   })
   members: VirtualRefs<Person>;
+
+  @VirtualRef({
+    ref: Person, // The model to use
+    localField: "name",  // Find people where `localField`
+    foreignField: "band", // is equal to `foreignField`
+    // If `count` is true, 'memberCount' will be the number of documents
+    // instead of an array.
+    count: true
+  })
+  memberCount: number;
 }
 
 @Model()

--- a/packages/orm/mongoose/src/decorators/virtualRef.spec.ts
+++ b/packages/orm/mongoose/src/decorators/virtualRef.spec.ts
@@ -21,6 +21,7 @@ describe("@VirtualRef()", () => {
       expect(store.get(MONGOOSE_SCHEMA)).toEqual({
         ref: "RefTest",
         justOne: false,
+        count: false,
         foreignField: "foreign",
         localField: "_id",
         options: undefined
@@ -44,6 +45,7 @@ describe("@VirtualRef()", () => {
         localField: "_id",
         foreignField: "foreign",
         justOne: false,
+        count: false,
         options: undefined
       });
     });
@@ -58,6 +60,7 @@ describe("@VirtualRef()", () => {
           foreignField: "foreign",
           localField: "test_2",
           justOne: true,
+          count: true,
           options: {}
         })
         test: any;
@@ -71,6 +74,7 @@ describe("@VirtualRef()", () => {
         localField: "test_2",
         foreignField: "foreign",
         justOne: true,
+        count: true,
         options: {}
       });
     });
@@ -95,6 +99,7 @@ describe("@VirtualRef()", () => {
           foreignField: "foreign",
           localField: "test_2",
           justOne: true,
+          count: false,
           options: {}
         })
         members: VirtualRef<TestPerson>;
@@ -108,6 +113,7 @@ describe("@VirtualRef()", () => {
         localField: "test_2",
         foreignField: "foreign",
         justOne: true,
+        count: false,
         options: {}
       });
 
@@ -180,6 +186,7 @@ describe("@VirtualRef()", () => {
         localField: "test_2",
         foreignField: "foreign",
         justOne: true,
+        count: false,
         options: {}
       });
 

--- a/packages/orm/mongoose/src/decorators/virtualRef.ts
+++ b/packages/orm/mongoose/src/decorators/virtualRef.ts
@@ -63,7 +63,10 @@ export function VirtualRef(options: string | MongooseVirtualRefOptions, foreignF
   const schema = mapToSchema(opts);
   const type = getType(opts);
 
-  return useDecorators(StoreMerge(MONGOOSE_SCHEMA, schema), type && (schema.justOne ? Property(type) : CollectionOf(type)));
+  return useDecorators(
+    StoreMerge(MONGOOSE_SCHEMA, schema),
+    schema.count ? Property(Number) : type && (schema.justOne ? Property(type) : CollectionOf(type))
+  );
 }
 
 export type VirtualRef<T> = T | null;

--- a/packages/orm/mongoose/src/decorators/virtualRef.ts
+++ b/packages/orm/mongoose/src/decorators/virtualRef.ts
@@ -27,6 +27,7 @@ function mapToSchema(opts: any) {
     localField: opts.localField || "_id",
     foreignField: opts.foreignField,
     justOne: opts.justOne || false,
+    count: opts.count || false,
     options: opts.options
   };
 

--- a/packages/orm/mongoose/src/interfaces/MongooseVirtualRefOptions.ts
+++ b/packages/orm/mongoose/src/interfaces/MongooseVirtualRefOptions.ts
@@ -9,5 +9,6 @@ export interface MongooseVirtualRefOptions {
   foreignField?: string;
   localField?: string;
   justOne?: boolean;
+  count?: boolean;
   options?: object;
 }

--- a/packages/orm/mongoose/src/utils/createSchema.spec.ts
+++ b/packages/orm/mongoose/src/utils/createSchema.spec.ts
@@ -694,4 +694,25 @@ describe("createSchema", () => {
 
     expect(options.versionKey).toBe("version");
   });
+
+  it("should create json schema with virtual ref and count", () => {
+    // GIVEN
+    @Model()
+    class Children5 {
+      @Name("id")
+      _id: string;
+    }
+
+    @Model()
+    class Test13 {
+      @VirtualRef({ref: Children5, foreignField: "test13", count: true})
+      childrenCount: number;
+    }
+
+    // WHEN
+    const testSchema: any = getJsonSchema(Test13);
+
+    // THEN
+    expect(testSchema.properties.childrenCount.type).toEqual("number");
+  });
 });


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No

****

## Usage example

Adds support for the count option on VirtualRefs (https://mongoosejs.com/docs/populate.html#count):

```typescript
@Model()
class CompanyEntity {
  @VirtualRef({
      ref: 'UserEntity',
      localField: '_id',
      foreignField: 'membership.company',
      count: true,
      options: {
        match: { roles: 'client' },
      },
    })
  clientCount: number;
}
```

## Todos

- [x] ⚠️ How to generate the JsonSchema correctly so we get a number type there instead of the Ref (Array) Type?. I could use some help here 😅 
- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
