### PR TITLE
ci: prevent `benchmarks` job for running on an action for fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Run benchmarks
         run: yarn benchmarks
       - uses: actions/github-script@v4
+        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Chore | No

****

See details in actions/github-script#42

