### PR TITLE
Update SocketClientService to support custom paths

### DIFF
--- a/packages/third-parties/socketio-testing/src/services/SocketClientService.ts
+++ b/packages/third-parties/socketio-testing/src/services/SocketClientService.ts
@@ -21,7 +21,7 @@ export class SocketClientService implements OnDestroy {
     const uri = `http://${address}:${port}${namespace}`;
 
     this.logger.info("Bind Socket.io client on:", uri);
-    const client = io(uri, path ? { path } : undefined);
+    const client = io(uri, path ? {path} : undefined);
 
     this.clients.set(namespace, client);
 

--- a/packages/third-parties/socketio-testing/src/services/SocketClientService.ts
+++ b/packages/third-parties/socketio-testing/src/services/SocketClientService.ts
@@ -12,7 +12,7 @@ export class SocketClientService implements OnDestroy {
 
   private clients: Map<string, Socket> = new Map();
 
-  async get(namespace: string = "/"): Promise<Socket> {
+  async get(namespace: string = "/", path?: string): Promise<Socket> {
     if (this.clients.has(namespace)) {
       return this.clients.get(namespace)!;
     }
@@ -21,7 +21,7 @@ export class SocketClientService implements OnDestroy {
     const uri = `http://${address}:${port}${namespace}`;
 
     this.logger.info("Bind Socket.io client on:", uri);
-    const client = io(uri);
+    const client = io(uri, path ? { path } : undefined);
 
     this.clients.set(namespace, client);
 

--- a/packages/third-parties/socketio/test/socket.integration.spec.ts
+++ b/packages/third-parties/socketio/test/socket.integration.spec.ts
@@ -27,7 +27,7 @@ export class TestWS {
 }
 
 
-describe("Socket integration", () => {
+describe("Socket integration: default path", () => {
   before(PlatformTest.bootstrap(Server, {
     platform: PlatformExpress,
     listen: true,
@@ -46,6 +46,39 @@ describe("Socket integration", () => {
       const client2 = await service.get("/test");
 
       expect(client).to.eq(client2)
+
+      return new Promise((resolve: any) => {
+        client.on("output:scenario1", (result) => {
+          expect(result).to.eq("my Message test2");
+          resolve();
+        });
+
+        client.emit("input:scenario1");
+      });
+    });
+  });
+});
+
+describe("Socket integration: custom path", () => {
+
+  const CUSTOM_WS_PATH = "/ws";
+
+  before(PlatformTest.bootstrap(Server, {
+    platform: PlatformExpress,
+    listen: true,
+    httpPort: 8999,
+    componentsScan: [],
+    mount: {},
+    disableComponentScan: true,
+    imports: [TestWS],
+    socketIO: { path: CUSTOM_WS_PATH }
+  }));
+  after(PlatformTest.reset);
+
+  describe("RoomWS: eventName", () => {
+    it("should return the data", async () => {
+      const service = PlatformTest.get<SocketClientService>(SocketClientService);
+      const client = await service.get("/test", CUSTOM_WS_PATH);
 
       return new Promise((resolve: any) => {
         client.on("output:scenario1", (result) => {


### PR DESCRIPTION
## Information
Problem: Default value for Socket.io server path is '/socket.io'. If you use some custom path for production code configuration, then your tests will fail as SocketClientService ignores that.
I've added path parameter to the get() so in tests, you could use the same path as for production code.
Without that parameter Socket Manager uses default path '/socket.io' and fails to connect.

Type | Breaking change
---|---
Fix | No

****
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
const CUSTOM_WS_PATH = "/ws";

before(PlatformTest.bootstrap(Server, {
    platform: PlatformExpress,
    listen: true,
    httpPort: 8999,
    ...
    socketIO: { path: CUSTOM_WS_PATH }
}));

const service = PlatformTest.get<SocketClientService>(SocketClientService);
const client = await service.get("/test", CUSTOM_WS_PATH);

```
For more details see here: https://github.com/tsedio/tsed/blob/production/packages/third-parties/socketio/test/socket.integration.spec.ts

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [*] Documentation
