### PR TITLE
Feat dynamic protocol settings

### DIFF
--- a/docs/tutorials/passport.md
+++ b/docs/tutorials/passport.md
@@ -99,7 +99,7 @@ Here is an example with the PassportLocal:
   
 <<< @/tutorials/snippets/passport/LoginLocalProtocol.spec.ts
 
-  </Tab>  
+  </Tab>
 </Tabs>  
 
 ::: tip

--- a/docs/tutorials/snippets/passport/LoginLocalProtocol.ts
+++ b/docs/tutorials/snippets/passport/LoginLocalProtocol.ts
@@ -1,6 +1,7 @@
 import {Req} from "@tsed/common";
+import {Inject} from "@tsed/di";
 import {BodyParams} from "@tsed/platform-params";
-import {OnInstall, OnVerify, Protocol} from "@tsed/passport";
+import {BeforeInstall, OnInstall, OnVerify, Protocol} from "@tsed/passport";
 import {IStrategyOptions, Strategy} from "passport-local";
 import {Credentials} from "../models/Credentials";
 import {UsersService} from "../services/users/UsersService";
@@ -14,14 +15,26 @@ import {UsersService} from "../services/users/UsersService";
     passwordField: "password"
   }
 })
-export class LoginLocalProtocol implements OnVerify, OnInstall {
-  constructor(private usersService: UsersService) {
+export class LoginLocalProtocol implements OnVerify, OnInstall, BeforeInstall {
+  @Inject()
+  private usersService: UsersService;
+
+  // hook added with v6.99.0
+  async $beforeInstall(settings: IStrategyOptions): Promise<IStrategyOptions> {
+    // load something from backend
+    // settings.usernameField = await this.usersService.loadFieldConfiguration()
+
+    return settings
+  }
+
+  $onInstall(strategy: Strategy): void {
+    // intercept the strategy instance to adding extra configuration
   }
 
   async $onVerify(@Req() request: Req, @BodyParams() credentials: Credentials) {
-    const {email, password} = credentials;
+    const { email, password } = credentials;
 
-    const user = await this.usersService.findOne({email});
+    const user = await this.usersService.findOne({ email });
 
     if (!user) {
       return false;
@@ -34,9 +47,5 @@ export class LoginLocalProtocol implements OnVerify, OnInstall {
     }
 
     return user;
-  }
-
-  $onInstall(strategy: Strategy): void {
-    // intercept the strategy instance to adding extra configuration
   }
 }

--- a/packages/security/jwks/jest.config.js
+++ b/packages/security/jwks/jest.config.js
@@ -1,0 +1,14 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  ...require("@tsed/jest-config")(__dirname, "jwk"),
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 85.71,
+      functions: 100,
+      lines: 100
+    }
+  }
+};

--- a/packages/security/jwks/package.json
+++ b/packages/security/jwks/package.json
@@ -15,6 +15,7 @@
     "build": "yarn run build:esm && yarn run build:cjs",
     "build:cjs": "tsc --build tsconfig.compile.json",
     "build:esm": "tsc --build tsconfig.compile.esm.json",
