### PR TITLE
feat(mikro-orm): add support for MikroOrm

### DIFF
--- a/packages/di/src/services/DITest.ts
+++ b/packages/di/src/services/DITest.ts
@@ -1,6 +1,6 @@
 import {Env, getValue} from "@tsed/core";
 import {$log} from "@tsed/logger";
-import {Container} from "../domain/Container";
+import {createContainer} from "../utils/createContainer";
 import {LocalsContainer} from "../domain/LocalsContainer";
 import {OnInit} from "../interfaces/OnInit";
 import {TokenProvider} from "../interfaces/TokenProvider";
@@ -10,6 +10,10 @@ import {InjectorService} from "./InjectorService";
 export interface DITestInvokeOptions {
   token?: TokenProvider;
   use: any;
+}
+
+export interface DITestOptions extends Partial<TsED.Configuration> {
+  imports?: DITestInvokeOptions[];
 }
 
 /**
@@ -42,11 +46,20 @@ export class DITest {
     return !!DITest._injector;
   }
 
-  static async create(settings: Partial<TsED.Configuration> = {}) {
+  static async create(settings: DITestOptions = {}) {
     DITest.injector = DITest.createInjector(settings);
 
-    const container = new Container();
-    DITest.injector.bootstrap(container);
+    await this.createContainer(settings);
+  }
+
+  static async createContainer(settings: DITestOptions = {}) {
+    const container = createContainer();
+
+    settings.imports?.forEach(({token, use}) => {
+      container.addProvider(token, {
+        useValue: use
+      });
+    });
 
     await DITest.injector.load(container);
   }

--- a/packages/di/src/services/InjectorService.ts
+++ b/packages/di/src/services/InjectorService.ts
@@ -261,7 +261,7 @@ export class InjectorService extends Container {
     return locals;
   }
 
-  loadSync(locals: LocalsContainer<any> = new LocalsContainer()) {
+  loadSync(locals: LocalsContainer = new LocalsContainer()) {
     for (const [, provider] of this) {
       if (!locals.has(provider.token) && this.scopeOf(provider) === ProviderScope.SINGLETON) {
         this.invoke(provider.token, locals);
@@ -579,7 +579,7 @@ export class InjectorService extends Container {
   }
 
   protected getInstance(token: any) {
-    return this.#cache.get(getClassOrSymbol(token));
+    return this.#cache.get(token);
   }
 
   /**

--- a/packages/di/test/integration/imports.spec.ts
+++ b/packages/di/test/integration/imports.spec.ts
@@ -1,0 +1,38 @@
+import {DITest, Inject, Injectable, Module} from "../../src";
+import Sinon from "sinon";
+import {expect} from "chai";
+import {PlatformTest} from "@tsed/common/src";
+
+@Injectable()
+class MyService {
+  createConnection() {
+  }
+}
+
+@Module()
+class MyModule {
+  @Inject()
+  myService: MyService;
+
+  $onInit() {
+    this.myService.createConnection();
+  }
+}
+
+describe("DITest", () => {
+  beforeEach(() => DITest.create({
+    imports: [
+      {
+        token: MyService,
+        use: {
+          createConnection: Sinon.stub()
+        }
+      }
+    ]
+  }));
+
+  it("should create container with stubbed service", () => {
+    const service = DITest.get(MyService);
+    expect(service.createConnection).to.have.been.calledWithExactly();
+  });
+});

--- a/packages/orm/mikro-orm/.npmignore
+++ b/packages/orm/mikro-orm/.npmignore
@@ -1,0 +1,4 @@
+src
+test
+tsconfig.compile.json
+tsconfig.json

--- a/packages/orm/mikro-orm/jest.config.js
+++ b/packages/orm/mikro-orm/jest.config.js
@@ -1,0 +1,14 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  ...require("@tsed/jest-config")(__dirname, "mikro-orm"),
+  coverageThreshold: {
+    global: {
+      branches: 85.29,
+      functions: 100,
+      lines: 98.95,
+      statements: 99.15
+    }
+  }
+};

--- a/packages/orm/mikro-orm/package.json
+++ b/packages/orm/mikro-orm/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@tsed/mikro-orm",
+  "version": "6.95.10",
+  "description": "MikroORM package for Ts.ED framework",
+  "private": false,
+  "source": "./src/index.ts",
+  "main": "./lib/cjs/index.js",
+  "typings": "./lib/types/index.d.ts",
+  "exports": {
+    "types": "./lib/types/index.d.ts",
+    "import": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js",
+    "default": "./lib/esm/index.js"
+  },
+  "scripts": {
+    "build": "yarn run build:esm && yarn run build:cjs",
+    "build:cjs": "tsc --build tsconfig.compile.json",
+    "build:esm": "tsc --build tsconfig.compile.esm.json",
+    "test": "cross-env NODE_ENV=test jest"
+  },
+  "dependencies": {
+    "tslib": "2.2.0"
+  },
+  "devDependencies": {
+    "@mikro-orm/core": "^4.5.9",
+    "@mikro-orm/mongodb": "^4.5.9",
+    "@tsed/core": "6.95.10",
+    "@tsed/common": "6.95.10",
+    "@tsed/di": "6.95.10",
+    "@tsed/json-mapper": "6.95.10",
+    "@tsed/schema": "6.95.10",
+    "ts-mockito": "^2.6.1"
+  },
+  "peerDependencies": {
+    "@tsed/core": "6.95.10",
+    "@tsed/common": "6.95.10",
+    "@tsed/di": "6.95.10",
+    "@tsed/json-mapper": "6.95.10",
+    "@tsed/schema": "6.95.10",
+    "@mikro-orm/core": ">=4.5.9"
+  }
+}

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -1,0 +1,237 @@
+<p style="text-align: center" align="center">
+ <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+</p>
+
+<div align="center">
+   <h1>MikroORM</h1>
+
+[![Build & Release](https://github.com/tsedio/tsed/workflows/Build%20&%20Release/badge.svg)](https://github.com/tsedio/tsed/actions?query=workflow%3A%22Build+%26+Release%22)
+[![PR Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/tsedio/tsed/blob/master/CONTRIBUTING.md)
+[![Coverage Status](https://coveralls.io/repos/github/tsedio/tsed/badge.svg?branch=production)](https://coveralls.io/github/tsedio/tsed?branch=production)
+[![npm version](https://badge.fury.io/js/%40tsed%2Fcommon.svg)](https://badge.fury.io/js/%40tsed%2Fcommon)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![backers](https://opencollective.com/tsed/tiers/badge.svg)](https://opencollective.com/tsed)
+
+</div>
+
+<div align="center">
+  <a href="https://tsed.io/">Website</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://tsed.io/getting-started/">Getting started</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://twitter.com/TsED_io">Twitter</a>
+</div>
+
+<hr />
+
+A package of Ts.ED framework. See website: https://tsed.io/tutorials/mikro-orm
+
+## Feature
+
+Currently, `@tsed/mikro-orm` allows you:
+
+- Configure one or more MikroOrm connections via the `@ServerSettings` configuration. All databases will be initialized
+  when the server starts during the server's `OnInit` phase.
+- Use the Entity MikroOrm as Model for Controllers, AJV Validation and Swagger.
+
+## Installation
+
+To begin, install the MikroOrm module for TS.ED:
+
+```bash
+npm install --save @tsed/mikro-orm
+npm install --save @mikro-orm/core
+```
+
+Then import `@tsed/mikro-orm` in your Server:
+
+```typescript
+import {Configuration} from "@tsed/common";
+import {MikroOrmModule} from "@tsed/mikro-orm";
+
+@Configuration({
+  imports: [MikroOrmModule],
+  mikroOrm: [
+    {
+      contextName: 'default',
+      type: 'postgres',
+      ...,
+
+      entities: [
+        `${__dirname}/entity/*{.ts,.js}`
+      ]
+    },
+    {
+      contextName: 'mongo',
+      type: 'mongo',
+      ...
+    }
+  ]
+})
+export class Server {
+
+}
+```
+
+For more information about MikroOrm look his documentation [here](https://mikro-orm.io/docs);
+
+## Obtain a connection
+
+`Connection` decorator lets you retrieve an instance of MikroOrm Connection.
+
+```typescript
+import {Injectable, AfterRoutesInit} from "@tsed/common";
+import {Connection} from "@tsed/mikro-orm";
+import {MikroORM} from "@mikro-orm/core";
+
+@Injectable()
+export class UsersService {
+  @Connection()
+  private readonly connection!: MikroORM;
+
+  async create(user: User): Promise<User> {
+
+    // do something
+    // ...
+    // Then save
+    await this.connection.em.persistAndFlush(user);
+    console.log("Saved a new user with id: " + user.id);
+
+    return user;
+  }
+
+  async find(): Promise<User[]> {
+    const users = await this.connection.em.find(User, {});
+    console.log("Loaded users: ", users);
+
+    return users;
+  }
+}
+```
+
+## Use Entity with Controller
+
+To begin, we need to define an Entity MikroOrm like this and use Ts.ED Decorator to define the JSON Schema.
+
+```typescript
+import {Property, MaxLength, Required} from "@tsed/common";
+import {Entity, Property, PrimaryKey, Property as Column} from "@mikro-orm/core";
+
+@Entity()
+export class User {
+
+  @PrimaryKey()
+  @Property()
+  id: number;
+
+  @Column()
+  @MaxLength(100)
+  @Required()
+  firstName: string;
+
+  @Column()
+  @MaxLength(100)
+  @Required()
+  lastName: string;
+
+  @Column()
+  @Mininum(0)
+  @Maximum(100)
+  age: number;
+}
+```
+
+Now, the model is correctly defined and can be used with a [Controller](https://tsed.io/docs/controllers.html)
+, [AJV validation](tutorials/ajv.md),
+[Swagger](tutorials/swagger.md) and [MikroOrm](https://mikro-orm.io/docs/defining-entities).
+
+We can use this model with a Controller like that:
+
+```typescript
+import {Controller, Post, BodyParams, Inject, Post, Get} from "@tsed/common";
+
+@Controller("/users")
+export class UsersCtrl {
+  @Inject()
+  private usersService: UsersService;
+
+  @Post("/")
+  create(@BodyParams() user: User): Promise<User> {
+    return this.usersService.create(user);
+  }
+
+  @Get("/")
+  getList(): Promise<User[]> {
+    return this.usersService.find();
+  }
+}
+```
+
+## Transactions and Request context
+
+As mentioned in the [docs](https://mikro-orm.io/docs/identity-map), we need to isolate a state for each request. That is
+handled automatically thanks to the `AsyncLocalStorage` registered via interceptor.
+
+We can use the `@Transactional()` decorator, which will register a new request context for your method and execute it
+inside the context.
+
+```typescript
+import {Controller, Post, BodyParams, Inject, Get} from "@tsed/common";
+import {Transactional} from "@tsed/mikro-orm";
+
+@Controller("/users")
+export class UsersCtrl {
+  @Inject()
+  private usersService: UsersService;
+
+  @Post("/")
+  @Transactional()
+  create(@BodyParams() user: User): Promise<User> {
+    return this.usersService.create(user);
+  }
+
+  @Get("/")
+  getList(): Promise<User[]> {
+    return this.usersService.find();
+  }
+}
+```
+
+## Contributors
+
+Please read [contributing guidelines here](https://tsed.io/CONTRIBUTING.html)
+
+<a href="https://github.com/tsedio/ts-express-decorators/graphs/contributors"><img src="https://opencollective.com/tsed/contributors.svg?width=890" /></a>
+
+## Backers
+
+Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/tsed#backer)]
+
+<a href="https://opencollective.com/tsed#backers" target="_blank"><img src="https://opencollective.com/tsed/backers.svg?width=890"></a>
+
+## Sponsors
+
+Support this project by becoming a sponsor. Your logo will show up here with a link to your
+website. [[Become a sponsor](https://opencollective.com/tsed#sponsor)]
+
+## License
+
+The MIT License (MIT)
+
+Copyright (c) 2016 - 2018 Romain Lenzotti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/orm/mikro-orm/src/MikroOrmModule.spec.ts
+++ b/packages/orm/mikro-orm/src/MikroOrmModule.spec.ts
@@ -1,0 +1,53 @@
+import {PlatformTest} from "@tsed/common";
+import {Options} from "@mikro-orm/core";
+import {MikroOrmRegistry} from "./services";
+import {MikroOrmModule} from "./MikroOrmModule";
+
+describe("MikroOrmModule", () => {
+  const config: Options = {
+    type: "mongo",
+    entities: [],
+    clientUrl: "mongo://localhost"
+  };
+
+  beforeEach(() =>
+    PlatformTest.create({
+      mikroOrm: [config],
+      imports: [
+        {
+          token: MikroOrmRegistry,
+          use: {
+            createConnection: jest.fn(),
+            closeConnections: jest.fn()
+          }
+        }
+      ]
+    })
+  );
+
+  afterEach(() => {
+    return PlatformTest.reset();
+  });
+
+  describe("$onInit", () => {
+    it("should create the corresponding connections", async () => {
+      const mikroOrmRegistry = PlatformTest.get<MikroOrmRegistry>(MikroOrmRegistry);
+
+      expect(mikroOrmRegistry.createConnection).toHaveBeenCalledWith(config);
+    });
+  });
+
+  describe("$onDestroy", () => {
+    it("should destroy the corresponding connections", async () => {
+      // arrange
+      const mikroOrmRegistry = PlatformTest.get<MikroOrmRegistry>(MikroOrmRegistry);
+      const mikroOrmModule = PlatformTest.get<MikroOrmModule>(MikroOrmModule);
+
+      // act
+      await mikroOrmModule.$onDestroy();
+
+      // assert
+      expect(mikroOrmRegistry.closeConnections).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/MikroOrmModule.ts
+++ b/packages/orm/mikro-orm/src/MikroOrmModule.ts
@@ -1,0 +1,38 @@
+import {DBContext, MikroOrmRegistry} from "./services";
+import {Configuration, Constant, Inject, Module, OnDestroy, OnInit} from "@tsed/di";
+import {Options} from "@mikro-orm/core";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace TsED {
+    interface Configuration {
+      /**
+       * The the ORM configuration, entity metadata.
+       * If you omit the `options` parameter, your CLI config will be used.
+       */
+      mikroOrm?: Options[];
+    }
+  }
+}
+
+@Module({
+  imports: [DBContext, MikroOrmRegistry],
+  deps: [Configuration, MikroOrmRegistry]
+})
+export class MikroOrmModule implements OnDestroy, OnInit {
+  @Constant("mikroOrm", [])
+  private readonly settings!: Options[];
+
+  @Inject()
+  private readonly mikroOrmRegistry!: MikroOrmRegistry;
+
+  public async $onInit(): Promise<void> {
+    const promises = this.settings.map((opts) => this.mikroOrmRegistry.createConnection(opts));
+
+    await Promise.all(promises);
+  }
+
+  public $onDestroy(): Promise<void> {
+    return this.mikroOrmRegistry.closeConnections();
+  }
+}

