### PR TITLE
fix: rollback changes introduced by v6.116.0 on the async hook context

### DIFF
--- a/packages/platform/platform-express/src/components/PlatformExpress.ts
+++ b/packages/platform/platform-express/src/components/PlatformExpress.ts
@@ -1,6 +1,3 @@
-import type multer from "multer";
-import Express, {RouterOptions} from "express";
-import type {PlatformViews} from "@tsed/platform-views";
 import {
   createContext,
   InjectorService,
@@ -14,17 +11,19 @@ import {
   PlatformMulterSettings,
   PlatformRequest,
   PlatformResponse,
-  PlatformStaticsOptions,
-  runInContext
+  PlatformStaticsOptions
 } from "@tsed/common";
-import {promisify} from "util";
 import {Env, isFunction, nameOf, Type} from "@tsed/core";
-import {PlatformExpressHandler} from "../services/PlatformExpressHandler";
-import {PlatformExpressResponse} from "../services/PlatformExpressResponse";
-import {PlatformExpressRequest} from "../services/PlatformExpressRequest";
-import {staticsMiddleware} from "../middlewares/staticsMiddleware";
-import {PlatformExpressStaticsOptions} from "../interfaces/PlatformExpressStaticsOptions";
+import type {PlatformViews} from "@tsed/platform-views";
 import {OptionsJson, OptionsText, OptionsUrlencoded} from "body-parser";
+import Express, {RouterOptions} from "express";
+import type multer from "multer";
+import {promisify} from "util";
+import {PlatformExpressStaticsOptions} from "../interfaces/PlatformExpressStaticsOptions";
+import {staticsMiddleware} from "../middlewares/staticsMiddleware";
+import {PlatformExpressHandler} from "../services/PlatformExpressHandler";
+import {PlatformExpressRequest} from "../services/PlatformExpressRequest";
+import {PlatformExpressResponse} from "../services/PlatformExpressResponse";
 
 declare module "express" {
   export interface Request {
@@ -158,9 +157,9 @@ export class PlatformExpress implements PlatformAdapter<Express.Application, Exp
     const app = this.injector.get<PlatformApplication<Express.Application>>(PlatformApplication)!;
 
     app.getApp().use(async (request: any, response: any, next: any) => {
-      const $ctx = await invoke({request, response});
+      await invoke({request, response});
 
-      return $ctx.runInContext(next);
+      return next();
     });
 
     return this;

--- a/packages/platform/platform-koa/src/components/PlatformKoa.ts
+++ b/packages/platform/platform-koa/src/components/PlatformKoa.ts
@@ -11,21 +11,20 @@ import {
   PlatformMulterSettings,
   PlatformRequest,
   PlatformResponse,
-  PlatformStaticsOptions,
-  runInContext
+  PlatformStaticsOptions
 } from "@tsed/common";
 import {isFunction, Type} from "@tsed/core";
 import Koa, {Context, Next} from "koa";
-import {resourceNotFoundMiddleware} from "../middlewares/resourceNotFoundMiddleware";
-import {PlatformKoaResponse} from "../services/PlatformKoaResponse";
-import {PlatformKoaRequest} from "../services/PlatformKoaRequest";
-import {PlatformKoaHandler} from "../services/PlatformKoaHandler";
-import {getMulter} from "../utils/multer";
-import {staticsMiddleware} from "../middlewares/staticsMiddleware";
-import send from "koa-send";
+import koaBodyParser, {Options} from "koa-bodyparser";
 // @ts-ignore
 import koaQs from "koa-qs";
-import koaBodyParser, {Options} from "koa-bodyparser";
+import send from "koa-send";
+import {resourceNotFoundMiddleware} from "../middlewares/resourceNotFoundMiddleware";
+import {staticsMiddleware} from "../middlewares/staticsMiddleware";
+import {PlatformKoaHandler} from "../services/PlatformKoaHandler";
+import {PlatformKoaRequest} from "../services/PlatformKoaRequest";
+import {PlatformKoaResponse} from "../services/PlatformKoaResponse";
+import {getMulter} from "../utils/multer";
 
 declare global {
   namespace TsED {
@@ -129,13 +128,13 @@ export class PlatformKoa implements PlatformAdapter<Koa, KoaRouter> {
     const invoke = createContext(this.injector);
 
     app.getApp().use(async (ctx: Context, next: Next) => {
-      const $ctx = await invoke({
+      await invoke({
         request: ctx.request as any,
         response: ctx.response as any,
         ctx
       });
 
-      return $ctx.runInContext(next);
+      return next();
     });
 
     return this;


### PR DESCRIPTION
## Information

Fix the issue related to the context creation and binding with the async_hook_context.

Fix the issue when we use the `@InjectContext()` decorator!