### PR TITLE
fix(json-mapper): fix serialization of additional properties

### DIFF
--- a/packages/specs/json-mapper/src/utils/serialize.spec.ts
+++ b/packages/specs/json-mapper/src/utils/serialize.spec.ts
@@ -591,7 +591,7 @@ describe("serialize()", () => {
         }
       });
     });
-    it("should serialize model with additonal object props", () => {
+    it("should serialize model with additional object props", () => {
       @AdditionalProperties(true)
       class Model {
         @Property()
@@ -622,7 +622,7 @@ describe("serialize()", () => {
         }
       });
     });
-    it("should not serialize model with additonal object props", () => {
+    it("should not serialize model with additional object props", () => {
       class Model {
         @Property()
         id: string;

--- a/packages/specs/json-mapper/src/utils/serialize.spec.ts
+++ b/packages/specs/json-mapper/src/utils/serialize.spec.ts
@@ -1,5 +1,5 @@
 import {deserialize} from "@tsed/json-mapper";
-import {CollectionOf, Ignore, JsonHookContext, Name, Property} from "@tsed/schema";
+import {AdditionalProperties, CollectionOf, Ignore, JsonHookContext, Name, Property} from "@tsed/schema";
 import {expect} from "chai";
 import {parse} from "querystring";
 import {Post} from "../../test/helpers/Post";
@@ -589,6 +589,64 @@ describe("serialize()", () => {
         test: {
           value: "test"
         }
+      });
+    });
+    it("should serialize model with additonal object props", () => {
+      @AdditionalProperties(true)
+      class Model {
+        @Property()
+        id: string;
+
+        @Ignore(true)
+        ignored: boolean;
+
+        @Name("renamed")
+        name: string;
+
+        [type: string]: any;
+      }
+
+      const test = new Model();
+      test.id = "id";
+      test.ignored = true;
+      test.name = "myname";
+      test.additional = {foo: "bar"};
+
+      const result = serialize(test, {type: Model});
+
+      expect(result).to.deep.eq({
+        id: "id",
+        renamed: "myname",
+        additional: {
+          foo: "bar"
+        }
+      });
+    });
+    it("should not serialize model with additonal object props", () => {
+      class Model {
+        @Property()
+        id: string;
+
+        @Ignore(true)
+        ignored: boolean;
+
+        @Name("renamed")
+        name: string;
+
+        [type: string]: any;
+      }
+
+      const test = new Model();
+      test.id = "id";
+      test.ignored = true;
+      test.name = "myname";
+      test.additional = {foo: "bar"};
+
+      const result = serialize(test, {type: Model});
+
+      expect(result).to.deep.eq({
+        id: "id",
+        renamed: "myname"
       });
     });
   });

--- a/packages/specs/json-mapper/src/utils/serialize.ts
+++ b/packages/specs/json-mapper/src/utils/serialize.ts
@@ -67,8 +67,10 @@ export function classToPlainObject(obj: any, options: JsonSerializerOptions<any,
 
   const additionalProperties = !!entity.schema.get("additionalProperties");
   const schemaProperties = getSchemaProperties(entity, obj);
-
+  const properties = new Set<string>();
   const out: any = schemaProperties.reduce((newObj, [key, propStore]) => {
+    properties.add(key as string);
+
     const schema = propStore.schema;
 
     if (alterIgnore(schema, {useAlias, ...props, self: obj})) {
@@ -96,10 +98,10 @@ export function classToPlainObject(obj: any, options: JsonSerializerOptions<any,
   }, {});
 
   if (additionalProperties) {
-    const additionalKeys = new Set<any>(objectKeys(obj));
-    schemaProperties.forEach(([key, propStore]) => additionalKeys.delete(key));
-    additionalKeys.forEach((key: any) => {
-      out[key] = obj[key];
+    objectKeys(obj).forEach((key: any) => {
+      if (!properties.has(key)) {
+        out[key] = obj[key];
+      }
     });
   }
   return out;

--- a/packages/specs/json-mapper/src/utils/serialize.ts
+++ b/packages/specs/json-mapper/src/utils/serialize.ts
@@ -65,7 +65,10 @@ export function classToPlainObject(obj: any, options: JsonSerializerOptions<any,
 
   const entity = JsonEntityStore.from(type || obj);
 
-  return getSchemaProperties(entity, obj).reduce((newObj, [key, propStore]) => {
+  const additionalProperties = !!entity.schema.get("additionalProperties");
+  const schemaProperties = getSchemaProperties(entity, obj);
+
+  const out: any = schemaProperties.reduce((newObj, [key, propStore]) => {
     const schema = propStore.schema;
 
     if (alterIgnore(schema, {useAlias, ...props, self: obj})) {
@@ -91,6 +94,15 @@ export function classToPlainObject(obj: any, options: JsonSerializerOptions<any,
       [key]: value
     };
   }, {});
+
+  if (additionalProperties) {
+    const additionalKeys = new Set<any>(objectKeys(obj));
+    schemaProperties.forEach(([key, propStore]) => additionalKeys.delete(key));
+    additionalKeys.forEach((key: any) => {
+      out[key] = obj[key];
+    });
+  }
+  return out;
 }
 
 function toObject(obj: any, options: JsonSerializerOptions): any {


### PR DESCRIPTION
Serialization of additional properties if @additionalProperties(true) decorator is set on Model

## Information

Type | Breaking change
---|---
Fix | No

****
I expected the addition of the @additionalProperties decorator to a Model to also allow serialization of any additional properties but it didn't. This changes fixes this.