### PR TITLE
fix(mongoose): Fix json schema for `VirtualRef` if MongooseModels entry not set yet

### DIFF
--- a/packages/orm/mongoose/src/decorators/virtualRef.ts
+++ b/packages/orm/mongoose/src/decorators/virtualRef.ts
@@ -12,8 +12,7 @@ function getRef(opts: any) {
 
 function getType(opts: any) {
   const ref = opts.ref || opts.type;
-
-  return !isString(ref) ? ref : MongooseModels.get(ref);
+  return !isString(ref) ? ref : MongooseModels.get(ref) || Object;
 }
 
 function getInitialOpts(options: string | MongooseVirtualRefOptions, foreignField?: string): any {

--- a/packages/orm/mongoose/src/decorators/virtualRef.ts
+++ b/packages/orm/mongoose/src/decorators/virtualRef.ts
@@ -12,7 +12,7 @@ function getRef(opts: any) {
 
 function getType(opts: any) {
   const ref = opts.ref || opts.type;
-  return !isString(ref) ? ref : MongooseModels.get(ref) || Object;
+  return !isString(ref) ? ref : MongooseModels.get(ref) || (() => MongooseModels.get(ref) || Object);
 }
 
 function getInitialOpts(options: string | MongooseVirtualRefOptions, foreignField?: string): any {


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

Sadly my last fix (https://github.com/tsedio/tsed/pull/1670) introduced a new bug.

`MongooseModels.get(ref)` can return undefined and the property doesn't even get serialized. With the fallback to `Object` it would behave like before.

That happens a lot in my project because

https://github.com/tsedio/tsed/blob/3e6ceced19a039200519c3882c39c4c4792c10de/packages/orm/mongoose/src/utils/createModel.ts#L11 gets executed after https://github.com/tsedio/tsed/blob/3e6ceced19a039200519c3882c39c4c4792c10de/packages/orm/mongoose/src/decorators/virtualRef.ts#L16

@Romakita any idea on how to fix the order problem?

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
