### PR TITLE
feat(mikro-orm): provide the ability to set up a retry strategy

### DIFF
--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -180,6 +180,93 @@ export class UsersCtrl {
 }
 ```
 
+By default, the automatic retry policy is disabled. You can implement your own to match the business requirements and the nature of the failure. For some noncritical operations, it is better to fail as soon as possible rather than retry a coupe of times. For example, in an interactive web application, it is better to fail right after a smaller number of retries with only a short delay between retry attempts, and display a message to the user (for example, "please try again later").
+
+The `@Transactional()` decorator allows you to enable a retry policy for the particular resources. You just need to implement the `RetryStrategy` interface and use `registerProvider()` or `@OverrideProvider()` to register it in the IoC container. Below you can find an example to handle occurred optimistic locks based on [an exponential backoff retry strategy](https://en.wikipedia.org/wiki/Exponential_backoff).
+
+```ts
+import { OptimisticLockError } from '@mikro-orm/core';
+import { RetryStrategy } from '@tsed/mikro-orm';
+
+export interface ExponentialBackoffOptions {
+  maxDepth: number;
+}
+
+export class ExponentialBackoff implements RetryStrategy {
+  private depth = 0;
+
+  constructor(private readonly options: ExponentialBackoffOptions) {}
+
+  public async acquire<T extends (...args: unknown[]) => unknown>(
+    task: T
+  ): Promise<ReturnType<T>> {
+    try {
+      return (await task()) as ReturnType<T>;
+    } catch (e) {
+      if (
+        this.shouldRetry(e as Error) &&
+        this.depth < this.options.maxDepth
+      ) {
+        return this.retry(task);
+      }
+
+      throw e;
+    }
+  }
+
+  private shouldRetry(error: Error): boolean {
+    return error instanceof OptimisticLockError;
+  }
+
+  private async retry<T extends (...args: unknown[]) => unknown>(
+    task: T
+  ): Promise<ReturnType<T>> {
+    await this.sleep(2 ** this.depth * 50);
+
+    this.depth += 1;
+
+    return this.acquire(task);
+  }
+
+  private sleep(milliseconds: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+  }
+}
+
+registerProvider({
+  provide: RetryStrategy,
+  useFactory(): ExponentialBackoff {
+    return new ExponentialBackoff({maxDepth: 3})
+  }
+});
+```
+
+`ExponentialBackoff` invokes passed function recursively is contained in a try/catch block. The method returns control to the interceptor if the call to the `task` function succeeds without throwing an exception. If the `task` method fails, the catch block examines the reason for the failure. If it's optimistic locking the code waits for a short delay before retrying the operation.
+
+Once a retry strategy is implemented, you can enable an automatic retry mechanism using the `@Transactional` decorator like that:
+
+```typescript
+import {Controller, Post, BodyParams, Inject, Get} from "@tsed/common";
+import {Transactional} from "@tsed/mikro-orm";
+
+@Controller("/users")
+export class UsersCtrl {
+  @Inject()
+  private usersService: UsersService;
+
+  @Post("/")
+  @Transactional({retry: true})
+  create(@BodyParams() user: User): Promise<User> {
+    return this.usersService.create(user);
+  }
+
+  @Get("/")
+  getList(): Promise<User[]> {
+    return this.usersService.find();
+  }
+}
+```
+
 ## Author
 
 <GithubContributors :users="['derevnjuk']"/>

--- a/packages/orm/mikro-orm/jest.config.js
+++ b/packages/orm/mikro-orm/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   ...require("@tsed/jest-config")(__dirname, "mikro-orm"),
   coverageThreshold: {
     global: {
-      branches: 85.29,
+      branches: 90.91,
       functions: 100,
-      lines: 98.95,
-      statements: 99.15
+      lines: 99.06,
+      statements: 99.21
     }
   }
 };

--- a/packages/orm/mikro-orm/package.json
+++ b/packages/orm/mikro-orm/package.json
@@ -28,7 +28,9 @@
     "@tsed/core": "6.96.2",
     "@tsed/di": "6.96.2",
     "@tsed/json-mapper": "6.96.2",
+    "@tsed/logger": "^6.0.0",
     "@tsed/schema": "6.96.2",
+    "@tsed/testing-mongoose": "6.96.2",
     "ts-mockito": "^2.6.1"
   },
   "peerDependencies": {
@@ -36,7 +38,6 @@
     "@tsed/common": "^6.96.2",
     "@tsed/core": "^6.96.2",
     "@tsed/di": "^6.96.2",
-    "@tsed/json-mapper": "^6.96.2",
-    "@tsed/schema": "^6.96.2"
+    "@tsed/logger": "^6.0.0"
   }
 }

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -287,7 +287,6 @@ export class UsersCtrl {
 }
 ```
 
