### PR TITLE
Fix Buffer support in Mongoose

### DIFF
--- a/packages/core/src/utils/objects/isBuffer.ts
+++ b/packages/core/src/utils/objects/isBuffer.ts
@@ -1,0 +1,8 @@
+/**
+ * Tests to see if the object is Buffer
+ * @param target
+ * @returns {boolean}
+ */
+export function isBuffer(target: any): target is Buffer {
+  return target === Buffer || target instanceof Buffer;
+}

--- a/packages/core/src/utils/objects/isClass.spec.ts
+++ b/packages/core/src/utils/objects/isClass.spec.ts
@@ -9,6 +9,7 @@ describe("isClass", () => {
     expect(isClass(Number)).toEqual(false);
     expect(isClass(Promise)).toEqual(false);
     expect(isClass(Array)).toEqual(false);
+    expect(isClass(Buffer)).toEqual(false);
     expect(isClass(() => {})).toEqual(false);
   });
 });

--- a/packages/core/src/utils/objects/isClass.ts
+++ b/packages/core/src/utils/objects/isClass.ts
@@ -1,5 +1,6 @@
 import {isArrayOrArrayClass} from "./isArray";
 import {isArrowFn} from "./isArrowFn";
+import {isBuffer} from "./isBuffer";
 import {isDate} from "./isDate";
 import {isClassObject} from "./isPlainObject";
 import {isPrimitiveOrPrimitiveClass} from "./isPrimitive";
@@ -21,6 +22,7 @@ export function isClass(target: any) {
     isClassObject(target) ||
     isDate(target) ||
     isPromise(target) ||
-    isArrayOrArrayClass(target)
+    isArrayOrArrayClass(target) ||
+    isBuffer(target)
   );
 }

--- a/packages/orm/mongoose/src/utils/createSchema.spec.ts
+++ b/packages/orm/mongoose/src/utils/createSchema.spec.ts
@@ -71,6 +71,28 @@ describe("createSchema", () => {
       }
     });
   });
+  it("should create schema with buffer", () => {
+    // GIVEN
+    @Model()
+    class Test {
+      @Name("id")
+      _id: string;
+
+      @Property(Buffer)
+      image: Buffer;
+    }
+
+    // WHEN
+    const result = getSchema(Test);
+
+    // THEN
+    expect(result.obj).toEqual({
+      image: {
+        required: false,
+        type: Buffer
+      }
+    });
+  });
   it("should create schema with required property", () => {
     // GIVEN
     @Model()

--- a/packages/orm/mongoose/test/buffer.integration.spec.ts
+++ b/packages/orm/mongoose/test/buffer.integration.spec.ts
@@ -1,0 +1,38 @@
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import axios from "axios";
+import faker from "faker";
+import {MongooseModel} from "../src/interfaces/MongooseModel";
+import {TestAvatar} from "./helpers/models/Avatar";
+
+describe("Mongoose", () => {
+  describe("Models with Buffer", () => {
+    beforeEach(TestMongooseContext.create);
+    afterEach(TestMongooseContext.reset);
+
+    it(
+      "Should save and load buffer",
+      TestMongooseContext.inject([TestAvatar], async (avatarModel: MongooseModel<TestAvatar>) => {
+        const imageBuffer = await axios
+          .get(faker.image.people(256, 256), {
+            responseType: "arraybuffer"
+          })
+          .then((response) => Buffer.from(response.data, "binary"));
+
+        // GIVEN
+        const newAvatar = new avatarModel({
+          image: imageBuffer
+        });
+
+        // WHEN
+        await newAvatar.save();
+        const savedAvatar = await avatarModel.findById(newAvatar.id);
+
+        // THEN
+        expect(savedAvatar).not.toBeNull();
+        if (savedAvatar) {
+          expect(savedAvatar.image).toBeInstanceOf(Buffer);
+        }
+      })
+    );
+  });
+});

--- a/packages/orm/mongoose/test/helpers/models/Avatar.ts
+++ b/packages/orm/mongoose/test/helpers/models/Avatar.ts
@@ -1,0 +1,11 @@
+import {Property} from "@tsed/schema";
+import {Model, ObjectID} from "../../../src";
+
+@Model({schemaOptions: {timestamps: true}})
+export class TestAvatar {
+  @ObjectID()
+  _id: string;
+
+  @Property(Buffer)
+  image: Buffer;
+}


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

This closes #1811.

Since `propEntity.isClass` returns true for `Buffer` typed property, so it is being treated as Schema instead of directly getting assigned to `type` like `String` or `Number`. So I have updated the `isClass` method to return false for `Buffer`.

## Todos

- [x] Tests
- [x] Coverage
