### PR TITLE
style(mikro-orm): fix wording and formatting issues

### DIFF
--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -1,7 +1,7 @@
 ---
 meta:
  - name: description 
-   content: Use Mikro ORM with Ts.ED. TypeScript ORM for Node.js based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, MySQL, MariaDB, PostgreSQL and SQLite databases..
+   content: Use MikroORM with Ts.ED. TypeScript ORM for Node.js based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, MySQL, MariaDB, PostgreSQL and SQLite databases..
  - name: keywords 
    content: ts.ed express typescript mikro orm node.js javascript decorators
 ---
@@ -14,8 +14,8 @@ meta:
 
 Currently, `@tsed/mikro-orm` allows you:
 
-- Configure one or more MikroORM instances via the `@Configuration` decorator. All databases will be initialized when
-  the server starts during the server's `OnInit` phase.
+- Configure one or more MikroORM instances via the `@Configuration` decorator. All databases will be initialized
+  when the server starts during the server's `OnInit` phase.
 - Use the Entity MikroORM as Model for Controllers, AJV Validation and Swagger.
 
 ## Installation
@@ -79,7 +79,7 @@ The `mikroOrm` options accepts the same configuration object as `init()` from th
 
 ## Obtain ORM instance
 
-`@Orm` decorator lets you retrieve an instance of MikroOrm.
+`@Orm` decorator lets you retrieve an instance of MikroORM.
 
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
@@ -129,7 +129,7 @@ export class MyService {
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
 import {Em} from "@tsed/mikro-orm";
-import {EntityManager} from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import {EntityManager} from "@mikro-orm/mysql"; // Import EntityManager from your driver package or `@mikro-orm/knex`
 
 @Injectable()
 export class UsersService {
@@ -150,7 +150,7 @@ It's also possible to inject Entity manager by his context name:
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
 import {Em} from "@tsed/mikro-orm";
-import {EntityManager} from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import {EntityManager} from "@mikro-orm/mysql"; // Import EntityManager from your driver package or `@mikro-orm/knex`
 
 @Injectable()
 export class UsersService {
@@ -258,8 +258,8 @@ By default, the automatic retry policy is disabled. You can implement your own t
 The `@Transactional()` decorator allows you to enable a retry policy for the particular resources. You just need to implement the `RetryStrategy` interface and use `registerProvider()` or `@OverrideProvider()` to register it in the IoC container. Below you can find an example to handle occurred optimistic locks based on [an exponential backoff retry strategy](https://en.wikipedia.org/wiki/Exponential_backoff).
 
 ```ts
-import { OptimisticLockError } from '@mikro-orm/core';
-import { RetryStrategy } from '@tsed/mikro-orm';
+import {OptimisticLockError} from "@mikro-orm/core";
+import {RetryStrategy} from "@tsed/mikro-orm";
 
 export interface ExponentialBackoffOptions {
   maxDepth: number;
@@ -270,16 +270,11 @@ export class ExponentialBackoff implements RetryStrategy {
 
   constructor(private readonly options: ExponentialBackoffOptions) {}
 
-  public async acquire<T extends (...args: unknown[]) => unknown>(
-    task: T
-  ): Promise<ReturnType<T>> {
+  public async acquire<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>> {
     try {
       return (await task()) as ReturnType<T>;
     } catch (e) {
-      if (
-        this.shouldRetry(e as Error) &&
-        this.depth < this.options.maxDepth
-      ) {
+      if (this.shouldRetry(e as Error) && this.depth < this.options.maxDepth) {
         return this.retry(task);
       }
 
@@ -291,9 +286,7 @@ export class ExponentialBackoff implements RetryStrategy {
     return error instanceof OptimisticLockError;
   }
 
-  private async retry<T extends (...args: unknown[]) => unknown>(
-    task: T
-  ): Promise<ReturnType<T>> {
+  private async retry<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>> {
     await this.sleep(2 ** this.depth * 50);
 
     this.depth += 1;
@@ -302,14 +295,14 @@ export class ExponentialBackoff implements RetryStrategy {
   }
 
   private sleep(milliseconds: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, milliseconds));
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
   }
 }
 
 registerProvider({
   provide: RetryStrategy,
   useFactory(): ExponentialBackoff {
-    return new ExponentialBackoff({maxDepth: 3})
+    return new ExponentialBackoff({maxDepth: 3});
   }
 });
 ```

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -33,13 +33,13 @@ A package of Ts.ED framework. See website: https://tsed.io/tutorials/mikro-orm
 
 Currently, `@tsed/mikro-orm` allows you:
 
-- Configure one or more MikroOrm instances via the `@Configuration` decorator. All databases will be initialized
+- Configure one or more MikroORM instances via the `@Configuration` decorator. All databases will be initialized
   when the server starts during the server's `OnInit` phase.
-- Use the Entity MikroOrm as Model for Controllers, AJV Validation and Swagger.
+- Use the Entity MikroORM as Model for Controllers, AJV Validation and Swagger.
 
 ## Installation
 
-To begin, install the MikroOrm module for TS.ED:
+To begin, install the MikroORM module for TS.ED:
 
 <Tabs class="-code">
   <Tab label="NPM">
@@ -98,7 +98,7 @@ The `mikroOrm` options accepts the same configuration object as `init()` from th
 
 ## Obtain ORM instance
 
-`@Orm` decorator lets you retrieve an instance of MikroOrm.
+`@Orm` decorator lets you retrieve an instance of MikroORM.
 
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
@@ -148,7 +148,7 @@ export class MyService {
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
 import {Em} from "@tsed/mikro-orm";
-import {EntityManager} from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import {EntityManager} from "@mikro-orm/mysql"; // Import EntityManager from your driver package or `@mikro-orm/knex`
 
 @Injectable()
 export class UsersService {
@@ -169,7 +169,7 @@ It's also possible to inject Entity manager by his context name:
 ```typescript
 import {Injectable, AfterRoutesInit} from "@tsed/common";
 import {Em} from "@tsed/mikro-orm";
-import {EntityManager} from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import {EntityManager} from "@mikro-orm/mysql"; // Import EntityManager from your driver package or `@mikro-orm/knex`
 
 @Injectable()
 export class UsersService {
@@ -187,7 +187,7 @@ export class UsersService {
 
 ## Use Entity with Controller
 
-To begin, we need to define an Entity MikroOrm like this and use Ts.ED Decorator to define the JSON Schema.
+To begin, we need to define an Entity MikroORM like this and use Ts.ED Decorator to define the JSON Schema.
 
 ```typescript
 import {Property, MaxLength, Required} from "@tsed/common";
@@ -218,7 +218,7 @@ export class User {
 
 Now, the model is correctly defined and can be used with a [Controller](https://tsed.io/docs/controllers.html)
 , [AJV validation](tutorials/ajv.md),
-[Swagger](tutorials/swagger.md) and [MikroOrm](https://mikro-orm.io/docs/defining-entities).
+[Swagger](tutorials/swagger.md) and [MikroORM](https://mikro-orm.io/docs/defining-entities).
 
 We can use this model with a Controller like that:
 
@@ -277,8 +277,8 @@ By default, the automatic retry policy is disabled. You can implement your own t
 The `@Transactional()` decorator allows you to enable a retry policy for the particular resources. You just need to implement the `RetryStrategy` interface and use `registerProvider()` or `@OverrideProvider()` to register it in the IoC container. Below you can find an example to handle occurred optimistic locks based on [an exponential backoff retry strategy](https://en.wikipedia.org/wiki/Exponential_backoff).
 
 ```ts
-import { OptimisticLockError } from '@mikro-orm/core';
-import { RetryStrategy } from '@tsed/mikro-orm';
+import {OptimisticLockError} from "@mikro-orm/core";
+import {RetryStrategy} from "@tsed/mikro-orm";
 
 export interface ExponentialBackoffOptions {
   maxDepth: number;
@@ -289,16 +289,11 @@ export class ExponentialBackoff implements RetryStrategy {
 
   constructor(private readonly options: ExponentialBackoffOptions) {}
 
-  public async acquire<T extends (...args: unknown[]) => unknown>(
-    task: T
-  ): Promise<ReturnType<T>> {
+  public async acquire<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>> {
     try {
       return (await task()) as ReturnType<T>;
     } catch (e) {
-      if (
-        this.shouldRetry(e as Error) &&
-        this.depth < this.options.maxDepth
-      ) {
+      if (this.shouldRetry(e as Error) && this.depth < this.options.maxDepth) {
         return this.retry(task);
       }
 
@@ -310,9 +305,7 @@ export class ExponentialBackoff implements RetryStrategy {
     return error instanceof OptimisticLockError;
   }
 
-  private async retry<T extends (...args: unknown[]) => unknown>(
-    task: T
-  ): Promise<ReturnType<T>> {
+  private async retry<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>> {
     await this.sleep(2 ** this.depth * 50);
 
     this.depth += 1;
@@ -321,14 +314,14 @@ export class ExponentialBackoff implements RetryStrategy {
   }
 
   private sleep(milliseconds: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, milliseconds));
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
   }
 }
 
 registerProvider({
   provide: RetryStrategy,
   useFactory(): ExponentialBackoff {
-    return new ExponentialBackoff({maxDepth: 3})
+    return new ExponentialBackoff({maxDepth: 3});
   }
 });
 ```

--- a/packages/orm/mikro-orm/test/helpers/services/UserService.ts
+++ b/packages/orm/mikro-orm/test/helpers/services/UserService.ts
@@ -1,7 +1,7 @@
 import {Injectable} from "@tsed/di";
 import {EntityManager, MikroORM} from "@mikro-orm/core";
 import {Orm, Em, Transactional} from "../../../src";
-import {User} from '../entity/User';
+import {User} from "../entity/User";
 
 @Injectable()
 export class UserService {
@@ -27,7 +27,7 @@ export class UserService {
   em3!: EntityManager;
 
   @Transactional()
-  async create(data: { email: string }): Promise<User> {
+  async create(data: {email: string}): Promise<User> {
     return this.orm.em.create(User, data);
   }
 }

--- a/packages/orm/mikro-orm/test/integration.spec.ts
+++ b/packages/orm/mikro-orm/test/integration.spec.ts
@@ -1,11 +1,11 @@
-import {PlatformTest} from '@tsed/common';
-import {TestMongooseContext} from '@tsed/testing-mongoose';
-import {User} from './helpers/entity/User';
-import {Server} from './helpers/Server';
-import {UserService} from './helpers/services/UserService';
-import {MikroORM} from '@mikro-orm/core';
-import {MikroOrmModule, TransactionalInterceptor} from '../src';
-import {anything, spy, verify} from 'ts-mockito';
+import {PlatformTest} from "@tsed/common";
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import {User} from "./helpers/entity/User";
+import {Server} from "./helpers/Server";
+import {UserService} from "./helpers/services/UserService";
+import {MikroORM} from "@mikro-orm/core";
+import {MikroOrmModule, TransactionalInterceptor} from "../src";
+import {anything, spy, verify} from "ts-mockito";
 
 describe("MikroOrm integration", () => {
   beforeEach(async () => {
@@ -48,22 +48,22 @@ describe("MikroOrm integration", () => {
     expect(service.em.name).toBe("default");
 
     expect(service.orm1).toBeInstanceOf(MikroORM);
-    expect(service.orm1.em.name).toBe('db1');
-    expect(service.em1.name).toBe('db1');
+    expect(service.orm1.em.name).toBe("db1");
+    expect(service.em1.name).toBe("db1");
 
     expect(service.orm2).toBeInstanceOf(MikroORM);
-    expect(service.orm2.em.name).toBe('db2');
-    expect(service.em2.name).toBe('db2');
+    expect(service.orm2.em.name).toBe("db2");
+    expect(service.em2.name).toBe("db2");
 
     expect(service.em3).toEqual(undefined);
   });
 
-  it('should create a request context', async () => {
+  it("should create a request context", async () => {
     const service = PlatformTest.injector.get<UserService>(UserService)!;
     const transactionalInterceptor = PlatformTest.injector.get<TransactionalInterceptor>(TransactionalInterceptor)!;
     const spiedTransactionalInterceptor = spy(transactionalInterceptor);
 
-    await service.create({email: 'test@example.com'});
+    await service.create({email: "test@example.com"});
 
     verify(spiedTransactionalInterceptor.intercept(anything(), anything())).once();
   });


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Chore | No

****

To follow the project code style in docs and tests, a couple of changes have been introduced, e.g:

```diff
Index: packages/orm/mikro-orm/test/helpers/services/UserService.ts
===================================================

- import {User} from '../entity/User';
+ import {User} from "../entity/User";
```
or
```diff
Index: packages/orm/mikro-orm/readme.md
===================================================

- To begin, install the MikroOrm module for TS.ED:
+ To begin, install the MikroORM module for TS.ED:
```
