### PR TITLE
feat(schema): Allow multiple types for `Returns` decorator ...

### DIFF
--- a/packages/specs/schema/src/decorators/operations/returns.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.spec.ts
@@ -1,6 +1,7 @@
 import "@tsed/platform-exceptions";
 import {CollectionOf, Generics, getSpec, OperationPath, Property, Returns, SpecTypes} from "@tsed/schema";
 import {expect} from "chai";
+import {OpenSpec3} from "../../../../openspec/src/openspec3/OpenSpec3";
 
 describe("@Returns", () => {
   describe("Single contentType", () => {
@@ -1206,6 +1207,69 @@ describe("@Returns", () => {
             name: "Controller"
           }
         ]
+      });
+    });
+  });
+
+  describe("Multiple return types", () => {
+    class ClassA {
+      @Property()
+      prop1: string;
+
+      @Property()
+      prop2: string;
+    }
+
+    class ClassB {
+      @Property()
+      prop3: string;
+
+      @Property()
+      prop4: string;
+    }
+
+    it("should return oneOf schema", () => {
+      class Controller {
+        @Returns(200, [ClassA, ClassB])
+        @OperationPath("GET", "/")
+        method() {}
+      }
+
+      const spec = getSpec(Controller, {specType: SpecTypes.OPENAPI}) as Partial<OpenSpec3>;
+
+      expect(spec.paths!["/"].get!.responses["200"].content!["application/json"].schema).to.deep.equal({
+        oneOf: [
+          {
+            $ref: "#/components/schemas/ClassA"
+          },
+          {
+            $ref: "#/components/schemas/ClassB"
+          }
+        ]
+      });
+    });
+
+    it("should return oneOf array schema", () => {
+      class Controller {
+        @(Returns(200, Array).OneOf(ClassA, ClassB))
+        @OperationPath("GET", "/")
+        method() {}
+      }
+
+      const spec = getSpec(Controller, {specType: SpecTypes.OPENAPI}) as Partial<OpenSpec3>;
+
+      expect(spec.paths!["/"].get!.responses["200"].content!["application/json"].schema).to.deep.equal({
+        type: "array",
+        items: {
+          oneOf: [
+            {
+              $ref: "#/components/schemas/ClassA"
+            },
+            {
+              $ref: "#/components/schemas/ClassB"
+            }
+          ]
+        }
       });
     });
   });

--- a/packages/specs/schema/src/decorators/operations/returns.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.spec.ts
@@ -1272,5 +1272,53 @@ describe("@Returns", () => {
         }
       });
     });
+
+    it("should return allOf array schema", () => {
+      class Controller {
+        @(Returns(200, Array).AllOf(ClassA, ClassB))
+        @OperationPath("GET", "/")
+        method() {}
+      }
+
+      const spec = getSpec(Controller, {specType: SpecTypes.OPENAPI}) as Partial<OpenSpec3>;
+
+      expect(spec.paths!["/"].get!.responses["200"].content!["application/json"].schema).to.deep.equal({
+        type: "array",
+        items: {
+          allOf: [
+            {
+              $ref: "#/components/schemas/ClassA"
+            },
+            {
+              $ref: "#/components/schemas/ClassB"
+            }
+          ]
+        }
+      });
+    });
+
+    it("should return allOf array schema", () => {
+      class Controller {
+        @(Returns(200, Array).AnyOf(ClassA, ClassB))
+        @OperationPath("GET", "/")
+        method() {}
+      }
+
+      const spec = getSpec(Controller, {specType: SpecTypes.OPENAPI}) as Partial<OpenSpec3>;
+
+      expect(spec.paths!["/"].get!.responses["200"].content!["application/json"].schema).to.deep.equal({
+        type: "array",
+        items: {
+          anyOf: [
+            {
+              $ref: "#/components/schemas/ClassA"
+            },
+            {
+              $ref: "#/components/schemas/ClassB"
+            }
+          ]
+        }
+      });
+    });
   });
 });

--- a/packages/specs/schema/src/decorators/operations/returns.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.ts
@@ -70,7 +70,23 @@ export interface ReturnsChainedDecorators {
    */
   Of(...types: GenericValue[]): this;
 
+  /**
+   * Add the nested types
+   * @param types
+   */
   OneOf(...types: GenericValue[]): this;
+
+  /**
+   * Add the nested types
+   * @param types
+   */
+  AllOf(...types: GenericValue[]): this;
+
+  /**
+   * Add the nested types
+   * @param types
+   */
+  AnyOf(...types: GenericValue[]): this;
 
   /**
    * Declare a nested generic models
@@ -145,6 +161,8 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
     "status",
     "of",
     "oneOf",
+    "allOf",
+    "anyOf",
     "nested",
     "header",
     "headers",
@@ -249,6 +267,30 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
       const schema = this.get("schema") as JsonSchema;
       schema.type(model);
       schema.itemSchema({oneOf: types.map((type) => ({type}))});
+    });
+
+    return this;
+  }
+
+  allOf(...types: (Type<any> | any)[]) {
+    const model = this.get("model");
+
+    this.addAction(() => {
+      const schema = this.get("schema") as JsonSchema;
+      schema.type(model);
+      schema.itemSchema({allOf: types.map((type) => ({type}))});
+    });
+
+    return this;
+  }
+
+  anyOf(...types: (Type<any> | any)[]) {
+    const model = this.get("model");
+
+    this.addAction(() => {
+      const schema = this.get("schema") as JsonSchema;
+      schema.type(model);
+      schema.itemSchema({anyOf: types.map((type) => ({type}))});
     });
 
     return this;


### PR DESCRIPTION
... resulting in a `oneOf` schema

## Information

Type | Breaking change
---|---
Feature | No 🙏 

****

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
class ClassA {}
class ClassB {}

class Controller {
        @(Returns(200, [ClassA, ClassB]))
        @Get("/1")
        method1() {
            // ...
        }

        @(Returns(200, Array).OneOf(ClassA, ClassB))
        @Get("/2")
        method2() {
            // ...
        }
}

```

⏬ 

```js
{
  oneOf: [
    {
      $ref: "#/components/schemas/ClassA",
    },
    {
      $ref: "#/components/schemas/ClassB",
    },
  ];
}
```

or

```js
{
  type: "array",
  items: {
    oneOf: [
      {
        $ref: "#/components/schemas/ClassA",
      },
      {
        $ref: "#/components/schemas/ClassB",
      },
    ],
  },
}
```

## Todos

~~⚠️ looks like it is not working with `Groups` and I could need some help on that ⚠️~~  (later PR)

- [x] Tests
- [x] Coverage
- [x] Example
- [ ] Documentation
