### PR TITLE
feat(mikro-orm): rename all occurrences of connection

### DIFF
--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -14,7 +14,7 @@ meta:
 
 Currently, `@tsed/mikro-orm` allows you:
 
-- Configure one or more MikroORM connections via the `@Configuration` decorator. All databases will be initialized when
+- Configure one or more MikroORM instances via the `@Configuration` decorator. All databases will be initialized when
   the server starts during the server's `OnInit` phase.
 - Use the Entity MikroORM as Model for Controllers, AJV Validation and Swagger.
 
@@ -110,7 +110,7 @@ export class UsersService {
 }
 ```
 
-It's also possible to inject an ORM by a connection name:
+It's also possible to inject an ORM by its context name:
 
 ```ts
 import {Injectable} from "@tsed/di";
@@ -145,7 +145,7 @@ export class UsersService {
 }
 ```
 
-It's also possible to inject Entity manager by his connection name:
+It's also possible to inject Entity manager by his context name:
 
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
@@ -154,7 +154,7 @@ import {EntityManager} from '@mikro-orm/mysql'; // Import EntityManager from you
 
 @Injectable()
 export class UsersService {
-  @Em("connectionName")
+  @Em("contextName")
   private readonly em!: EntityManager;
 
   async create(user: User): Promise<User> {

--- a/packages/orm/mikro-orm/jest.config.js
+++ b/packages/orm/mikro-orm/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   ...require("@tsed/jest-config")(__dirname, "mikro-orm"),
   coverageThreshold: {
     global: {
-      branches: 90.91,
-      functions: 96.97,
-      lines: 99.06,
-      statements: 98.54
+      branches: 90.38,
+      functions: 91.43,
+      lines: 96.52,
+      statements: 97.1
     }
   }
 };

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -33,7 +33,7 @@ A package of Ts.ED framework. See website: https://tsed.io/tutorials/mikro-orm
 
 Currently, `@tsed/mikro-orm` allows you:
 
-- Configure one or more MikroOrm connections via the `@Configuration` decorator. All databases will be initialized
+- Configure one or more MikroOrm instances via the `@Configuration` decorator. All databases will be initialized
   when the server starts during the server's `OnInit` phase.
 - Use the Entity MikroOrm as Model for Controllers, AJV Validation and Swagger.
 
@@ -129,7 +129,7 @@ export class UsersService {
 }
 ```
 
-It's also possible to inject an ORM by a connection name:
+It's also possible to inject an ORM by its context name:
 
 ```ts
 import {Injectable} from "@tsed/di";
@@ -164,7 +164,7 @@ export class UsersService {
 }
 ```
 
