### PR TITLE
fix: make getMountedControllers support nested controllers

### DIFF
--- a/packages/platform/common/src/services/Platform.spec.ts
+++ b/packages/platform/common/src/services/Platform.spec.ts
@@ -16,6 +16,21 @@ class MyCtrl {
   get() {}
 }
 
+@Controller("/my-sub-route")
+class MySubCtrl {
+  @Get("/")
+  get() {}
+}
+
+@Controller({
+  path: "/my-route",
+  children: [MySubCtrl]
+})
+class MyNestedCtrl {
+  @Get("/")
+  get() {}
+}
+
 describe("Platform", () => {
   beforeEach(PlatformTest.create);
   afterEach(PlatformTest.reset);
@@ -35,6 +50,25 @@ describe("Platform", () => {
 
       // THEN
       expect(platform.getMountedControllers()).to.deep.eq([{provider, route: "/test/my-route"}]);
+      expect(platform.app.use).to.have.been.calledWithExactly("/test/my-route", router.raw);
+    });
+    it("should add nested controllers", async () => {
+      // GIVEN
+      const nestedProvider: ControllerProvider = PlatformTest.injector.getProvider(MyNestedCtrl)! as ControllerProvider;
+      const subProvider: ControllerProvider = PlatformTest.injector.getProvider(MySubCtrl)! as ControllerProvider;
+      const platform = await PlatformTest.get<Platform>(Platform);
+
+      sandbox.spy(platform.app, "use");
+
+      // WHEN
+      platform.addRoute("/test", MyNestedCtrl);
+      const router = PlatformTest.get<PlatformRouter>(nestedProvider.tokenRouter);
+
+      // THEN
+      expect(platform.getMountedControllers()).to.deep.eq([
+        {provider: nestedProvider, route: "/test/my-route"},
+        {provider: subProvider, route: "/test/my-route/my-sub-route"}
+      ]);
       expect(platform.app.use).to.have.been.calledWithExactly("/test/my-route", router.raw);
     });
   });

--- a/packages/platform/common/src/services/Platform.ts
+++ b/packages/platform/common/src/services/Platform.ts
@@ -48,7 +48,6 @@ export class Platform {
     }
 
     this._controllers.push(...this.getAllControllers(basePath, token));
-    console.dir(this.getAllControllers(basePath, token));
 
     const ctrlPath = concatPath(basePath, JsonEntityStore.from(provider.token).path);
 

--- a/packages/platform/common/src/services/Platform.ts
+++ b/packages/platform/common/src/services/Platform.ts
@@ -1,5 +1,6 @@
+import {Type} from "@tsed/core";
 import {Injectable, InjectorService, ProviderScope, ProviderType, TokenProvider} from "@tsed/di";
-import {concatPath, EndpointMetadata, getOperationsRoutes, JsonEntityStore} from "@tsed/schema";
+import {concatPath, EndpointMetadata, getJsonEntityStore, getOperationsRoutes, JsonEntityStore} from "@tsed/schema";
 import {buildRouter, createRouter, getRouter} from "../builder/PlatformControllerBuilder";
 import {ControllerProvider} from "../domain/ControllerProvider";
 import {PlatformRouteDetails} from "../domain/PlatformRouteDetails";
@@ -46,12 +47,10 @@ export class Platform {
       return;
     }
 
-    const ctrlPath = concatPath(basePath, JsonEntityStore.from(provider.token).path);
+    this._controllers.push(...this.getAllControllers(basePath, token));
+    console.dir(this.getAllControllers(basePath, token));
 
-    this._controllers.push({
-      route: ctrlPath,
-      provider
-    });
+    const ctrlPath = concatPath(basePath, JsonEntityStore.from(provider.token).path);
 
     this.app.use(ctrlPath, ...[].concat(getRouter(injector, provider).callback()));
 
@@ -83,6 +82,10 @@ export class Platform {
     return this._routes;
   }
 
+  /**
+   * Get all controllers mounted on the application.
+   * @returns  {RouteController[]}
+   */
   public getMountedControllers(): RouteController[] {
     return this._controllers;
   }
