### PR TITLE
feat(mikro-orm): create `@Orm()` alias decorator

### DIFF
--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -77,37 +77,48 @@ export class Server {}
 
 The `mikroOrm` options accepts the same configuration object as `init()` from the MikroORM package. Check [this page](https://mikro-orm.io/docs/configuration) for the complete configuration documentation.
 
-## Obtain a connection
+## Obtain ORM instance
 
-`@Connection` decorator lets you retrieve an instance of MikroORM Connection.
+`@Orm` decorator lets you retrieve an instance of MikroOrm.
 
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
-import {Connection} from "@tsed/mikro-orm";
+import {Orm} from "@tsed/mikro-orm";
 import {MikroORM} from "@mikro-orm/core";
 
 @Injectable()
 export class UsersService {
-  @Connection()
-  private readonly connection!: MikroORM;
+  @Orm()
+  private readonly orm!: MikroORM;
 
   async create(user: User): Promise<User> {
-
     // do something
     // ...
     // Then save
-    await this.connection.em.persistAndFlush(user);
+    await this.orm.em.persistAndFlush(user);
     console.log("Saved a new user with id: " + user.id);
 
     return user;
   }
 
   async find(): Promise<User[]> {
-    const users = await this.connection.em.find(User, {});
+    const users = await this.orm.em.find(User, {});
     console.log("Loaded users: ", users);
 
     return users;
   }
+}
+```
+
+It's also possible to inject an ORM by a connection name:
+
+```ts
+import {Injectable} from "@tsed/di";
+
+@Injectable()
+export class MyService {
+  @Orm("mongo")
+  private readonly orm!: MikroORM;
 }
 ```
 
@@ -167,22 +178,22 @@ import {Entity, Property, PrimaryKey, Property as Column} from "@mikro-orm/core"
 export class User {
   @PrimaryKey()
   @Property()
-  id: number;
+  id!: number;
 
   @Column()
   @MaxLength(100)
   @Required()
-  firstName: string;
+  firstName!: string;
 
   @Column()
   @MaxLength(100)
   @Required()
-  lastName: string;
+  lastName!: string;
 
   @Column()
   @Mininum(0)
   @Maximum(100)
-  age: number;
+  age!: number;
 }
 ```
 
@@ -198,7 +209,7 @@ import {Controller, Post, BodyParams, Inject, Post, Get} from "@tsed/common";
 @Controller("/users")
 export class UsersCtrl {
   @Inject()
-  private usersService: UsersService;
+  private readonly usersService!: UsersService;
 
   @Post("/")
   create(@BodyParams() user: User): Promise<User> {
@@ -227,7 +238,7 @@ import {Transactional} from "@tsed/mikro-orm";
 @Controller("/users")
 export class UsersCtrl {
   @Inject()
-  private usersService: UsersService;
+  private readonly usersService!: UsersService;
 
   @Post("/")
   @Transactional()
@@ -314,7 +325,7 @@ import {Transactional} from "@tsed/mikro-orm";
 @Controller("/users")
 export class UsersCtrl {
   @Inject()
-  private usersService: UsersService;
+  private readonly usersService!: UsersService;
 
   @Post("/")
   @Transactional({retry: true})

--- a/packages/orm/mikro-orm/jest.config.js
+++ b/packages/orm/mikro-orm/jest.config.js
@@ -6,9 +6,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 90.91,
-      functions: 100,
+      functions: 96.97,
       lines: 99.06,
-      statements: 99.21
+      statements: 98.54
     }
   }
 };

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -96,32 +96,32 @@ export class Server {}
 
 The `mikroOrm` options accepts the same configuration object as `init()` from the MikroORM package. Check [this page](https://mikro-orm.io/docs/configuration) for the complete configuration documentation.
 
-## Obtain a connection
+## Obtain ORM instance
 
-`@Connection` decorator lets you retrieve an instance of MikroOrm Connection.
+`@Orm` decorator lets you retrieve an instance of MikroOrm.
 
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
-import {Connection} from "@tsed/mikro-orm";
+import {Orm} from "@tsed/mikro-orm";
 import {MikroORM} from "@mikro-orm/core";
 
 @Injectable()
 export class UsersService {
-  @Connection()
-  private readonly connection!: MikroORM;
+  @Orm()
+  private readonly orm!: MikroORM;
 
   async create(user: User): Promise<User> {
     // do something
     // ...
     // Then save
-    await this.connection.em.persistAndFlush(user);
+    await this.orm.em.persistAndFlush(user);
     console.log("Saved a new user with id: " + user.id);
 
     return user;
   }
 
   async find(): Promise<User[]> {
-    const users = await this.connection.em.find(User, {});
+    const users = await this.orm.em.find(User, {});
     console.log("Loaded users: ", users);
 
     return users;
@@ -129,15 +129,15 @@ export class UsersService {
 }
 ```
 
-It's also possible to inject a connection by his name:
+It's also possible to inject an ORM by a connection name:
 
 ```ts
 import {Injectable} from "@tsed/di";
 
 @Injectable()
 export class MyService {
-  @Connection("mongo")
-  private readonly connection!: MikroORM;
+  @Orm("mongo")
+  private readonly orm!: MikroORM;
 }
 ```
 
@@ -195,25 +195,24 @@ import {Entity, Property, PrimaryKey, Property as Column} from "@mikro-orm/core"
 
 @Entity()
 export class User {
-
   @PrimaryKey()
   @Property()
-  id: number;
+  id!: number;
 
   @Column()
   @MaxLength(100)
   @Required()
-  firstName: string;
+  firstName!: string;
 
   @Column()
   @MaxLength(100)
   @Required()
-  lastName: string;
+  lastName!: string;
 
   @Column()
   @Mininum(0)
   @Maximum(100)
-  age: number;
+  age!: number;
 }
 ```
 
@@ -229,7 +228,7 @@ import {Controller, Post, BodyParams, Inject, Post, Get} from "@tsed/common";
 @Controller("/users")
 export class UsersCtrl {
   @Inject()
-  private usersService: UsersService;
+  private readonly usersService!: UsersService;
 
   @Post("/")
   create(@BodyParams() user: User): Promise<User> {
@@ -258,7 +257,7 @@ import {Transactional} from "@tsed/mikro-orm";
 @Controller("/users")
 export class UsersCtrl {
   @Inject()
-  private usersService: UsersService;
+  private readonly usersService!: UsersService;
 
   @Post("/")
   @Transactional()
@@ -345,7 +344,7 @@ import {Transactional} from "@tsed/mikro-orm";
 @Controller("/users")
 export class UsersCtrl {
   @Inject()
-  private usersService: UsersService;
+  private readonly usersService!: UsersService;
 
   @Post("/")
   @Transactional({retry: true})

--- a/packages/orm/mikro-orm/src/decorators/connection.ts
+++ b/packages/orm/mikro-orm/src/decorators/connection.ts
@@ -1,5 +1,0 @@
-import {MikroOrmRegistry} from "../services";
-import {Inject} from "@tsed/di";
-
-export const Connection = (connectionName?: string): PropertyDecorator =>
-  Inject(MikroOrmRegistry, (registry: MikroOrmRegistry) => registry.get(connectionName)) as PropertyDecorator;

--- a/packages/orm/mikro-orm/src/decorators/index.ts
+++ b/packages/orm/mikro-orm/src/decorators/index.ts
@@ -1,3 +1,3 @@
 export * from "./transactional";
-export * from "./connection";
+export * from "./orm";
 export * from "./entityManager";

--- a/packages/orm/mikro-orm/src/decorators/orm.ts
+++ b/packages/orm/mikro-orm/src/decorators/orm.ts
@@ -1,0 +1,10 @@
+import {MikroOrmRegistry} from "../services";
+import {Inject} from "@tsed/di";
+
+/**
+ * @deprecated Since 2022-02-01. Use {@link Orm} instead
+ */
+export const Connection = (contextName?: string): PropertyDecorator => Orm(contextName);
+
+export const Orm = (contextName?: string): PropertyDecorator =>
+  Inject(MikroOrmRegistry, (registry: MikroOrmRegistry) => registry.get(contextName)) as PropertyDecorator;

--- a/packages/orm/mikro-orm/test/helpers/services/UserService.ts
+++ b/packages/orm/mikro-orm/test/helpers/services/UserService.ts
@@ -1,17 +1,17 @@
 import {Injectable} from "@tsed/di";
 import {EntityManager, MikroORM} from "@mikro-orm/core";
-import {Connection, Em} from "../../../src";
+import {Orm, Em} from "../../../src";
 
 @Injectable()
 export class UserService {
-  @Connection()
-  connection!: MikroORM;
+  @Orm()
+  orm!: MikroORM;
 
-  @Connection("db1")
-  connection1!: MikroORM;
+  @Orm("db1")
+  orm1!: MikroORM;
 
-  @Connection("db2")
-  connection2!: MikroORM;
+  @Orm("db2")
+  orm2!: MikroORM;
 
   @Em()
   em!: EntityManager;

--- a/packages/orm/mikro-orm/test/integration.spec.ts
+++ b/packages/orm/mikro-orm/test/integration.spec.ts
@@ -42,16 +42,16 @@ describe("TypeORM integration", () => {
     const service = PlatformTest.injector.get<UserService>(UserService)!;
 
     expect(service).toBeInstanceOf(UserService);
-    expect(service.connection).toBeInstanceOf(MikroORM);
-    expect(service.connection.em.name).toBe("default");
+    expect(service.orm).toBeInstanceOf(MikroORM);
+    expect(service.orm.em.name).toBe("default");
     expect(service.em.name).toBe("default");
 
-    expect(service.connection1).toBeInstanceOf(MikroORM);
-    expect(service.connection1.em.name).toBe("db1");
+    expect(service.orm1).toBeInstanceOf(MikroORM);
+    expect(service.orm1.em.name).toBe("db1");
     expect(service.em1.name).toBe("db1");
 
-    expect(service.connection2).toBeInstanceOf(MikroORM);
-    expect(service.connection2.em.name).toBe("db2");
+    expect(service.orm2).toBeInstanceOf(MikroORM);
+    expect(service.orm2.em.name).toBe("db2");
     expect(service.em2.name).toBe("db2");
 
     expect(service.em3).toEqual(undefined);


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No

****

## Usage example

`@Connection()` decorator has been deprecated and aliased with a new `@Orm()` to align API with MikroORM naming convention.

See https://github.com/mikro-orm/mikro-orm/pull/2587

```ts
import {Injectable, AfterRoutesInit} from "@tsed/common";
import {Orm} from "@tsed/mikro-orm";
import {MikroORM} from "@mikro-orm/core";

@Injectable()
export class UsersService {
  @Orm()
  private readonly orm!: MikroORM;

  async create(user: User): Promise<User> {

    // do something
    // ...
    // Then save
    await this.orm.em.persistAndFlush(user);
    console.log("Saved a new user with id: " + user.id);

    return user;
  }

  async find(): Promise<User[]> {
    const users = await this.orm.em.find(User, {});
    console.log("Loaded users: ", users);

    return users;
  }
}

```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation

closes #1741

