### PR TITLE
fix(schema): `schema` can be null in `mapNullableType`

### DIFF
--- a/packages/specs/schema/src/utils/mapNullableType.ts
+++ b/packages/specs/schema/src/utils/mapNullableType.ts
@@ -7,8 +7,8 @@ function hasNullable(obj: any) {
   return obj.oneOf.find((o: any) => o.type === "null");
 }
 
-export function mapNullableType(obj: any, schema: JsonSchema, options: JsonSchemaOptions) {
-  if (!schema.isNullable) {
+export function mapNullableType(obj: any, schema: JsonSchema | null, options: JsonSchemaOptions) {
+  if (!schema?.isNullable) {
     return obj;
   }
   let types: string[] = [].concat(obj.type).filter(Boolean);


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix| No

****


## The problem and fix
This PR fixes the below error I'm receiving when sending the following request body.

<details>
	<summary>
show request
	</summary>

```json
{"type":"ARREST_REPORT","citizenId":"ckygxvp6t0551cqo6xt9zxcpw","citizenName":"john doe","violations":[{"penalCodeId":"ckygy7p7b0159jmo63x9xjdv7","bail":null,"jailTime":501,"fine":null}],"postal":"42042","notes":""}
```	

</details>

<details>
	<summary>
show response error
	</summary>

```txt
name	"TypeError"
message	"Cannot read properties of null (reading 'isNullable')"
status	500
errors	[]
stack	"TypeError: Cannot read properties of null (reading 'isNullable')
 at mapNullableType (/srv/api/node_modules/@tsed/schema/src/utils/mapNullableType.ts:11:15)
 at /srv/api/node_modules/@tsed/schema/src/components/objectMapper.ts:26:35
 at Array.reduce (<anonymous>)
 at objectMapper (/srv/api/node_modules/@tsed/schema/src/components/objectMapper.ts:17:32)
 at execMapper (/srv/api/node_modules/@tsed/schema/src/registries/JsonSchemaMapperContainer.ts:35:35)
 at anyMapper (/srv/api/node_modules/@tsed/schema/src/components/anyMapper.ts:22:20)
 at execMapper (/srv/api/node_modules/@tsed/schema/src/registries/JsonSchemaMapperContainer.ts:35:35)
 at itemMapper (/srv/api/node_modules/@tsed/schema/src/components/itemMapper.ts:5:83)
 at execMapper (/srv/api/node_modules/@tsed/schema/src/registries/JsonSchemaMapperContainer.ts:35:35)
 at /srv/api/node_modules/@tsed/schema/src/components/objectMapper.ts:25:30
```


</details>



## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