@@ -101,6 +104,28 @@ export class Platform {
     injector.getProviders(ProviderType.CONTROLLER).map((provider: ControllerProvider) => {
       createRouter(injector, provider);
     });
+  }
+
+  /**
+   * Get all router controllers from the controller token.
+   * @private
+   */
+  private getAllControllers(basePath: string, token: Type<any> | any): RouteController[] {
+    const store: JsonEntityStore = token.isStore ? token : getJsonEntityStore(token);
+    const ctrlPath = concatPath(basePath, JsonEntityStore.from(token).path);
+    const controllers: RouteController[] = [
+      {
+        route: ctrlPath,
+        provider: this.injector.getProvider(token) as ControllerProvider
+      }
+    ];
+
+    const children = store.get<Type[]>("childrenControllers", []);
+
+    return children.reduce<RouteController[]>((controllers, token) => {
+      const childBasePath = concatPath(basePath, store.path);
+      return controllers.concat(this.getAllControllers(childBasePath, token));
+    }, controllers);
   }
 
   /**

--- a/packages/specs/schema/src/utils/getOperationsRoutes.ts
+++ b/packages/specs/schema/src/utils/getOperationsRoutes.ts
@@ -4,6 +4,7 @@ import {getOperationsStores} from "./getOperationsStores";
 import {JsonOperationRoute} from "../domain/JsonOperationRoute";
 import {JsonEntityStore} from "../domain/JsonEntityStore";
 import {getJsonEntityStore} from "./getJsonEntityStore";
+import {concatPath} from "./concatPath";
 
 export interface GetOperationsRoutesOptions {
   withChildren?: boolean;
@@ -15,7 +16,7 @@ export function getOperationsRoutes<Entity extends JsonMethodStore = JsonMethodS
   options: GetOperationsRoutesOptions = {}
 ): JsonOperationRoute<Entity>[] {
   const store: JsonEntityStore = token.isStore ? token : getJsonEntityStore(token);
-  const basePath = ((options.basePath || "") + (store.path || "")).replace(/\/\//gi, "/");
+  const basePath = concatPath(options.basePath, store.path);
   let operationsRoutes: JsonOperationRoute<Entity>[] = [];
 
   if (options.withChildren) {

--- a/packages/specs/swagger/src/services/SwaggerService.ts
+++ b/packages/specs/swagger/src/services/SwaggerService.ts
@@ -51,7 +51,10 @@ export class SwaggerService {
 
       this.platform.getMountedControllers().forEach(({route, provider}) => {
         if (includeRoute(route, provider, conf)) {
-          const spec = getSpec(provider.token, options);
+          const spec = getSpec(provider.token, {
+            ...options,
+            rootPath: route.replace(provider.path, "")
+          });
 
           options.append(spec);
         }

--- a/packages/specs/swagger/src/services/SwaggerService.ts
+++ b/packages/specs/swagger/src/services/SwaggerService.ts
@@ -51,10 +51,7 @@ export class SwaggerService {
 
       this.platform.getMountedControllers().forEach(({route, provider}) => {
         if (includeRoute(route, provider, conf)) {
-          const spec = this.buildRoutes(provider, {
-            ...options,
-            rootPath: route.replace(provider.path, "")
-          });
+          const spec = getSpec(provider.token, options);
 
           options.append(spec);
         }
@@ -93,29 +90,5 @@ export class SwaggerService {
     }
 
     return {};
-  }
-
-  /**
-   *
-   * @param ctrl
-   * @param options
-   */
-  protected buildRoutes(ctrl: ControllerProvider, options: SpecSerializerOptions) {
-    const rootPath = options.rootPath + ctrl.path;
-
-    ctrl.children
-      .map((ctrl) => this.injectorService.getProvider(ctrl))
-      .forEach((provider: ControllerProvider) => {
-        if (!provider.store.get("hidden")) {
-          const spec = this.buildRoutes(provider, {
-            ...options,
-            rootPath
-          });
-
-          options.append(spec);
-        }
-      });
-
-    return getSpec(ctrl.token, options);
   }
 }

--- a/packages/specs/swagger/test/swagger.integration.spec.ts
+++ b/packages/specs/swagger/test/swagger.integration.spec.ts
@@ -199,10 +199,10 @@ describe("Swagger integration", () => {
         swagger: "2.0",
         tags: [
           {
-            name: "EventCtrl"
+            name: "CalendarsController"
           },
           {
-            name: "CalendarsController"
+            name: "EventCtrl"
           }
         ]
       });
@@ -326,7 +326,7 @@ describe("Swagger integration", () => {
             }
           }
         },
-        tags: [{name: "EventCtrl"}, {name: "CalendarsController"}],
+        tags: [{name: "CalendarsController"}, {name: "EventCtrl"}],
         components: {
           schemas: {
             Calendar: {

--- a/packages/specs/swagger/test/swagger.operationId.spec.ts
+++ b/packages/specs/swagger/test/swagger.operationId.spec.ts
@@ -205,10 +205,10 @@ describe("Swagger integration", () => {
         swagger: "2.0",
         tags: [
           {
-            name: "EventCtrl"
+            name: "CalendarsController"
           },
           {
-            name: "CalendarsController"
+            name: "EventCtrl"
           }
         ]
       });
@@ -338,10 +338,10 @@ describe("Swagger integration", () => {
         },
         tags: [
           {
-            name: "EventCtrl"
+            name: "CalendarsController"
           },
           {
-            name: "CalendarsController"
+            name: "EventCtrl"
           }
         ]
       });


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

Fixes #1802

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