-
 ## Contributors
 
 Please read [contributing guidelines here](https://tsed.io/CONTRIBUTING.html)

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -200,6 +200,94 @@ export class UsersCtrl {
 }
 ```
 
+By default, the automatic retry policy is disabled. You can implement your own to match the business requirements and the nature of the failure. For some noncritical operations, it is better to fail as soon as possible rather than retry a coupe of times. For example, in an interactive web application, it is better to fail right after a smaller number of retries with only a short delay between retry attempts, and display a message to the user (for example, "please try again later").
+
+The `@Transactional()` decorator allows you to enable a retry policy for the particular resources. You just need to implement the `RetryStrategy` interface and use `registerProvider()` or `@OverrideProvider()` to register it in the IoC container. Below you can find an example to handle occurred optimistic locks based on [an exponential backoff retry strategy](https://en.wikipedia.org/wiki/Exponential_backoff).
+
+```ts
+import { OptimisticLockError } from '@mikro-orm/core';
+import { RetryStrategy } from '@tsed/mikro-orm';
+
+export interface ExponentialBackoffOptions {
+  maxDepth: number;
+}
+
+export class ExponentialBackoff implements RetryStrategy {
+  private depth = 0;
+
+  constructor(private readonly options: ExponentialBackoffOptions) {}
+
+  public async acquire<T extends (...args: unknown[]) => unknown>(
+    task: T
+  ): Promise<ReturnType<T>> {
+    try {
+      return (await task()) as ReturnType<T>;
+    } catch (e) {
+      if (
+        this.shouldRetry(e as Error) &&
+        this.depth < this.options.maxDepth
+      ) {
+        return this.retry(task);
+      }
+
+      throw e;
+    }
+  }
+
+  private shouldRetry(error: Error): boolean {
+    return error instanceof OptimisticLockError;
+  }
+
+  private async retry<T extends (...args: unknown[]) => unknown>(
+    task: T
+  ): Promise<ReturnType<T>> {
+    await this.sleep(2 ** this.depth * 50);
+
+    this.depth += 1;
+
+    return this.acquire(task);
+  }
+
+  private sleep(milliseconds: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+  }
+}
+
+registerProvider({
+  provide: RetryStrategy,
+  useFactory(): ExponentialBackoff {
+    return new ExponentialBackoff({maxDepth: 3})
+  }
+});
+```
+
+`ExponentialBackoff` invokes passed function recursively is contained in a try/catch block. The method returns control to the interceptor if the call to the `task` function succeeds without throwing an exception. If the `task` method fails, the catch block examines the reason for the failure. If it's optimistic locking the code waits for a short delay before retrying the operation.
+
+Once a retry strategy is implemented, you can enable an automatic retry mechanism using the `@Transactional` decorator like that:
+
+```typescript
+import {Controller, Post, BodyParams, Inject, Get} from "@tsed/common";
+import {Transactional} from "@tsed/mikro-orm";
+
+@Controller("/users")
+export class UsersCtrl {
+  @Inject()
+  private usersService: UsersService;
+
+  @Post("/")
+  @Transactional({retry: true})
+  create(@BodyParams() user: User): Promise<User> {
+    return this.usersService.create(user);
+  }
+
+  @Get("/")
+  getList(): Promise<User[]> {
+    return this.usersService.find();
+  }
+}
+```
+
+
 ## Contributors
 
 Please read [contributing guidelines here](https://tsed.io/CONTRIBUTING.html)

--- a/packages/orm/mikro-orm/src/MikroOrmModule.ts
+++ b/packages/orm/mikro-orm/src/MikroOrmModule.ts
@@ -1,5 +1,5 @@
-import {DBContext, MikroOrmRegistry} from "./services";
-import {Configuration, Constant, Inject, Module, OnDestroy, OnInit} from "@tsed/di";
+import {DBContext, MikroOrmRegistry, RetryStrategy} from "./services";
+import {Configuration, Constant, Inject, Module, OnDestroy, OnInit, registerProvider} from "@tsed/di";
 import {Options} from "@mikro-orm/core";
 
 declare global {
@@ -36,3 +36,6 @@ export class MikroOrmModule implements OnDestroy, OnInit {
     return this.mikroOrmRegistry.closeConnections();
   }
 }
+
+// TODO: the IoC container should provide null or undefined by default until tsedio/tsed#1694 is closed
+registerProvider({provide: RetryStrategy, useValue: null});

--- a/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
+++ b/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
@@ -1,7 +1,8 @@
 import {DBContext, MikroOrmRegistry, RetryStrategy} from "../services";
 import {TransactionalInterceptor} from "./TransactionalInterceptor";
 import {anything, instance, mock, reset, spy, verify, when} from "ts-mockito";
-import {InterceptorContext, InterceptorNext, Logger} from "@tsed/common";
+import {InterceptorContext, InterceptorNext} from "@tsed/di";
+import {Logger} from "@tsed/logger";
 import {EntityManager, MikroORM, OptimisticLockError} from "@mikro-orm/core";
 
 describe("TransactionalInterceptor", () => {

--- a/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
+++ b/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
@@ -1,20 +1,23 @@
 import {DBContext, MikroOrmRegistry} from "../services";
 import {TransactionalInterceptor} from "./TransactionalInterceptor";
 import {anything, instance, mock, reset, spy, verify, when} from "ts-mockito";
-import {InterceptorContext, InterceptorNext} from "@tsed/common";
+import {InterceptorContext, InterceptorNext, Logger} from "@tsed/common";
 import {EntityManager, MikroORM, OptimisticLockError} from "@mikro-orm/core";
 
 describe("TransactionalInterceptor", () => {
   const mikroOrmRegistryMock = mock<MikroOrmRegistry>();
   const mikroOrm = mock(MikroORM);
   const entityManagerMock = mock(EntityManager);
+  const loggerMock = mock<Logger>();
   const dbContext = new DBContext();
 
   let transactionalInterceptor!: TransactionalInterceptor;
 
-  afterEach(() => reset<MikroOrmRegistry | MikroORM | EntityManager>(mikroOrmRegistryMock, mikroOrm, entityManagerMock));
+  afterEach(() =>
+    reset<MikroOrmRegistry | MikroORM | EntityManager | Logger>(mikroOrmRegistryMock, mikroOrm, entityManagerMock, loggerMock)
+  );
   beforeEach(() => {
-    transactionalInterceptor = new TransactionalInterceptor(instance(mikroOrmRegistryMock), dbContext);
+    transactionalInterceptor = new TransactionalInterceptor(instance(mikroOrmRegistryMock), dbContext, instance(loggerMock));
     when(mikroOrm.em).thenReturn(instance(entityManagerMock));
     when(entityManagerMock.fork(anything(), anything())).thenReturn(instance(entityManagerMock));
   });

--- a/packages/orm/mikro-orm/src/services/MikroOrmRegistry.spec.ts
+++ b/packages/orm/mikro-orm/src/services/MikroOrmRegistry.spec.ts
@@ -1,7 +1,7 @@
 import {MikroOrmRegistry} from "./MikroOrmRegistry";
 import {MikroOrmFactory} from "./MikroOrmFactory";
 import {anything, instance, mock, reset, verify, when} from "ts-mockito";
-import {InjectorService, Logger} from "@tsed/common";
+import {Logger} from "@tsed/logger";
 import {MikroORM, Options} from "@mikro-orm/core";
 
 const fixtures: {mydb2: Options; none: Options; mydb: Options} = {
@@ -22,16 +22,13 @@ const fixtures: {mydb2: Options; none: Options; mydb: Options} = {
 };
 
 describe("MikroOrmRegistry", () => {
-  const injectorServiceMock = mock<InjectorService>();
   const loggerMock = mock<Logger>();
   const mikroOrmFactoryMock = mock<MikroOrmFactory>();
   const mikroOrm = mock(MikroORM);
 
-  when(injectorServiceMock.logger).thenReturn(instance(loggerMock));
-
   Object.values(fixtures).forEach((options: Options) => when(mikroOrmFactoryMock.create(options)).thenResolve(instance(mikroOrm)));
 
-  const mikroOrmRegistry = new MikroOrmRegistry(instance(injectorServiceMock), instance(mikroOrmFactoryMock));
+  const mikroOrmRegistry = new MikroOrmRegistry(instance(loggerMock), instance(mikroOrmFactoryMock));
 
   beforeEach(() => reset<MikroORM | MikroOrmFactory>(mikroOrmFactoryMock, mikroOrm));
 

--- a/packages/orm/mikro-orm/src/services/MikroOrmRegistry.ts
+++ b/packages/orm/mikro-orm/src/services/MikroOrmRegistry.ts
@@ -1,13 +1,14 @@
 import {MikroOrmFactory} from "./MikroOrmFactory";
-import {Inject, Injectable, InjectorService} from "@tsed/di";
+import {Inject, Injectable} from "@tsed/di";
 import {IDatabaseDriver as DatabaseDriver, MikroORM, Options} from "@mikro-orm/core";
 import {catchAsyncError, getValue} from "@tsed/core";
+import {Logger} from "@tsed/logger";
 
 @Injectable()
 export class MikroOrmRegistry {
   private readonly connections = new Map<string, MikroORM>();
 
-  constructor(@Inject() private readonly injector: InjectorService, @Inject() private readonly mikroOrmFactory: MikroOrmFactory) {}
+  constructor(@Inject() private readonly logger: Logger, @Inject() private readonly mikroOrmFactory: MikroOrmFactory) {}
 
   public async createConnection<T extends DatabaseDriver>(connectionOptions: Options<T>): Promise<MikroORM> {
     const connectionName = getValue<string>(connectionOptions, "contextName", "default");
@@ -16,14 +17,14 @@ export class MikroOrmRegistry {
       return this.get(connectionName);
     }
 
-    this.injector.logger.info(`Create connection with MikroOrm to database: %s`, connectionName);
-    this.injector.logger.debug(`options: %j`, connectionOptions);
+    this.logger.info(`Create connection with MikroOrm to database: %s`, connectionName);
+    this.logger.debug(`options: %j`, connectionOptions);
 
     const connection = await this.mikroOrmFactory.create(connectionOptions);
 
     this.connections.set(connectionName, connection);
 
-    this.injector.logger.info(`Connected with MikroOrm to database: %s`, connectionName);
+    this.logger.info(`Connected with MikroOrm to database: %s`, connectionName);
 
     return connection;
   }

--- a/packages/orm/mikro-orm/src/services/RetryStrategy.ts
+++ b/packages/orm/mikro-orm/src/services/RetryStrategy.ts
@@ -1,3 +1,5 @@
 export interface RetryStrategy {
   acquire<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>>;
 }
+
+export const RetryStrategy: unique symbol = Symbol("RetryStrategy");

--- a/packages/orm/mikro-orm/test/helpers/Server.ts
+++ b/packages/orm/mikro-orm/test/helpers/Server.ts
@@ -1,4 +1,5 @@
-import {Configuration, Inject, PlatformApplication} from "@tsed/common";
+import {Configuration, Inject} from "@tsed/di";
+import {PlatformApplication} from "@tsed/common";
 import Path from "path";
 import "@tsed/platform-express";
 

--- a/packages/orm/mikro-orm/test/helpers/Server.ts
+++ b/packages/orm/mikro-orm/test/helpers/Server.ts
@@ -1,6 +1,6 @@
 import {Configuration, Inject} from "@tsed/di";
 import {PlatformApplication} from "@tsed/common";
-import Path from "path";
+import {resolve} from "path";
 import "@tsed/platform-express";
 
 const cookieParser = require("cookie-parser"),
@@ -8,7 +8,7 @@ const cookieParser = require("cookie-parser"),
   compress = require("compression"),
   methodOverride = require("method-override");
 
-const rootDir = Path.resolve(__dirname);
+const rootDir = resolve(__dirname);
 
 @Configuration({
   rootDir,
@@ -22,7 +22,7 @@ const rootDir = Path.resolve(__dirname);
 })
 export class Server {
   @Inject()
-  app: PlatformApplication;
+  app!: PlatformApplication;
 
   public $beforeRoutesInit(): void {
     this.app

--- a/packages/orm/mikro-orm/test/helpers/entity/User.ts
+++ b/packages/orm/mikro-orm/test/helpers/entity/User.ts
@@ -6,5 +6,5 @@ import {ObjectId} from "@mikro-orm/mongodb";
 export class User {
   @PrimaryKey()
   @Property()
-  _id: ObjectId;
+  _id!: ObjectId;
 }

--- a/packages/orm/mikro-orm/test/helpers/services/UserService.ts
+++ b/packages/orm/mikro-orm/test/helpers/services/UserService.ts
@@ -5,11 +5,11 @@ import {MikroORM} from "@mikro-orm/core";
 @Injectable()
 export class UserService {
   @Connection()
-  connection: MikroORM;
+  connection!: MikroORM;
 
   @Connection("db1")
-  connection1: MikroORM;
+  connection1!: MikroORM;
 
   @Connection("db2")
-  connection2: MikroORM;
+  connection2!: MikroORM;
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No


## Usage example

To begin, you need to implement the `RetryStrategy` interface and use `registerProvider` to register it in the IoC container. Below you can find an example to handle occurred optimistic locks based on [an exponential backoff retry strategy](https://en.wikipedia.org/wiki/Exponential_backoff).  

`ExponentialBackoff` invokes passed function recursively is contained in a try/catch block. The method returns control to the interceptor if the call to the `task` function succeeds without throwing an exception. If the `task` method fails, the catch block examines the reason for the failure. If it's optimistic locking the code waits for a short delay before retrying the operation.

```typescript
import { OptimisticLockError } from '@mikro-orm/core';
import { RetryStrategy } from '@tsed/mikro-orm';

export interface ExponentialBackoffOptions {
  maxDepth: number;
}

export class ExponentialBackoff implements RetryStrategy {
  private depth = 0;

  constructor(private readonly options: ExponentialBackoffOptions) {}

  public async acquire<T extends (...args: unknown[]) => unknown>(
    task: T
  ): Promise<ReturnType<T>> {
    try {
      return (await task()) as ReturnType<T>;
    } catch (e) {
      if (
        this.shouldRetry(e as Error) &&
        this.depth < this.options.maxDepth
      ) {
        return this.retry(task);
      }

      throw e;
    }
  }

  private shouldRetry(error: Error): boolean {
    return error instanceof OptimisticLockError;
  }

  private async retry<T extends (...args: unknown[]) => unknown>(
    task: T
  ): Promise<ReturnType<T>> {
    await this.sleep(2 ** this.depth * 50);

    this.depth += 1;

    return this.acquire(task);
  }

  private sleep(milliseconds: number): Promise<void> {
    return new Promise(resolve => setTimeout(resolve, milliseconds));
  }
}

registerProvider({
  provide: RetryStrategy,
  useClass: ExponentialBackoff
});
```

Once it is done, you can enable an automatic retry mechanism using the `@Transactional` decoratory  like that:

```typescript
import {Controller, Post, BodyParams, Inject, Get} from "@tsed/common";
import {Transactional} from "@tsed/mikro-orm";

@Controller("/users")
export class UsersCtrl {
  @Inject()
  private usersService: UsersService;

  @Post("/")
  @Transactional({retry: true})
  create(@BodyParams() user: User): Promise<User> {
    return this.usersService.create(user);
  }

  @Get("/")
  getList(): Promise<User[]> {
    return this.usersService.find();
  }
}
```


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation

closes #1696
todo: the IoC container should provide `null` or `undefined` for the `RetryStrategy` interface by default until #1694 is closed