+    "test": "cross-env NODE_ENV=test yarn jest --max-workers=2",
     "start": "ts-node -r tsconfig-paths/register test/app/index.ts"
   },
   "dependencies": {

--- a/packages/security/jwks/src/getJwks.spec.ts
+++ b/packages/security/jwks/src/getJwks.spec.ts
@@ -1,4 +1,3 @@
-import {expect} from "chai";
 import {removeSync} from "fs-extra";
 import {join} from "path";
 import {generateJwks, getJwks} from "./getJwks";
@@ -13,7 +12,7 @@ describe("GetJwks", () => {
     it("should generate Jwks keys without certificates", async () => {
       const output = await generateJwks();
 
-      expect(output.keys.length).to.deep.eq(3);
+      expect(output.keys.length).toEqual(3);
     });
     it("should generateJwks keys from certificates", async () => {
       const output = await generateJwks({
@@ -25,7 +24,7 @@ describe("GetJwks", () => {
         ]
       });
 
-      expect(output).to.deep.eq({
+      expect(output).toEqual({
         keys: [
           {
             alg: "RS256",
@@ -55,7 +54,7 @@ describe("GetJwks", () => {
         path: join(rootDir, "generated", "keys.json")
       });
 
-      expect(output.keys.length).to.deep.eq(3);
+      expect(output.keys.length).toEqual(3);
     });
   });
 });

--- a/packages/security/passport/jest.config.js
+++ b/packages/security/passport/jest.config.js
@@ -1,0 +1,14 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  ...require("@tsed/jest-config")(__dirname, "passport"),
+  coverageThreshold: {
+    global: {
+      statements: 99.36,
+      branches: 80.7,
+      functions: 100,
+      lines: 99.32
+    }
+  }
+};

--- a/packages/security/passport/package.json
+++ b/packages/security/passport/package.json
@@ -15,6 +15,7 @@
     "build": "yarn run build:esm && yarn run build:cjs",
     "build:cjs": "tsc --build tsconfig.compile.json",
     "build:esm": "tsc --build tsconfig.compile.esm.json",
+    "test": "cross-env NODE_ENV=test yarn jest --max-workers=2",
     "start": "ts-node src/index.ts"
   },
   "dependencies": {

--- a/packages/security/passport/src/PassportModule.ts
+++ b/packages/security/passport/src/PassportModule.ts
@@ -28,12 +28,13 @@ export class PassportModule implements OnInit, BeforeRoutesInit {
     private passportSerializer: PassportSerializerService
   ) {}
 
-  $onInit(): Promise<any> | void {
+  async $onInit(): Promise<any> {
     Passport.serializeUser(this.passportSerializer.serialize.bind(this.passportSerializer));
     Passport.deserializeUser(this.passportSerializer.deserialize.bind(this.passportSerializer));
 
-    this.protocolsService.getProtocols().forEach((provider: Provider<any>) => this.protocolsService.invoke(provider));
+    const promises = this.protocolsService.getProtocols().map((provider: Provider) => this.protocolsService.invoke(provider));
 
+    await Promise.all(promises);
     return undefined;
   }
 

--- a/packages/security/passport/src/decorators/args.spec.ts
+++ b/packages/security/passport/src/decorators/args.spec.ts
@@ -1,4 +1,3 @@
-import {expect} from "chai";
 import {ParamTypes} from "@tsed/common";
 import {Arg, Args} from "./args";
 import {JsonParameterStore} from "@tsed/schema";
@@ -10,8 +9,8 @@ describe("@Args", () => {
     }
 
     const param = JsonParameterStore.get(Ctrl, "test", 0);
-    expect(param.expression).to.eq("PROTOCOL_ARGS");
-    expect(param.paramType).to.eq(ParamTypes.$CTX);
+    expect(param.expression).toBe("PROTOCOL_ARGS");
+    expect(param.paramType).toBe(ParamTypes.$CTX);
   });
 });
 
@@ -22,7 +21,7 @@ describe("@Arg", () => {
     }
 
     const param = JsonParameterStore.get(Ctrl, "test", 0);
-    expect(param.expression).to.eq("PROTOCOL_ARGS.0");
-    expect(param.paramType).to.eq(ParamTypes.$CTX);
+    expect(param.expression).toBe("PROTOCOL_ARGS.0");
+    expect(param.paramType).toBe(ParamTypes.$CTX);
   });
 });

--- a/packages/security/passport/src/decorators/authenticate.spec.ts
+++ b/packages/security/passport/src/decorators/authenticate.spec.ts
@@ -1,5 +1,4 @@
 import {Store} from "@tsed/core";