-It's also possible to inject Entity manager by his connection name:
+It's also possible to inject Entity manager by his context name:
 
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
@@ -173,7 +173,7 @@ import {EntityManager} from '@mikro-orm/mysql'; // Import EntityManager from you
 
 @Injectable()
 export class UsersService {
-  @Em("connectionName")
+  @Em("contextName")
   private readonly em!: EntityManager;
 
   async create(user: User): Promise<User> {

--- a/packages/orm/mikro-orm/src/MikroOrmModule.spec.ts
+++ b/packages/orm/mikro-orm/src/MikroOrmModule.spec.ts
@@ -31,29 +31,29 @@ describe("MikroOrmModule", () => {
   });
 
   describe("$onInit", () => {
-    it("should create the corresponding connections", async () => {
+    it("should register the corresponding instances", async () => {
       // arrange
       const mikroOrmModule = PlatformTest.get<MikroOrmModule>(MikroOrmModule);
-      when(mockMikroOrmRegistry.createConnection(config)).thenResolve(({} as unknown) as MikroORM);
+      when(mockMikroOrmRegistry.register(config)).thenResolve(({} as unknown) as MikroORM);
 
       // act
       await mikroOrmModule.$onInit();
 
-      verify(mockMikroOrmRegistry.createConnection(deepEqual(config))).called();
+      verify(mockMikroOrmRegistry.register(deepEqual(config))).called();
     });
   });
 
   describe("$onDestroy", () => {
-    it("should destroy the corresponding connections", async () => {
+    it("should destroy the corresponding instances", async () => {
       // arrange
       const mikroOrmModule = PlatformTest.get<MikroOrmModule>(MikroOrmModule);
-      when(mockMikroOrmRegistry.closeConnections()).thenResolve();
+      when(mockMikroOrmRegistry.clear()).thenResolve();
 
       // act
       await mikroOrmModule.$onDestroy();
 
       // assert
-      verify(mockMikroOrmRegistry.closeConnections()).called();
+      verify(mockMikroOrmRegistry.clear()).called();
     });
   });
 });

--- a/packages/orm/mikro-orm/src/MikroOrmModule.ts
+++ b/packages/orm/mikro-orm/src/MikroOrmModule.ts
@@ -27,13 +27,13 @@ export class MikroOrmModule implements OnDestroy, OnInit {
   private readonly mikroOrmRegistry!: MikroOrmRegistry;
 
   public async $onInit(): Promise<void> {
-    const promises = this.settings.map((opts) => this.mikroOrmRegistry.createConnection(opts));
+    const promises = this.settings.map((opts) => this.mikroOrmRegistry.register(opts));
 
     await Promise.all(promises);
   }
 
   public $onDestroy(): Promise<void> {
-    return this.mikroOrmRegistry.closeConnections();
+    return this.mikroOrmRegistry.clear();
   }
 }
 

--- a/packages/orm/mikro-orm/src/decorators/entityManager.spec.ts
+++ b/packages/orm/mikro-orm/src/decorators/entityManager.spec.ts
@@ -1,0 +1,22 @@
+import {DecoratorTypes, Store} from "@tsed/core";
+import {Controller, INJECTABLE_PROP} from "@tsed/di";
+import {EntityManager} from "@tsed/mikro-orm";
+import {MongoEntityManager} from "@mikro-orm/mongodb";
+
+@Controller("/users")
+export class UsersCtrl {
+  @EntityManager()
+  public readonly em!: MongoEntityManager;
+}
+
+describe("@Orm", () => {
+  it("should decorate property", () => {
+    expect(Store.from(UsersCtrl).get(INJECTABLE_PROP)).toEqual({
+      em: {
+        propertyKey: "em",
+        bindingType: DecoratorTypes.PROP,
+        resolver: expect.any(Function)
+      }
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/decorators/entityManager.ts
+++ b/packages/orm/mikro-orm/src/decorators/entityManager.ts
@@ -2,17 +2,17 @@ import {Inject} from "@tsed/di";
 import {MikroOrmRegistry} from "../services";
 
 /**
- * Get the entity manager for the given connection name.
- * @param connectionName
+ * Get the entity manager for the given context name.
+ * @param {String} contextName
  * @decorator
  * @mikroOrm
  */
-export const EntityManager = (connectionName?: string): PropertyDecorator =>
-  Inject(MikroOrmRegistry, (registry: MikroOrmRegistry) => registry.get(connectionName)?.em) as PropertyDecorator;
+export const EntityManager = (contextName?: string): PropertyDecorator =>
+  Inject(MikroOrmRegistry, (registry: MikroOrmRegistry) => registry.get(contextName)?.em) as PropertyDecorator;
 
 /**
- * Get the entity manager for the given connection name.
- * @param connectionName
+ * Get the entity manager for the given context name.
+ * @param {String} connectionName
  * @decorator
  * @mikroOrm
  */

--- a/packages/orm/mikro-orm/src/decorators/orm.spec.ts
+++ b/packages/orm/mikro-orm/src/decorators/orm.spec.ts
@@ -1,0 +1,22 @@
+import {DecoratorTypes, Store} from "@tsed/core";
+import {Controller, INJECTABLE_PROP} from "@tsed/di";
+import {Orm} from "@tsed/mikro-orm";
+import {MikroORM} from "@mikro-orm/core";
+
+@Controller("/users")
+export class UsersCtrl {
+  @Orm()
+  public readonly orm!: MikroORM;
+}
+
+describe("@Orm", () => {
+  it("should decorate property", () => {
+    expect(Store.from(UsersCtrl).get(INJECTABLE_PROP)).toEqual({
+      orm: {
+        propertyKey: "orm",
+        bindingType: DecoratorTypes.PROP,
+        resolver: expect.any(Function)
+      }
+    });
+  });
+});

--- a/packages/orm/mikro-orm/src/decorators/orm.ts
+++ b/packages/orm/mikro-orm/src/decorators/orm.ts
@@ -2,9 +2,15 @@ import {MikroOrmRegistry} from "../services";
 import {Inject} from "@tsed/di";
 
 /**
- * @deprecated Since 2022-02-01. Use {@link Orm} instead
+ * Get the ORM for the given context name.
+ * @param {String} contextName
  */
-export const Connection = (contextName?: string): PropertyDecorator => Orm(contextName);
-
 export const Orm = (contextName?: string): PropertyDecorator =>
   Inject(MikroOrmRegistry, (registry: MikroOrmRegistry) => registry.get(contextName)) as PropertyDecorator;
+
+/**
+ * Get the ORM for the given context name.
+ * @param {String} contextName
+ * @deprecated Since 2022-02-01. Use {@link Orm} instead
+ */
+export const Connection = Orm;

--- a/packages/orm/mikro-orm/src/decorators/transactional.ts
+++ b/packages/orm/mikro-orm/src/decorators/transactional.ts
@@ -1,5 +1,9 @@
 import {TransactionalInterceptor, TransactionOptions} from "../interceptors";
 import {Intercept} from "@tsed/di";
 
-export const Transactional = (connectionOrOptions?: string | TransactionOptions): MethodDecorator =>
-  Intercept(TransactionalInterceptor, connectionOrOptions);
+/**
+ * Register a new request context for your method and execute it inside the context.
+ * @param {String | TransactionOptions} contextNameOrOptions
+ */
+export const Transactional = (contextNameOrOptions?: string | TransactionOptions): MethodDecorator =>
+  Intercept(TransactionalInterceptor, contextNameOrOptions);

--- a/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
+++ b/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.spec.ts
@@ -8,7 +8,9 @@ import {EntityManager, MikroORM, OptimisticLockError} from "@mikro-orm/core";
 describe("TransactionalInterceptor", () => {
   const mikroOrmRegistryMock = mock<MikroOrmRegistry>();
   const mikroOrm = mock(MikroORM);
-  const entityManagerMock = mock(EntityManager);
+  const entityManagerMock: EntityManager & {
+    fork(clearOrForkOptions?: boolean | {clear?: boolean; useContext?: boolean}, useContext?: boolean): EntityManager;
+  } = mock(EntityManager);
   const loggerMock = mock<Logger>();
   const retryStrategyMock = mock<RetryStrategy>();
   const dbContext = new DBContext();

--- a/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.ts
+++ b/packages/orm/mikro-orm/src/interceptors/TransactionalInterceptor.ts
@@ -57,7 +57,21 @@ export class TransactionalInterceptor implements InterceptorMethods {
       );
     }
 
-    const em = orm.em.fork(true, true);
+    /**
+     * The fork method signature has been changed since v5.x,
+     * which might lead to unexpected behavior while using the @Transactional() decorator.
+     *
+     * ```diff
+     * - fork(clear = true, useContext = false): D[typeof EntityManagerType]
+     * + fork(options: ForkOptions = {}): D[typeof EntityManagerType] {
+     * ```
+     *
+     * To ensure backward compatibility with v4.x and add support for v5.x, provided the following workaround:
+     */
+    const em = (orm.em.fork as (
+      clearOrForkOptions?: boolean | {clear?: boolean; useContext?: boolean},
+      useContext?: boolean
+    ) => EntityManager)({clear: true, useContext: true}, true);
 
     ctx.set(em.name, em);
 

--- a/packages/orm/mikro-orm/src/services/DBContent.spec.ts
+++ b/packages/orm/mikro-orm/src/services/DBContent.spec.ts
@@ -89,7 +89,7 @@ describe("DBContext", () => {
       const dbCtx = new DBContext();
 
       // act
-      const result = dbCtx.getContext();
+      const result = dbCtx.entries();
 
       // assert
       expect(result).toBeUndefined();
@@ -100,7 +100,7 @@ describe("DBContext", () => {
       const dbCtx = new DBContext();
       const store = new Map<string, EntityManager>();
       const callback = jest.fn().mockImplementation(() => {
-        const result = dbCtx.getContext();
+        const result = dbCtx.entries();
 
         // assert
         expect(result).toEqual(store);

--- a/packages/orm/mikro-orm/src/services/DBContext.ts
+++ b/packages/orm/mikro-orm/src/services/DBContext.ts
@@ -18,18 +18,25 @@ export class DBContext {
     return this.storage.run(ctx, callback);
   }
 
-  public getContext(): Map<string, EntityManager> | undefined {
+  public entries(): Map<string, EntityManager> | undefined {
     return this.storage.getStore();
   }
 
+  /**
+   * @deprecated Since 2022-02-01. Use {@link entries} instead
+   */
+  public getContext(): Map<string, EntityManager> | undefined {
+    return this.entries();
+  }
+
   public get(contextName: string): EntityManager | undefined {
-    const context = this.getContext();
+    const context = this.entries();
 
     return context?.get(contextName);
   }
 
   public has(contextName: string): boolean {
-    const context = this.getContext();
+    const context = this.entries();
 
     return !!context?.has(contextName);
   }

--- a/packages/orm/mikro-orm/src/services/MikroOrmFactory.ts
+++ b/packages/orm/mikro-orm/src/services/MikroOrmFactory.ts
@@ -7,9 +7,9 @@ export class MikroOrmFactory {
   @Inject()
   private readonly dbContext!: DBContext;
 
-  public create(connectionOptions: Options): Promise<MikroORM> {
+  public create(options: Options): Promise<MikroORM> {
     return MikroORM.init({
-      ...connectionOptions,
+      ...options,
       context: (name: string) => this.dbContext.get(name)
     });
   }

--- a/packages/orm/mikro-orm/test/helpers/entity/User.ts
+++ b/packages/orm/mikro-orm/test/helpers/entity/User.ts
@@ -7,4 +7,7 @@ export class User {
   @PrimaryKey()
   @Property()
   _id!: ObjectId;
+
+  @Property()
+  email!: string;
 }

--- a/packages/orm/mikro-orm/test/helpers/services/UserService.ts
+++ b/packages/orm/mikro-orm/test/helpers/services/UserService.ts
@@ -1,6 +1,7 @@
 import {Injectable} from "@tsed/di";
 import {EntityManager, MikroORM} from "@mikro-orm/core";
-import {Orm, Em} from "../../../src";
+import {Orm, Em, Transactional} from "../../../src";
+import {User} from '../entity/User';
 
 @Injectable()
 export class UserService {
@@ -24,4 +25,9 @@ export class UserService {
 
   @Em("db3")
   em3!: EntityManager;
+
+  @Transactional()
+  async create(data: { email: string }): Promise<User> {
+    return this.orm.em.create(User, data);
+  }
 }

--- a/packages/orm/mikro-orm/test/integration.spec.ts
+++ b/packages/orm/mikro-orm/test/integration.spec.ts
@@ -1,12 +1,13 @@
-import {PlatformTest} from "@tsed/common";
-import {TestMongooseContext} from "@tsed/testing-mongoose";
-import {User} from "./helpers/entity/User";
-import {Server} from "./helpers/Server";
-import {UserService} from "./helpers/services/UserService";
-import {MikroORM} from "@mikro-orm/core";
-import {MikroOrmModule} from "../src";
+import {PlatformTest} from '@tsed/common';
+import {TestMongooseContext} from '@tsed/testing-mongoose';
+import {User} from './helpers/entity/User';
+import {Server} from './helpers/Server';
+import {UserService} from './helpers/services/UserService';
+import {MikroORM} from '@mikro-orm/core';
+import {MikroOrmModule, TransactionalInterceptor} from '../src';
+import {anything, spy, verify} from 'ts-mockito';
 
-describe("TypeORM integration", () => {
+describe("MikroOrm integration", () => {
   beforeEach(async () => {
     await TestMongooseContext.install();
     const {url: clientUrl} = await TestMongooseContext.getMongooseOptions();
@@ -47,13 +48,23 @@ describe("TypeORM integration", () => {
     expect(service.em.name).toBe("default");
 
     expect(service.orm1).toBeInstanceOf(MikroORM);
-    expect(service.orm1.em.name).toBe("db1");
-    expect(service.em1.name).toBe("db1");
+    expect(service.orm1.em.name).toBe('db1');
+    expect(service.em1.name).toBe('db1');
 
     expect(service.orm2).toBeInstanceOf(MikroORM);
-    expect(service.orm2.em.name).toBe("db2");
-    expect(service.em2.name).toBe("db2");
+    expect(service.orm2.em.name).toBe('db2');
+    expect(service.em2.name).toBe('db2');
 
     expect(service.em3).toEqual(undefined);
+  });
+
+  it('should create a request context', async () => {
+    const service = PlatformTest.injector.get<UserService>(UserService)!;
+    const transactionalInterceptor = PlatformTest.injector.get<TransactionalInterceptor>(TransactionalInterceptor)!;
+    const spiedTransactionalInterceptor = spy(transactionalInterceptor);
+
+    await service.create({email: 'test@example.com'});
+
+    verify(spiedTransactionalInterceptor.intercept(anything(), anything())).once();
   });
 });


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No

****

As discussed in https://github.com/tsedio/tsed/pull/1742#issuecomment-1024934764, we should rename all occurrences of `connection` to satisfy the naming convention in MikroOrm. 

## Deprecations

* To register a new request context for the particular `MikroOrm` instance, use `TransactionOptions.contextName` since `TransactionOptions.connectionName` is deprecated.
* The `DbContext::getContext` method is deprecated, use `DbContext::entries` instead.
* The `MikroOrmRegistry::createConnection` method is deprecated, instead use `MikroOrmRegistry::register` to register a particular `MikroOrm` instance.
* The `MikroOrmRegistry::closeConnections` method is deprecated, instead use `MikroOrmRegistry::clear` to dispose registered `MikroOrm` instances and clear the registry.

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation

closes #1741
