### PR TITLE
Fix collection casing

### DIFF
--- a/packages/orm/prisma/src/generator/utils/generateRepositories.ts
+++ b/packages/orm/prisma/src/generator/utils/generateRepositories.ts
@@ -5,7 +5,7 @@ import path from "path";
 import {DmmfModel} from "../domain/DmmfModel";
 import {generateOutputsBarrelFile} from "./generateOutputsBarrelFile";
 import pluralize from "pluralize";
-import {pascalCase, camelCase} from "change-case";
+import {pascalCase, camelCase, lowerCase } from "change-case";
 
 interface MethodOptions {
   repository: ClassDeclaration;
@@ -103,7 +103,7 @@ export function generateRepositories(dmmf: DMMF.Document, project: Project, base
       .addGetAccessor({
         name: "collection"
       })
-      .setBodyText(`return this.prisma.${camelCase(model.name)}`);
+      .setBodyText(`return this.prisma.${lowerCase(model.name)}`);
 
     repository
       .addGetAccessor({

--- a/packages/orm/prisma/src/generator/utils/generateRepositories.ts
+++ b/packages/orm/prisma/src/generator/utils/generateRepositories.ts
@@ -5,7 +5,7 @@ import path from "path";
 import {DmmfModel} from "../domain/DmmfModel";
 import {generateOutputsBarrelFile} from "./generateOutputsBarrelFile";
 import pluralize from "pluralize";
-import {pascalCase, camelCase, lowerCase } from "change-case";
+import {pascalCase, camelCase} from "change-case";
 
 interface MethodOptions {
   repository: ClassDeclaration;
@@ -13,6 +13,10 @@ interface MethodOptions {
   model: string;
   returnType?: string | undefined;
   hasQuestionToken?: boolean;
+}
+
+function lowerCase(name: string) {
+  return name.substring(0, 1).toLowerCase() + name.substring(1);
 }
 
 function addDelegatedMethod({name, hasQuestionToken, repository, model, returnType}: MethodOptions) {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

Prisma generates collection name using `lowerCase`, instead of `camelCase`

https://github.com/prisma/prisma/blob/d7d33d896bcb104a56877fe4d87405f8200a63fc/packages/client/src/generation/TSClient/PrismaClient.ts#L225

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