--- a/packages/orm/mikro-orm/src/decorators/connection.ts
+++ b/packages/orm/mikro-orm/src/decorators/connection.ts
@@ -1,0 +1,5 @@
+import {MikroOrmRegistry} from "../services";
+import {Inject} from "@tsed/di";
+
+export const Connection = (connectionName?: string): PropertyDecorator =>
+  Inject(MikroOrmRegistry, (registry: MikroOrmRegistry) => registry.get(connectionName)) as PropertyDecorator;

--- a/packages/orm/mikro-orm/src/decorators/index.ts
+++ b/packages/orm/mikro-orm/src/decorators/index.ts
@@ -1,0 +1,2 @@
+export * from "./transactional";
+export * from "./connection";

--- a/packages/orm/mikro-orm/src/decorators/transactional.spec.ts
+++ b/packages/orm/mikro-orm/src/decorators/transactional.spec.ts
@@ -1,0 +1,24 @@
+import {Store} from "@tsed/core";
+import {Controller, INJECTABLE_PROP} from "@tsed/di";
+import {Post} from "@tsed/common";
+import {Transactional} from "./transactional";
+import {TransactionalInterceptor} from "@tsed/mikro-orm";
+
+@Controller("/users")
+export class UsersCtrl {
+  @Post("/")
+  @Transactional()
+  create() {}
+}
+
+describe("@Transactional", () => {
+  it("should decorate method", () => {
+    expect(Store.from(UsersCtrl).get(INJECTABLE_PROP)).toEqual({
+      create: {
+        bindingType: "interceptor",
+        propertyKey: "create",
+        useType: TransactionalInterceptor
+      }
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/decorators/transactional.ts
+++ b/packages/orm/mikro-orm/src/decorators/transactional.ts
@@ -1,0 +1,5 @@
+import {TransactionalInterceptor, TransactionOptions} from "../interceptors";
+import {Intercept} from "@tsed/di";
+
+export const Transactional = (connectionOrOptions?: string | TransactionOptions): MethodDecorator =>
+  Intercept(TransactionalInterceptor, connectionOrOptions);

--- a/packages/orm/mikro-orm/src/filters/OptimisticLockErrorFilter.spec.ts
+++ b/packages/orm/mikro-orm/src/filters/OptimisticLockErrorFilter.spec.ts
@@ -1,0 +1,49 @@
+import {instance, mock, objectContaining, reset, spy, verify} from "ts-mockito";
+import {OptimisticLockErrorFilter} from "@tsed/mikro-orm";
+import {OptimisticLockError} from "@mikro-orm/core";
+import {Logger, PlatformContext, PlatformTest} from "@tsed/common";
+
+describe("OptimisticLockErrorFilter", () => {
+  const mockedLogger: Logger = mock<Logger>();
+  let optimisticLockErrorFilter!: OptimisticLockErrorFilter;
+
+  beforeEach(() => {
+    optimisticLockErrorFilter = new OptimisticLockErrorFilter();
+
+    return PlatformTest.create();
+  });
+
+  afterEach(() => {
+    reset(mockedLogger);
+
+    return PlatformTest.reset();
+  });
+
+  describe("catch", () => {
+    it("should set HTTP status to 409", () => {
+      // arrange
+      const exception = OptimisticLockError.lockFailed("entity");
+      const response = PlatformTest.createResponse();
+      const request = PlatformTest.createRequest({
+        url: "/admin"
+      });
+      const context = new PlatformContext({
+        event: {
+          response,
+          request
+        },
+        id: "id",
+        logger: instance(mockedLogger),
+        maxStackSize: 0,
+        injector: PlatformTest.injector
+      });
+      const spiedResponse = spy(response);
+
+      // act
+      optimisticLockErrorFilter.catch(exception, context);
+
+      verify(mockedLogger.error(objectContaining({exception}))).once();
+      verify(spiedResponse.status(409)).once();
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/filters/OptimisticLockErrorFilter.ts
+++ b/packages/orm/mikro-orm/src/filters/OptimisticLockErrorFilter.ts
@@ -1,0 +1,15 @@
+import {Catch, ExceptionFilterMethods, PlatformContext} from "@tsed/common";
+import {OptimisticLockError} from "@mikro-orm/core";
+
+@Catch(OptimisticLockError)
+export class OptimisticLockErrorFilter implements ExceptionFilterMethods<OptimisticLockError> {
+  public catch(exception: OptimisticLockError, ctx: PlatformContext): void {
+    const {response, logger} = ctx;
+
+    logger.error({
+      exception
+    });
+
+    response.status(409).body(`Update refused. The resource has changed on the server. Please try again later`);
+  }
+}

--- a/packages/orm/mikro-orm/src/filters/index.ts
+++ b/packages/orm/mikro-orm/src/filters/index.ts
@@ -1,0 +1,1 @@
+export * from "./OptimisticLockErrorFilter";

--- a/packages/orm/mikro-orm/src/index.ts
+++ b/packages/orm/mikro-orm/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./decorators";
+export * from "./filters";
+export * from "./interceptors";
+export * from "./services";
+export * from "./MikroOrmModule";

--- a/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
+++ b/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
@@ -1,0 +1,106 @@
+import {DBContext, MikroOrmRegistry} from "../services";
+import {TransactionalInterceptor} from "./TransactionalInterceptor";
+import {anything, instance, mock, reset, spy, verify, when} from "ts-mockito";
+import {InterceptorContext, InterceptorNext} from "@tsed/common";
+import {EntityManager, MikroORM, OptimisticLockError} from "@mikro-orm/core";
+
+describe("TransactionalInterceptor", () => {
+  const mikroOrmRegistryMock = mock<MikroOrmRegistry>();
+  const mikroOrm = mock(MikroORM);
+  const entityManagerMock = mock(EntityManager);
+  const dbContext = new DBContext();
+
+  let transactionalInterceptor!: TransactionalInterceptor;
+
+  afterEach(() => reset<MikroOrmRegistry | MikroORM | EntityManager>(mikroOrmRegistryMock, mikroOrm, entityManagerMock));
+  beforeEach(() => {
+    transactionalInterceptor = new TransactionalInterceptor(instance(mikroOrmRegistryMock), dbContext);
+    when(mikroOrm.em).thenReturn(instance(entityManagerMock));
+    when(entityManagerMock.fork(anything(), anything())).thenReturn(instance(entityManagerMock));
+  });
+
+  describe("intercept", () => {
+    it("should run within a new context", async () => {
+      // arrange
+      const context = {} as InterceptorContext;
+      const next = (() => {
+        // noop
+      }) as InterceptorNext;
+      when(mikroOrmRegistryMock.get(anything())).thenReturn(instance(mikroOrm));
+      when(entityManagerMock.name).thenReturn("default");
+
+      // act
+      await transactionalInterceptor.intercept(context, next);
+
+      // assert
+      verify(mikroOrmRegistryMock.get(anything())).once();
+      verify(entityManagerMock.fork(anything(), anything())).once();
+      verify(entityManagerMock.flush()).once();
+    });
+
+    it("should throw an optimistic lock exception immediately if no retry strategy", async () => {
+      // arrange
+      const context = {} as InterceptorContext;
+      const next = (() => {
+        // noop
+      }) as InterceptorNext;
+      when(mikroOrmRegistryMock.get(anything())).thenReturn(instance(mikroOrm));
+      when(entityManagerMock.name).thenReturn("default");
+      when(entityManagerMock.flush()).thenReject(OptimisticLockError.lockFailed("Lock"));
+
+      // act
+      await expect(transactionalInterceptor.intercept(context, next)).rejects.toThrowError("Lock");
+
+      // assert
+      verify(mikroOrmRegistryMock.get(anything())).once();
+      verify(entityManagerMock.fork(anything(), anything())).once();
+      verify(entityManagerMock.flush()).times(1);
+    });
+
+    it("should run under existing context", async () => {
+      // arrange
+      const spiedDbContext = spy(dbContext);
+      const existingCtx = new Map([["default", instance(entityManagerMock)]]);
+
+      when(spiedDbContext.getContext()).thenReturn(existingCtx);
+
+      const context = {} as InterceptorContext;
+      const next = (() => {
+        // noop
+      }) as InterceptorNext;
+
+      // act
+      await transactionalInterceptor.intercept(context, next);
+
+      // assert
+      verify(mikroOrmRegistryMock.get(anything())).never();
+      verify(entityManagerMock.fork(anything(), anything())).never();
+      verify(entityManagerMock.flush()).never();
+    });
+
+    it("should run under existing context using different connection", async () => {
+      // arrange
+      const spiedDbContext = spy(dbContext);
+      const existingCtx = new Map([["default", instance(entityManagerMock)]]);
+
+      when(spiedDbContext.getContext()).thenReturn(existingCtx);
+
+      const context = {
+        options: "mydb"
+      } as InterceptorContext;
+      const next = (() => {
+        // noop
+      }) as InterceptorNext;
+      when(mikroOrmRegistryMock.get("mydb")).thenReturn(instance(mikroOrm));
+      when(entityManagerMock.name).thenReturn("mydb");
+
+      // act
+      await transactionalInterceptor.intercept(context, next);
+
+      // assert
+      verify(mikroOrmRegistryMock.get("mydb")).once();
+      verify(entityManagerMock.fork(anything(), anything())).once();
+      verify(entityManagerMock.flush()).once();
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.ts
+++ b/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.ts
@@ -1,0 +1,76 @@
+import {DBContext, MikroOrmRegistry, RetryStrategy} from "../services";
+import {Inject, Interceptor, InterceptorContext, InterceptorMethods, InterceptorNext} from "@tsed/di";
+import {EntityManager} from "@mikro-orm/core";
+
+export interface TransactionOptions {
+  connectionName?: string;
+  retryStrategy?: RetryStrategy;
+}
+
+@Interceptor()
+export class TransactionalInterceptor implements InterceptorMethods {
+  constructor(@Inject() private readonly registry: MikroOrmRegistry, @Inject() private readonly context: DBContext) {}
+
+  public async intercept(context: InterceptorContext<unknown>, next: InterceptorNext): Promise<unknown> {
+    const options = this.extractContextName(context);
+
+    const ctx = this.context.getContext();
+
+    if (!ctx) {
+      return this.runWithinNewCtx(next, options);
+    }
+
+    if (ctx.has(options.connectionName!)) {
+      return next();
+    }
+
+    return this.runUnderCtx(next, ctx, options);
+  }
+
+  private runWithinNewCtx(next: InterceptorNext, options: TransactionOptions): Promise<unknown> | unknown {
+    const ctx = new Map<string, EntityManager>();
+
+    return this.runUnderCtx(next, ctx, options);
+  }
+
+  private runUnderCtx(next: InterceptorNext, ctx: Map<string, EntityManager>, options: TransactionOptions): Promise<unknown> | unknown {
+    const orm = this.registry.get(options.connectionName);
+    const em = orm.em.fork(true, true);
+
+    ctx.set(em.name, em);
+
+    const runInTransaction = () => this.executeInTransaction(options.connectionName!, next);
+
+    return this.context.run(ctx, () => (options.retryStrategy ? options.retryStrategy.acquire(runInTransaction) : runInTransaction()));
+  }
+
+  private extractContextName(context: InterceptorContext<unknown>): TransactionOptions {
+    const options = context.options || ({} as Partial<TransactionOptions> | string);
+
+    let connectionName: string | undefined;
+    let retryStrategy: RetryStrategy | undefined;
+
+    if (typeof options === "string") {
+      connectionName = options;
+    } else if (options) {
+      connectionName = options.connectionName;
+      retryStrategy = options.retryStrategy;
+    }
+
+    if (!connectionName) {
+      connectionName = "default";
+    }
+
+    return {connectionName, retryStrategy};
+  }
+
+  private async executeInTransaction(connectionName: string, next: InterceptorNext): Promise<unknown> {
+    const em = this.context.get(connectionName);
+
+    const result = await next();
+
+    await em?.flush();
+
+    return result;
+  }
+}

--- a/packages/orm/mikro-orm/src/interceptors/index.ts
+++ b/packages/orm/mikro-orm/src/interceptors/index.ts
@@ -1,0 +1,1 @@
+export * from "./TransactionalInterceptor";

--- a/packages/orm/mikro-orm/src/services/DBContent.spec.ts
+++ b/packages/orm/mikro-orm/src/services/DBContent.spec.ts
@@ -1,0 +1,116 @@
+import {DBContext} from "@tsed/mikro-orm";
+import {EntityManager} from "@mikro-orm/core";
+
+describe("DBContext", () => {
+  describe("run", () => {
+    it("should return result of execution of callback", async () => {
+      // arrange
+      const dbCtx = new DBContext();
+      const store = new Map<string, EntityManager>();
+      const expected = 1;
+      const callback = jest.fn().mockResolvedValue(expected);
+
+      // act
+      const result = await dbCtx.run(store, callback);
+
+      // assert
+      expect(callback).toBeCalled();
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("get", () => {
+    it("should return undefined if not such context", () => {
+      // arrange
+      const ctx = new DBContext();
+
+      // act
+      const result = ctx.get("unknown");
+
+      // assert
+      expect(result).toBeUndefined();
+    });
+
+    it("should return context if it is initialized", async () => {
+      // arrange
+      const dbCtx = new DBContext();
+      const expected = ({} as unknown) as EntityManager;
+      const store = new Map<string, EntityManager>([["context1", expected]]);
+      const callback = jest.fn().mockImplementation(() => {
+        const result = dbCtx.get("context1");
+
+        // assert
+        expect(result).toEqual(expected);
+      });
+
+      // act
+      await dbCtx.run(store, callback);
+
+      // assert
+      expect(callback).toBeCalled();
+    });
+  });
+
+  describe("has", () => {
+    it("should return false if not such context", () => {
+      // arrange
+      const ctx = new DBContext();
+
+      // act
+      const result = ctx.has("unknown");
+
+      // assert
+      expect(result).toBeFalsy();
+    });
+
+    it("should return context if it is initialized", async () => {
+      // arrange
+      const dbCtx = new DBContext();
+      const expected = ({} as unknown) as EntityManager;
+      const store = new Map<string, EntityManager>([["context1", expected]]);
+      const callback = jest.fn().mockImplementation(() => {
+        const result = dbCtx.has("context1");
+
+        // assert
+        expect(result).toBeTruthy();
+      });
+
+      // act
+      await dbCtx.run(store, callback);
+
+      // assert
+      expect(callback).toBeCalled();
+    });
+  });
+
+  describe("getContext", () => {
+    it("should return undefined if store is not initialized yet", () => {
+      // arrange
+      const dbCtx = new DBContext();
+
+      // act
+      const result = dbCtx.getContext();
+
+      // assert
+      expect(result).toBeUndefined();
+    });
+
+    it("should return story if it is initialized by calling `DBContext.run`", async () => {
+      // arrange
+      const dbCtx = new DBContext();
+      const store = new Map<string, EntityManager>();
+      const callback = jest.fn().mockImplementation(() => {
+        const result = dbCtx.getContext();
+
+        // assert
+        expect(result).toEqual(store);
+      });
+
+      // act
+      await dbCtx.run(store, callback);
+
+      // assert
+      expect(callback).toBeCalled();
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/services/DBContext.ts
+++ b/packages/orm/mikro-orm/src/services/DBContext.ts
@@ -1,0 +1,36 @@
+import {Injectable} from "@tsed/di";
+import {EntityManager} from "@mikro-orm/core";
+import {AsyncLocalStorage} from "async_hooks";
+
+@Injectable()
+export class DBContext {
+  private readonly storage = new AsyncLocalStorage<Map<string, EntityManager>>();
+
+  constructor() {
+    if (AsyncLocalStorage) {
+      this.storage = new AsyncLocalStorage();
+    } else {
+      throw new Error(`AsyncLocalStorage is not available for your Node.js version (${process.versions.node}).`);
+    }
+  }
+
+  public run<R>(ctx: Map<string, EntityManager>, callback: (...args: any[]) => R): R {
+    return this.storage.run(ctx, callback);
+  }
+
+  public getContext(): Map<string, EntityManager> | undefined {
+    return this.storage.getStore();
+  }
+
+  public get(contextName: string): EntityManager | undefined {
+    const context = this.getContext();
+
+    return context?.get(contextName);
+  }
+
+  public has(contextName: string): boolean {
+    const context = this.getContext();
+
+    return !!context?.has(contextName);
+  }
+}

--- a/packages/orm/mikro-orm/src/services/MikroOrmFactory.ts
+++ b/packages/orm/mikro-orm/src/services/MikroOrmFactory.ts
@@ -1,0 +1,16 @@
+import {DBContext} from "./DBContext";
+import {MikroORM, Options} from "@mikro-orm/core";
+import {Inject, Injectable} from "@tsed/di";
+
+@Injectable()
+export class MikroOrmFactory {
+  @Inject()
+  private readonly dbContext!: DBContext;
+
+  public create(connectionOptions: Options): Promise<MikroORM> {
+    return MikroORM.init({
+      ...connectionOptions,
+      context: (name: string) => this.dbContext.get(name)
+    });
+  }
+}

--- a/packages/orm/mikro-orm/src/services/MikroOrmRegistry.spec.ts
+++ b/packages/orm/mikro-orm/src/services/MikroOrmRegistry.spec.ts
@@ -1,0 +1,102 @@
+import {MikroOrmRegistry} from "./MikroOrmRegistry";
+import {MikroOrmFactory} from "./MikroOrmFactory";
+import {anything, instance, mock, reset, verify, when} from "ts-mockito";
+import {InjectorService, Logger} from "@tsed/common";
+import {MikroORM, Options} from "@mikro-orm/core";
+
+const fixtures: {mydb2: Options; none: Options; mydb: Options} = {
+  mydb: {
+    contextName: "mydb",
+    type: "postgresql",
+    clientUrl: "postgresql://localhost:5432"
+  },
+  none: {
+    type: "postgresql",
+    clientUrl: "postgresql://localhost:5432"
+  },
+  mydb2: {
+    contextName: "mydb2",
+    type: "postgresql",
+    clientUrl: "postgresql://localhost:5432"
+  }
+};
+
+describe("MikroOrmRegistry", () => {
+  const injectorServiceMock = mock<InjectorService>();
+  const loggerMock = mock<Logger>();
+  const mikroOrmFactoryMock = mock<MikroOrmFactory>();
+  const mikroOrm = mock(MikroORM);
+
+  when(injectorServiceMock.logger).thenReturn(instance(loggerMock));
+
+  Object.values(fixtures).forEach((options: Options) => when(mikroOrmFactoryMock.create(options)).thenResolve(instance(mikroOrm)));
+
+  const mikroOrmRegistry = new MikroOrmRegistry(instance(injectorServiceMock), instance(mikroOrmFactoryMock));
+
+  beforeEach(() => reset<MikroORM | MikroOrmFactory>(mikroOrmFactoryMock, mikroOrm));
+
+  describe("createConnection", () => {
+    it("should create connections", async () => {
+      // arrange
+      Object.values(fixtures).forEach((options: Options) => when(mikroOrmFactoryMock.create(options)).thenResolve(instance(mikroOrm)));
+
+      // act
+      const result1 = await mikroOrmRegistry.createConnection(fixtures.mydb);
+      const result2 = await mikroOrmRegistry.createConnection(fixtures.mydb);
+      const result3 = await mikroOrmRegistry.createConnection(fixtures.none);
+      const result4 = await mikroOrmRegistry.createConnection(fixtures.mydb2);
+
+      // assert
+      expect(result1).toEqual(mikroOrmRegistry.get("mydb"));
+      expect(result2).toEqual(mikroOrmRegistry.get("mydb"));
+      expect(result3).toEqual(mikroOrmRegistry.get("default"));
+      expect(result4).toEqual(mikroOrmRegistry.get("mydb2"));
+      verify(mikroOrmFactoryMock.create(anything())).thrice();
+    });
+
+    it("should close all connections", async () => {
+      // arrange
+      when(mikroOrm.isConnected()).thenResolve(true);
+
+      // act
+      await mikroOrmRegistry.closeConnections();
+
+      // assert
+      verify(mikroOrm.close(anything())).thrice();
+    });
+  });
+
+  describe("get", () => {
+    it("should return corresponded connections", async () => {
+      // arrange
+      Object.values(fixtures).forEach((options: Options) => when(mikroOrmFactoryMock.create(options)).thenResolve(instance(mikroOrm)));
+      const defaultConnection = await mikroOrmRegistry.createConnection(fixtures.none);
+      const customConnection = await mikroOrmRegistry.createConnection(fixtures.mydb);
+
+      // act
+      const result1 = mikroOrmRegistry.get();
+      const result2 = mikroOrmRegistry.get("default");
+      const result3 = mikroOrmRegistry.get("mydb");
+
+      // assert
+      expect(result1).toEqual(defaultConnection);
+      expect(result2).toEqual(defaultConnection);
+      expect(result3).toEqual(customConnection);
+    });
+  });
+
+  describe("has", () => {
+    it("should return corresponded connections existence", async () => {
+      // arrange
+      Object.values(fixtures).forEach((options: Options) => when(mikroOrmFactoryMock.create(options)).thenResolve(instance(mikroOrm)));
+      await mikroOrmRegistry.createConnection(fixtures.none);
+      await mikroOrmRegistry.createConnection(fixtures.mydb);
+
+      // act & assert
+      expect(mikroOrmRegistry.has()).toBeTruthy();
+      expect(mikroOrmRegistry.has("mydb")).toBeTruthy();
+      expect(mikroOrmRegistry.has("default")).toBeTruthy();
+      expect(mikroOrmRegistry.has("mydb10")).toBeFalsy();
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/services/MikroOrmRegistry.ts
+++ b/packages/orm/mikro-orm/src/services/MikroOrmRegistry.ts
@@ -1,0 +1,53 @@
+import {MikroOrmFactory} from "./MikroOrmFactory";
+import {Inject, Injectable, InjectorService} from "@tsed/di";
+import {IDatabaseDriver as DatabaseDriver, MikroORM, Options} from "@mikro-orm/core";
+import {catchAsyncError, getValue} from "@tsed/core";
+
+@Injectable()
+export class MikroOrmRegistry {
+  private readonly connections = new Map<string, MikroORM>();
+
+  constructor(@Inject() private readonly injector: InjectorService, @Inject() private readonly mikroOrmFactory: MikroOrmFactory) {}
+
+  public async createConnection<T extends DatabaseDriver>(connectionOptions: Options<T>): Promise<MikroORM> {
+    const connectionName = getValue<string>(connectionOptions, "contextName", "default");
+
+    if (this.has(connectionName)) {
+      return this.get(connectionName);
+    }
+
+    this.injector.logger.info(`Create connection with MikroOrm to database: %s`, connectionName);
+    this.injector.logger.debug(`options: %j`, connectionOptions);
+
+    const connection = await this.mikroOrmFactory.create(connectionOptions);
+
+    this.connections.set(connectionName, connection);
+
+    this.injector.logger.info(`Connected with MikroOrm to database: %s`, connectionName);
+
+    return connection;
+  }
+
+  public get(id: string = "default"): MikroORM {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.connections.get(id)!;
+  }
+
+  public has(id: string = "default"): boolean {
+    return this.connections.has(id);
+  }
+
+  public async closeConnections(): Promise<void> {
+    const connections = [...this.connections.values()];
+
+    await Promise.all(connections.map((connection: MikroORM) => catchAsyncError(() => this.dispose(connection))));
+
+    this.connections.clear();
+  }
+
+  private async dispose(connection: MikroORM): Promise<void> {
+    if (await connection.isConnected()) {
+      await connection.close(false);
+    }
+  }
+}

--- a/packages/orm/mikro-orm/src/services/RetryStrategy.ts
+++ b/packages/orm/mikro-orm/src/services/RetryStrategy.ts
@@ -1,0 +1,3 @@
+export interface RetryStrategy {
+  acquire<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>>;
+}

--- a/packages/orm/mikro-orm/src/services/index.ts
+++ b/packages/orm/mikro-orm/src/services/index.ts
@@ -1,0 +1,4 @@
+export * from "./DBContext";
+export * from "./MikroOrmFactory";
+export * from "./MikroOrmRegistry";
+export * from "./RetryStrategy";

--- a/packages/orm/mikro-orm/test/helpers/Server.ts
+++ b/packages/orm/mikro-orm/test/helpers/Server.ts
@@ -1,0 +1,38 @@
+import {Configuration, Inject, PlatformApplication} from "@tsed/common";
+import Path from "path";
+import "@tsed/platform-express";
+
+const cookieParser = require("cookie-parser"),
+  bodyParser = require("body-parser"),
+  compress = require("compression"),
+  methodOverride = require("method-override");
+
+const rootDir = Path.resolve(__dirname);
+
+@Configuration({
+  rootDir,
+  port: 8001,
+  httpsPort: false,
+  disableComponentScan: true,
+  logger: {
+    level: "info",
+    logRequest: true
+  }
+})
+export class Server {
+  @Inject()
+  app: PlatformApplication;
+
+  public $beforeRoutesInit(): void {
+    this.app
+      .use(bodyParser.json())
+      .use(
+        bodyParser.urlencoded({
+          extended: true
+        })
+      )
+      .use(cookieParser())
+      .use(compress({}))
+      .use(methodOverride());
+  }
+}

--- a/packages/orm/mikro-orm/test/helpers/entity/User.ts
+++ b/packages/orm/mikro-orm/test/helpers/entity/User.ts
@@ -1,0 +1,10 @@
+import {Property} from "@tsed/schema";
+import {Entity, PrimaryKey} from "@mikro-orm/core";
+import {ObjectId} from "@mikro-orm/mongodb";
+
+@Entity()
+export class User {
+  @PrimaryKey()
+  @Property()
+  _id: ObjectId;
+}

--- a/packages/orm/mikro-orm/test/helpers/services/UserService.ts
+++ b/packages/orm/mikro-orm/test/helpers/services/UserService.ts
@@ -1,0 +1,15 @@
+import {Injectable} from "@tsed/di";
+import {Connection} from "../../../src";
+import {MikroORM} from "@mikro-orm/core";
+
+@Injectable()
+export class UserService {
+  @Connection()
+  connection: MikroORM;
+
+  @Connection("db1")
+  connection1: MikroORM;
+
+  @Connection("db2")
+  connection2: MikroORM;
+}

--- a/packages/orm/mikro-orm/test/integration.spec.ts
+++ b/packages/orm/mikro-orm/test/integration.spec.ts
@@ -1,0 +1,53 @@
+import {PlatformTest} from "@tsed/common";
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import {User} from "./helpers/entity/User";
+import {Server} from "./helpers/Server";
+import {UserService} from "./helpers/services/UserService";
+import {MikroORM} from "@mikro-orm/core";
+import {MikroOrmModule} from "../src";
+
+describe("TypeORM integration", () => {
+  beforeEach(async () => {
+    await TestMongooseContext.install();
+    const {url: clientUrl} = await TestMongooseContext.getMongooseOptions();
+    const bstrp = PlatformTest.bootstrap(Server, {
+      disableComponentScan: true,
+      imports: [MikroOrmModule],
+      mikroOrm: [
+        {
+          clientUrl,
+          type: "mongo",
+          entities: [User]
+        },
+        {
+          clientUrl,
+          contextName: "db1",
+          type: "mongo",
+          entities: [User]
+        },
+        {
+          clientUrl,
+          contextName: "db2",
+          type: "mongo",
+          entities: [User]
+        }
+      ]
+    });
+
+    await bstrp();
+  });
+  afterEach(TestMongooseContext.reset);
+
+  it("should return repository", () => {
+    const service = PlatformTest.injector.get<UserService>(UserService)!;
+
+    expect(service).toBeInstanceOf(UserService);
+    expect(service.connection).toBeInstanceOf(MikroORM);
+    expect(service.connection.em.name).toBe("default");
+
+    expect(service.connection1).toBeInstanceOf(MikroORM);
+    expect(service.connection1.em.name).toBe("db1");
+    expect(service.connection2).toBeInstanceOf(MikroORM);
+    expect(service.connection2.em.name).toBe("db2");
+  });
+});

--- a/packages/orm/mikro-orm/tsconfig.compile.esm.json
+++ b/packages/orm/mikro-orm/tsconfig.compile.esm.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.compile.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "ES2020",
+    "rootDir": "src",
+    "outDir": "./lib/esm",
+    "declaration": true,
+    "declarationDir": "./lib/types"
+  },
+  "exclude": [
+    "node_modules",
+    "test",
+    "lib",
+    "benchmark",
+    "coverage",
+    "spec",
+    "**/*.benchmark.ts",
+    "**/*.spec.ts",
+    "keys",
+    "jest.config.js"
+  ]
+}

--- a/packages/orm/mikro-orm/tsconfig.compile.json
+++ b/packages/orm/mikro-orm/tsconfig.compile.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.compile.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib/cjs"
+  },
+  "exclude": [
+    "node_modules",
+    "test",
+    "lib",
+    "benchmark",
+    "coverage",
+    "spec",
+    "**/*.benchmark.ts",
+    "**/*.spec.ts",
+    "keys",
+    "jest.config.js"
+  ]
+}

--- a/packages/platform/common/src/services/PlatformTest.ts
+++ b/packages/platform/common/src/services/PlatformTest.ts
@@ -1,4 +1,4 @@
-import {createContainer, DITest, InjectorService} from "@tsed/di";
+import {DITest, DITestOptions, InjectorService} from "@tsed/di";
 import {PlatformBuilder} from "../builder/PlatformBuilder";
 import {PlatformContext, PlatformContextOptions} from "../domain/PlatformContext";
 import {createInjector} from "../utils/createInjector";
@@ -13,11 +13,9 @@ import {Type} from "@tsed/core";
 export class PlatformTest extends DITest {
   public static adapter: Type<PlatformAdapter>;
 
-  static async create(settings: Partial<TsED.Configuration> = {}) {
+  static async create(settings: DITestOptions = {}) {
     DITest.injector = PlatformTest.createInjector(getConfiguration(settings));
-    const container = createContainer();
-
-    await DITest.injector.load(container);
+    await DITest.createContainer(settings);
   }
 
   /**

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -36,6 +36,7 @@ module.exports = (rootDir) => ({
     "^@tsed/testing-mongoose$": fixPath(join(packageDir, "orm/testing-mongoose/src")),
     "^@tsed/objection$": fixPath(join(packageDir, "orm/objection/src")),
     "^@tsed/typeorm$": fixPath(join(packageDir, "orm/typeorm/src")),
+    "^@tsed/mikro-orm": fixPath(join(packageDir, "orm/mikro-orm/src")),
     "^@tsed/adapters$": fixPath(join(packageDir, "orm/adapters/src")),
     "^@tsed/mongoose$": fixPath(join(packageDir, "orm/mongoose/src")),
     "^@tsed/adapters-redis$": fixPath(join(packageDir, "orm/adapters-redis/src")),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,6 +2669,28 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
+"@mikro-orm/core@^4.5.9":
+  version "4.5.9"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/core/-/core-4.5.9.tgz#1b8fa2915544fc3f00f0b9db100868aeceb5b8f5"
+  integrity sha512-kG7nnchwhtDNjsAJ7Lau9ZsyNQo2rBqZg+6T54A/c6v4/yFRltbg3gv6eMd4vefH6PS2AKa71H5L49P105qYmQ==
+  dependencies:
+    ansi-colors "4.1.1"
+    clone "2.1.2"
+    dotenv "8.2.0"
+    escaya "0.0.61"
+    fs-extra "9.1.0"
+    globby "11.0.3"
+    reflect-metadata "0.1.13"
+    strip-json-comments "3.1.1"
+
+"@mikro-orm/mongodb@^4.5.9":
+  version "4.5.9"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/mongodb/-/mongodb-4.5.9.tgz#3e0d967f16d511b0a4435419389cf1666f83fda6"
+  integrity sha512-kn33Z9ufpSDPEZ2v+ax04D2qMEV82So4Dtnb1Ln6StLRv5qJ7UIFihiYSuJvgIl2I4M72B9bo51EasltTO8lPg==
+  dependencies:
+    "@types/mongodb" "3.6.12"
+    mongodb "3.6.6"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3945,6 +3967,14 @@
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.2.tgz#91daa226eb8c2ff261e6a8cbf8c7304641e095e0"
   integrity sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==
+
+"@types/mongodb@3.6.12":
+  version "3.6.12"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.6.12.tgz#727960d34f35054d2f2ce68909e16094f742d935"
+  integrity sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==
+  dependencies:
+    "@types/bson" "*"
+    "@types/node" "*"
 
 "@types/mongodb@^3.5.27":
   version "3.6.1"
@@ -6505,15 +6535,15 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.1.2, clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
-
-clone@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 cluster-key-slot@^1.1.0:
   version "1.1.0"
@@ -8006,15 +8036,15 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@8.2.0, dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
-
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 downloadjs@^1.4.7:
   version "1.4.7"
@@ -8451,6 +8481,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escaya@0.0.61:
+  version "0.0.61"
+  resolved "https://registry.yarnpkg.com/escaya/-/escaya-0.0.61.tgz#f87a89dd43d877c86b06b55b78b7a465cd2c5c3a"
+  integrity sha512-WLLmvdG72Z0pCq8XUBd03GEJlAiMceXFanjdQeEzeSiuV1ZgrJqbkU7ZEe/hu0OsBlg5wLlySEeOvfzcGoO8mg==
 
 escodegen@1.x.x, escodegen@^1.6.1:
   version "1.14.3"
@@ -9721,6 +9756,16 @@ fs-extra@9.0.1, fs-extra@^9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
+fs-extra@9.1.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
@@ -9738,16 +9783,6 @@ fs-extra@^7.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^9.0.1, fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -13432,7 +13467,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@4, lodash@4.17.21, lodash@4.x, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4, lodash@4.17.21, lodash@4.x, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -14310,6 +14345,19 @@ mongodb@3.6.5:
     bson "^1.1.4"
     denque "^1.4.1"
     require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongodb@3.6.6:
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.6.tgz#92e3658f45424c34add3003e3046c1535c534449"
+  integrity sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==
+  dependencies:
+    bl "^2.2.1"
+    bson "^1.1.4"
+    denque "^1.4.1"
+    optional-require "^1.0.2"
     safe-buffer "^5.1.2"
   optionalDependencies:
     saslprep "^1.0.0"
@@ -15485,6 +15533,13 @@ opener@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+optional-require@^1.0.2:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/optional-require/-/optional-require-1.1.8.tgz#16364d76261b75d964c482b2406cb824d8ec44b7"
+  integrity sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==
+  dependencies:
+    require-at "^1.0.6"
 
 optional-require@^1.0.3:
   version "1.0.3"
@@ -17354,7 +17409,7 @@ redux@^4.0.4:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
 
-reflect-metadata@^0.1.13:
+reflect-metadata@0.1.13, reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
@@ -17534,6 +17589,11 @@ request-promise@^4.2.2:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+require-at@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/require-at/-/require-at-1.0.6.tgz#9eb7e3c5e00727f5a4744070a7f560d4de4f6e6a"
+  integrity sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -19651,6 +19711,13 @@ ts-jest@^27.0.5:
     make-error "1.x"
     semver "7.x"
     yargs-parser "20.x"
+
+ts-mockito@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
+  dependencies:
+    lodash "^4.17.5"
 
 ts-node@^10.2.1:
   version "10.2.1"


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No

****

## Usage example

### Installation

To begin, install the MikroOrm module for TS.ED:
```bash
npm install --save @tsed/mikro-orm
npm install --save @mikro-orm/core
```

Then import `@tsed/mikro-orm` in your Server:

```typescript
import {Configuration} from "@tsed/common";
import {MikroOrmModule} from "@tsed/mikro-orm";

@Configuration({
    imports: [MikroOrmModule],
    mikroOrm: [
    {
      contextName: 'default',
      type: 'postgres',
      ...,

       entities: [
         `${__dirname}/entity/*{.ts,.js}`
       ]
    },
    {
       contextName: 'mongo',
       type: 'mongo',
       ...
    }
  ]
})
export class Server {

}
```

For more information about MikroOrm look his documentation [here](https://mikro-orm.io/docs);

### Obtain a connection

`Connection` decorator lets you retrieve an instance of MikroOrm Connection.

```typescript
import {Service, AfterRoutesInit} from "@tsed/common";
import {Connection} from "@tsed/mikro-orm";
import {MikroORM} from "@mikro-orm/core";

@Service()
export class UsersService {
    @Connection()
    private readonly connection!: MikroORM;

    async create(user: User): Promise<User> {

        // do something
        // ...
        // Then save
        await this.connection.em.persistAndFlush(user);
        console.log("Saved a new user with id: " + user.id);

        return user;
    }

    async find(): Promise<User[]> {
        const users = await this.connection.em.find(User, {});
        console.log("Loaded users: ", users);

        return users;
    }
}
```

### Use Entity with Controller

To begin, we need to define an Entity MikroOrm like this and use Ts.ED Decorator to define the JSON Schema.

```typescript
import {Property, MaxLength, Required} from "@tsed/common";
import {Entity, Property, PrimaryKey, Property as Column} from "@mikro-orm/core";

@Entity()
export class User {

    @PrimaryKey()
    @Property()
    id: number;

    @Column()
    @MaxLength(100)
    @Required()
    firstName: string;

    @Column()
    @MaxLength(100)
    @Required()
    lastName: string;

    @Column()
    @Mininum(0)
    @Maximum(100)
    age: number;
}
```

Now, the model is correctly defined and can be used with a [Controller](https://tsed.io/docs/controllers.html), [AJV validation](tutorials/ajv.md),
[Swagger](tutorials/swagger.md) and [MikroOrm](https://mikro-orm.io/docs/defining-entities).

We can use this model with a Controller like that:

```typescript
import {Controller, Post, BodyParams} from "@tsed/common";

@Controller("/users")
export class UsersCtrl {

    constructor(private usersService: UsersService) {

    }

    @Post("/")
    create(@BodyParams() user: User): Promise<User> {

        return this.usersService.create(user);
    }

    @Get("/")
    getList(): Promise<User[]> {

        return this.usersService.find();
    }
}
```

### Transactions and Request context

As mentioned in the [docs](https://mikro-orm.io/docs/identity-map), we need to isolate a state for each request. That is handled automatically thanks to the `AsyncLocalStorage` registered via interceptor.

We can use the `@Transactional()` decorator, which will register a new request context for your method and execute it inside the context.

```typescript
import {Controller, Post, BodyParams} from "@tsed/common";
import {Transactional} from "@tsed/mikro-orm";

@Controller("/users")
export class UsersCtrl {

    constructor(private usersService: UsersService) {

    }

    @Post("/")
    @Transactional()
    create(@BodyParams() user: User): Promise<User> {

        return this.usersService.create(user);
    }

    @Get("/")
    getList(): Promise<User[]> {

        return this.usersService.find();
    }
}
```

## Appendix

`ts-mockito` mocking library is used in unit tests as a convenient way to work with test doubles.

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [x] Documentation

closes #1547