-import {expect} from "chai";
 import {Authenticate, PassportMiddleware} from "../index";
 
 describe("@Authenticate", () => {
@@ -15,7 +14,7 @@ describe("@Authenticate", () => {
 
     const store = Store.fromMethod(Test, "test");
 
-    expect(store.get(PassportMiddleware)).to.deep.equal({
+    expect(store.get(PassportMiddleware)).toEqual({
       method: "authenticate",
       options: {
         security: {
@@ -39,7 +38,7 @@ describe("@Authenticate", () => {
 
     const store = Store.fromMethod(Test, "test");
 
-    expect(store.get(PassportMiddleware)).to.deep.equal({
+    expect(store.get(PassportMiddleware)).toEqual({
       method: "authenticate",
       options: {
         security: {

--- a/packages/security/passport/src/decorators/authorize.spec.ts
+++ b/packages/security/passport/src/decorators/authorize.spec.ts
@@ -1,5 +1,4 @@
 import {Store} from "@tsed/core";
-import {expect} from "chai";
 import {Authorize, PassportMiddleware} from "../index";
 
 describe("@Authorize", () => {
@@ -15,7 +14,7 @@ describe("@Authorize", () => {
 
     const store = Store.fromMethod(Test, "test");
 
-    expect(store.get(PassportMiddleware)).to.deep.equal({
+    expect(store.get(PassportMiddleware)).toEqual({
       method: "authorize",
       options: {
         security: {
@@ -39,7 +38,7 @@ describe("@Authorize", () => {
 
     const store = Store.fromMethod(Test, "test");
 
-    expect(store.get(PassportMiddleware)).to.deep.equal({
+    expect(store.get(PassportMiddleware)).toEqual({
       method: "authorize",
       options: {
         security: {

--- a/packages/security/passport/src/interfaces/BeforeInstall.ts
+++ b/packages/security/passport/src/interfaces/BeforeInstall.ts
@@ -1,0 +1,3 @@
+export interface BeforeInstall<Settings = any> {
+  $beforeInstall(setting: Settings): Promise<Settings> | Settings | void;
+}

--- a/packages/security/passport/src/interfaces/IProtocol.ts
+++ b/packages/security/passport/src/interfaces/IProtocol.ts
@@ -1,4 +1,0 @@
-import {OnInstall} from "./OnInstall";
-import {OnVerify} from "./OnVerify";
-
-export interface IProtocol extends OnVerify, OnInstall {}

--- a/packages/security/passport/src/interfaces/OnInstall.ts
+++ b/packages/security/passport/src/interfaces/OnInstall.ts
@@ -1,5 +1,5 @@
 import {Strategy} from "passport";
 
 export interface OnInstall {
-  $onInstall(strategy: Strategy): void;
+  $onInstall(strategy: Strategy): void | Promise<void>;
 }

--- a/packages/security/passport/src/interfaces/ProtocolMethods.ts
+++ b/packages/security/passport/src/interfaces/ProtocolMethods.ts
@@ -1,0 +1,9 @@
+import {OnInstall} from "./OnInstall";
+import {OnVerify} from "./OnVerify";
+import {BeforeInstall} from "./BeforeInstall";
+
+/**
+ * @deprecated Use ProtocolMethods instead
+ */
+export interface IProtocol<Settings = any> extends OnVerify, OnInstall, BeforeInstall<Settings> {}
+export interface ProtocolMethods<Settings = any> extends OnVerify, OnInstall, BeforeInstall<Settings> {}

--- a/packages/security/passport/src/interfaces/ProtocolOptions.ts
+++ b/packages/security/passport/src/interfaces/ProtocolOptions.ts
@@ -1,8 +1,8 @@
 import {Type} from "@tsed/core";
 import {Strategy} from "passport";
 
-export interface ProtocolOptions<T = any> {
+export interface ProtocolOptions<Settings = any> {
   name: string;
   useStrategy: Type<Strategy>;
-  settings: T;
+  settings: Settings;
 }

--- a/packages/security/passport/src/interfaces/index.ts
+++ b/packages/security/passport/src/interfaces/index.ts
@@ -17,6 +17,7 @@ declare global {
 }
 
 export * from "./ProtocolOptions";
-export * from "./IProtocol";
+export * from "./ProtocolMethods";
 export * from "./OnInstall";
 export * from "./OnVerify";
+export * from "./BeforeInstall";

--- a/packages/security/passport/src/services/PassportSerializerService.spec.ts
+++ b/packages/security/passport/src/services/PassportSerializerService.spec.ts
@@ -1,5 +1,4 @@
 import {PlatformTest} from "@tsed/common";
-import {expect} from "chai";
 import {PassportSerializerService, UserInfo} from "../index";
 
 describe("PassportSerializerService", () => {
@@ -17,7 +16,7 @@ describe("PassportSerializerService", () => {
 
       const result = await new Promise((resolve) => service.serialize(userInfo, (...args: any[]) => resolve(args)));
 
-      expect(result).to.deep.eq([null, '{"id":"id","email":"email@email.fr"}']);
+      expect(result).toEqual([null, '{"id":"id","email":"email@email.fr"}']);
     })
   );
 
@@ -28,7 +27,7 @@ describe("PassportSerializerService", () => {
         service.deserialize('{"id":"id","email":"email@email.fr"}', (...args: any[]) => resolve(args))
       );
 
-      expect(result).to.deep.eq([
+      expect(result).toEqual([
         null,
         {
           email: "email@email.fr",
@@ -45,7 +44,7 @@ describe("PassportSerializerService", () => {
         service.deserialize('{"id":"id","email":"email@email.fr}', (...args: any[]) => resolve(args))
       );
 
-      expect(result[0].message).to.deep.eq("Unexpected end of JSON input");
+      expect(result[0].message).toEqual("Unexpected end of JSON input");
     })
   );
 });

--- a/packages/security/passport/src/services/ProtocolsService.spec.ts
+++ b/packages/security/passport/src/services/ProtocolsService.spec.ts
@@ -1,13 +1,9 @@
 import {PlatformTest, Req} from "@tsed/common";
-import {expect} from "chai";
 import Passport from "passport";
-import Sinon from "sinon";
-import {stub} from "../../../../../test/helper/tools";
 import {Protocol, ProtocolsService} from "../index";
 
-const sandbox = Sinon.createSandbox();
 // tslint:disable-next-line:variable-name
-const Strategy = Sinon.stub();
+const Strategy = jest.fn();
 
 describe("ProtocolsService", () => {
   @Protocol({
@@ -47,15 +43,11 @@ describe("ProtocolsService", () => {
   afterEach(PlatformTest.reset);
 
   beforeEach(() => {
-    sandbox.stub(LocalProtocol.prototype, "$onInstall");
-    sandbox.stub(LocalProtocol.prototype, "$onVerify");
-    sandbox.spy(LocalProtocol.prototype, "$beforeInstall");
-    sandbox.stub(Passport, "use");
-    Strategy.resetHistory();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
+    jest.spyOn(LocalProtocol.prototype, "$onInstall");
+    jest.spyOn(LocalProtocol.prototype, "$onVerify");
+    jest.spyOn(LocalProtocol.prototype, "$beforeInstall");
+    jest.spyOn(Passport, "use").mockReturnValue(undefined as any);
+    Strategy.mockReset();
   });
 
   it("should create a protocol", async () => {
@@ -67,50 +59,50 @@ describe("ProtocolsService", () => {
     const result = await protocolService.invoke(provider);
 
     // THEN
-    expect(result).to.be.instanceof(LocalProtocol);
-    expect(result.$onInstall).to.have.been.calledWithExactly(protocolService.strategies.get("local"));
-    expect(result.$beforeInstall).to.have.been.calledWithExactly({
+    expect(result).toBeInstanceOf(LocalProtocol);
+    expect(result.$onInstall).toHaveBeenCalledWith(protocolService.strategies.get("local"));
+    expect(result.$beforeInstall).toHaveBeenCalledWith({
       passReqToCallback: true,
       prop1: "prop1",
       prop2: "prop2-server",
       prop3: "prop3"
     });
-    expect(Passport.use).to.have.been.calledWithExactly("local", protocolService.strategies.get("local"));
-    expect(Strategy).to.have.been.calledWithExactly(
+    expect(Passport.use).toHaveBeenCalledWith("local", protocolService.strategies.get("local"));
+    expect(Strategy).toHaveBeenCalledWith(
       {
         passReqToCallback: true,
         prop1: "prop1",
         prop2: "prop2-server",
         prop3: "prop3"
       },
-      Sinon.match.func
+      expect.any(Function)
     );
-    expect(protocolService.getProtocolsNames().includes("local")).to.deep.equal(true);
+    expect(protocolService.getProtocolsNames().includes("local")).toEqual(true);
   });
 
   it("should call metadata", async () => {
     const protocolService = PlatformTest.get<ProtocolsService>(ProtocolsService);
     // GIVEN
-    stub(LocalProtocol.prototype.$onVerify).returns({id: 0});
+    (LocalProtocol.prototype.$onVerify as any).mockReturnValue({id: 0});
     const provider = PlatformTest.injector.getProvider(LocalProtocol)!;
     const ctx = PlatformTest.createRequestContext();
 
     // WHEN
     const result = await protocolService.invoke(provider);
     const resultDone: any = await new Promise((resolve) => {
-      Strategy.args[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
+      Strategy.mock.calls[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
     });
 
     // THEN
-    expect(result.$onVerify).to.have.been.calledWithExactly(ctx.getRequest(), ctx);
-    expect(resultDone).to.deep.equal([null, {id: 0}]);
+    expect(result.$onVerify).toHaveBeenCalledWith(ctx.getRequest(), ctx);
+    expect(resultDone).toEqual([null, {id: 0}]);
   });
 
   it("should call metadata and catch error", async () => {
     const protocolService = PlatformTest.get<ProtocolsService>(ProtocolsService);
     // GIVEN
     const error = new Error("message");
-    stub(LocalProtocol.prototype.$onVerify).rejects(error);
+    (LocalProtocol.prototype.$onVerify as any).mockRejectedValue(error);
 
     const provider = PlatformTest.injector.getProvider(LocalProtocol)!;
     const ctx = PlatformTest.createRequestContext();
@@ -118,11 +110,11 @@ describe("ProtocolsService", () => {
     // WHEN
     const result = await protocolService.invoke(provider);
     const resultDone: any = await new Promise((resolve) => {
-      Strategy.args[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
+      Strategy.mock.calls[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
     });
 
     // THEN
-    expect(result.$onVerify).to.have.been.calledWithExactly(ctx.getRequest(), ctx);
-    expect(resultDone).to.deep.equal([error, false, {message: "message"}]);
+    expect(result.$onVerify).toHaveBeenCalledWith(ctx.getRequest(), ctx);
+    expect(resultDone).toEqual([error, false, {message: "message"}]);
   });
 });

--- a/packages/security/passport/src/services/ProtocolsService.spec.ts
+++ b/packages/security/passport/src/services/ProtocolsService.spec.ts
@@ -1,5 +1,4 @@
 import {PlatformTest, Req} from "@tsed/common";
-import {InjectorService} from "@tsed/di";
 import {expect} from "chai";
 import Passport from "passport";
 import Sinon from "sinon";
@@ -20,6 +19,10 @@ describe("ProtocolsService", () => {
     }
   })
   class LocalProtocol {
+    async $beforeInstall(settings: any) {
+      return settings;
+    }
+
     $onInstall() {}
 
     $onVerify(@Req() req: Req) {
@@ -46,6 +49,7 @@ describe("ProtocolsService", () => {
   beforeEach(() => {
     sandbox.stub(LocalProtocol.prototype, "$onInstall");
     sandbox.stub(LocalProtocol.prototype, "$onVerify");
+    sandbox.spy(LocalProtocol.prototype, "$beforeInstall");
     sandbox.stub(Passport, "use");
     Strategy.resetHistory();
   });
@@ -54,71 +58,71 @@ describe("ProtocolsService", () => {
     sandbox.restore();
   });
 
-  it(
-    "should create a protocol",
-    PlatformTest.inject([ProtocolsService, InjectorService], (protocolService: ProtocolsService, injector: InjectorService) => {
-      // GIVEN
-      const provider = injector.getProvider(LocalProtocol)!;
+  it("should create a protocol", async () => {
+    const protocolService = PlatformTest.get<ProtocolsService>(ProtocolsService);
+    // GIVEN
+    const provider = PlatformTest.injector.getProvider(LocalProtocol)!;
 
-      // WHEN
-      const result = protocolService.invoke(provider);
+    // WHEN
+    const result = await protocolService.invoke(provider);
 
-      // THEN
-      expect(result).to.be.instanceof(LocalProtocol);
-      expect(result.$onInstall).to.have.been.calledWithExactly(protocolService.strategies.get("local"));
-      expect(Passport.use).to.have.been.calledWithExactly("local", protocolService.strategies.get("local"));
-      expect(Strategy).to.have.been.calledWithExactly(
-        {
-          passReqToCallback: true,
-          prop1: "prop1",
-          prop2: "prop2-server",
-          prop3: "prop3"
-        },
-        Sinon.match.func
-      );
-      expect(protocolService.getProtocolsNames().includes("local")).to.deep.equal(true);
-    })
-  );
+    // THEN
+    expect(result).to.be.instanceof(LocalProtocol);
+    expect(result.$onInstall).to.have.been.calledWithExactly(protocolService.strategies.get("local"));
+    expect(result.$beforeInstall).to.have.been.calledWithExactly({
+      passReqToCallback: true,
+      prop1: "prop1",
+      prop2: "prop2-server",
+      prop3: "prop3"
+    });
+    expect(Passport.use).to.have.been.calledWithExactly("local", protocolService.strategies.get("local"));
+    expect(Strategy).to.have.been.calledWithExactly(
+      {
+        passReqToCallback: true,
+        prop1: "prop1",
+        prop2: "prop2-server",
+        prop3: "prop3"
+      },
+      Sinon.match.func
+    );
+    expect(protocolService.getProtocolsNames().includes("local")).to.deep.equal(true);
+  });
 
-  it(
-    "should call metadata",
-    PlatformTest.inject([ProtocolsService, InjectorService], async (protocolService: ProtocolsService, injector: InjectorService) => {
-      // GIVEN
-      stub(LocalProtocol.prototype.$onVerify).returns({id: 0});
-      const provider = injector.getProvider(LocalProtocol)!;
-      const ctx = PlatformTest.createRequestContext();
+  it("should call metadata", async () => {
+    const protocolService = PlatformTest.get<ProtocolsService>(ProtocolsService);
+    // GIVEN
+    stub(LocalProtocol.prototype.$onVerify).returns({id: 0});
+    const provider = PlatformTest.injector.getProvider(LocalProtocol)!;
+    const ctx = PlatformTest.createRequestContext();
 
-      // WHEN
-      const result = protocolService.invoke(provider);
-      const resultDone: any = await new Promise((resolve) => {
-        Strategy.args[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
-      });
+    // WHEN
+    const result = await protocolService.invoke(provider);
+    const resultDone: any = await new Promise((resolve) => {
+      Strategy.args[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
+    });
 
-      // THEN
-      expect(result.$onVerify).to.have.been.calledWithExactly(ctx.getRequest(), ctx);
-      expect(resultDone).to.deep.equal([null, {id: 0}]);
-    })
-  );
+    // THEN
+    expect(result.$onVerify).to.have.been.calledWithExactly(ctx.getRequest(), ctx);
+    expect(resultDone).to.deep.equal([null, {id: 0}]);
+  });
 
-  it(
-    "should call metadata and catch error",
-    PlatformTest.inject([ProtocolsService, InjectorService], async (protocolService: ProtocolsService, injector: InjectorService) => {
-      // GIVEN
-      const error = new Error("message");
-      stub(LocalProtocol.prototype.$onVerify).rejects(error);
+  it("should call metadata and catch error", async () => {
+    const protocolService = PlatformTest.get<ProtocolsService>(ProtocolsService);
+    // GIVEN
+    const error = new Error("message");
+    stub(LocalProtocol.prototype.$onVerify).rejects(error);
 
-      const provider = injector.getProvider(LocalProtocol)!;
-      const ctx = PlatformTest.createRequestContext();
+    const provider = PlatformTest.injector.getProvider(LocalProtocol)!;
+    const ctx = PlatformTest.createRequestContext();
 
-      // WHEN
-      const result = protocolService.invoke(provider);
-      const resultDone: any = await new Promise((resolve) => {
-        Strategy.args[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
-      });
+    // WHEN
+    const result = await protocolService.invoke(provider);
+    const resultDone: any = await new Promise((resolve) => {
+      Strategy.args[0][1](ctx.getRequest(), "test", (...args: any[]) => resolve(args));
+    });
 
-      // THEN
-      expect(result.$onVerify).to.have.been.calledWithExactly(ctx.getRequest(), ctx);
-      expect(resultDone).to.deep.equal([error, false, {message: "message"}]);
-    })
-  );
+    // THEN
+    expect(result.$onVerify).to.have.been.calledWithExactly(ctx.getRequest(), ctx);
+    expect(resultDone).to.deep.equal([error, false, {message: "message"}]);
+  });
 });

--- a/packages/security/passport/src/utils/getProtocolsFromRequest.spec.ts
+++ b/packages/security/passport/src/utils/getProtocolsFromRequest.spec.ts
@@ -1,4 +1,3 @@
-import {expect} from "chai";
 import {getProtocolsFromRequest} from "./getProtocolsFromRequest";
 
 describe("getProtocolsFromRequest", () => {
@@ -7,7 +6,7 @@ describe("getProtocolsFromRequest", () => {
     const req = {};
     const result = getProtocolsFromRequest(req, "*", defaultProtocols);
 
-    expect(result).to.deep.equal(["default"]);
+    expect(result).toEqual(["default"]);
   });
 
   it("should allow all protocol (from default protocols - array)", () => {
@@ -15,7 +14,7 @@ describe("getProtocolsFromRequest", () => {
     const req = {};
     const result = getProtocolsFromRequest(req, ["*"], defaultProtocols);
 
-    expect(result).to.deep.equal(["default"]);
+    expect(result).toEqual(["default"]);
   });
 
   it("should return providers", () => {
@@ -23,7 +22,7 @@ describe("getProtocolsFromRequest", () => {
     const req = {};
     const result = getProtocolsFromRequest(req, ["basic", "local"], defaultProtocols);
 
-    expect(result).to.deep.equal(["basic", "local"]);
+    expect(result).toEqual(["basic", "local"]);
   });
 
   it("should get protocol from request (params)", () => {
@@ -35,7 +34,7 @@ describe("getProtocolsFromRequest", () => {
     };
     const result = getProtocolsFromRequest(req, ":protocol", defaultProtocols);
 
-    expect(result).to.deep.equal(["basic"]);
+    expect(result).toEqual(["basic"]);
   });
 
   it("should not get protocol from request", () => {
@@ -45,7 +44,7 @@ describe("getProtocolsFromRequest", () => {
     };
     const result = getProtocolsFromRequest(req, ":protocol", defaultProtocols);
 
-    expect(result).to.deep.equal([]);
+    expect(result).toEqual([]);
   });
 
   it("should get protocol from request (query)", () => {
@@ -57,7 +56,7 @@ describe("getProtocolsFromRequest", () => {
     };
     const result = getProtocolsFromRequest(req, ":protocol", defaultProtocols);
 
-    expect(result).to.deep.equal(["basic"]);
+    expect(result).toEqual(["basic"]);
   });
 
   it("should get protocol from request (body)", () => {
@@ -69,7 +68,7 @@ describe("getProtocolsFromRequest", () => {
     };
     const result = getProtocolsFromRequest(req, ":protocol", defaultProtocols);
 
-    expect(result).to.deep.equal(["basic"]);
+    expect(result).toEqual(["basic"]);
   });
 
   it("should return basic protocol", () => {
@@ -81,7 +80,7 @@ describe("getProtocolsFromRequest", () => {
     };
     const result = getProtocolsFromRequest(req, "basic", defaultProtocols);
 
-    expect(result).to.deep.equal(["basic"]);
+    expect(result).toEqual(["basic"]);
   });
 
   it("should not return protocol when protocol doesn't match", () => {
@@ -93,6 +92,6 @@ describe("getProtocolsFromRequest", () => {
     };
     const result = getProtocolsFromRequest(req, "other", defaultProtocols);
 
-    expect(result).to.deep.equal([]);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/security/passport/test/passport.integration.spec.ts
+++ b/packages/security/passport/test/passport.integration.spec.ts
@@ -1,7 +1,6 @@
 import {PlatformTest} from "@tsed/common";
 import {PlatformExpress} from "@tsed/platform-express";
 import {PlatformTestUtils} from "@tsed/platform-test-utils";
-import {expect} from "chai";
 import SuperTest from "supertest";
 import {rootDir, Server} from "./app/Server";
 
@@ -27,13 +26,13 @@ describe("Passport", () => {
       password: "admin@tsed.io"
     }).expect(200);
 
-    expect(response.body.email).to.equal("admin@tsed.io");
+    expect(response.body.email).toBe("admin@tsed.io");
   });
 
   it("should throw bad request", async () => {
     const response = await request.post("/auth/login").send({}).expect(400);
 
-    expect(response.body).to.deep.equal({
+    expect(response.body).toEqual({
       "name": "AuthenticationError",
       "message": "Bad Request",
       "status": 400,

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -41,7 +41,9 @@ module.exports = (rootDir) => ({
     "^@tsed/mongoose$": fixPath(join(packageDir, "orm/mongoose/src")),
     "^@tsed/adapters-redis$": fixPath(join(packageDir, "orm/adapters-redis/src")),
     "^@tsed/schema-formio$": fixPath(join(packageDir, "third-parties/schema-formio/src")),
-    "^@tsed/components-scan$": fixPath(join(packageDir, "utils/components-scan/src"))
+    "^@tsed/components-scan$": fixPath(join(packageDir, "utils/components-scan/src")),
+    "^@tsed/passport$": fixPath(join(packageDir, "security/passport/src")),
+    "^@tsed/jwk$": fixPath(join(packageDir, "security/jwk/src"))
   },
   modulePathIgnorePatterns: ["<rootDir>/lib", "<rootDir>/dist"],
   // An object that configures minimum threshold enforcement for coverage results

--- a/tools/mocha/mocha.config.js
+++ b/tools/mocha/mocha.config.js
@@ -17,7 +17,7 @@ module.exports = () => ({
     "packages/orm/**/*.spec.ts",
     "packages/graphql/**/*.spec.ts",
     "packages/utils/**/*.spec.ts",
-    "packages/security/oidc-provider/**/*.spec.ts",
+    "packages/security/**/*.spec.ts",
     "packages/specs/schema/**/*.spec.ts",
     "packages/platform/platform-serverless/**/*.spec.ts",
     "packages/platform/platform-serverless-http/**/*.spec.ts",


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No

****


## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript

@Protocol<IStrategyOptions>({
  name: "login",
  useStrategy: Strategy,
  settings: {
    usernameField: "email",
    passwordField: "password"
  }
})
export class LoginLocalProtocol implements OnVerify, OnInstall, BeforeInstall {
  @Inject()
  private usersService: UsersService;

  // hook added with v6.99.0
  async $beforeInstall(settings: IStrategyOptions): Promise<IStrategyOptions> {
    // load something from backend
    settings.usernameField = await this.usersService.loadFieldConfiguration()

    return settings
  }
}
```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
