### PR TITLE
feat(mikro-orm): provide the ability to set an isolation level

### DIFF
--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -333,6 +333,20 @@ export class UsersCtrl {
 }
 ```
 
+## Transaction isolation levels
+
+By default, `IsolationLevel.READ_COMMITTED` is used. You can override it, specifying the isolation level for the transaction by supplying it as the `isolationLevel` parameter in the `@Transactional` decorator:
+
+```typescript
+@Post("/")
+@Transactional({isolationLevel: IsolationLevel.SERIALIZABLE})
+create(@BodyParams() user: User): Promise<User> {
+  return this.usersService.create(user);
+}
+```
+
+The MikroORM supports the standard isolation levels such as `SERIALIZABLE` or `REPEATABLE READ`, the full list of available options see [here](https://mikro-orm.io/docs/transactions#isolation-levels).
+
 ## Author
 
 <GithubContributors :users="['derevnjuk']"/>

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -353,6 +353,20 @@ export class UsersCtrl {
 }
 ```
 
+## Transaction isolation levels
+
+By default, `IsolationLevel.READ_COMMITTED` is used. You can override it, specifying the isolation level for the transaction by supplying it as the `isolationLevel` parameter in the `@Transactional` decorator:
+
+```typescript
+@Post("/")
+@Transactional({isolationLevel: IsolationLevel.SERIALIZABLE})
+create(@BodyParams() user: User): Promise<User> {
+  return this.usersService.create(user);
+}
+```
+
+The MikroORM supports the standard isolation levels such as `SERIALIZABLE` or `REPEATABLE READ`, the full list of available options see [here](https://mikro-orm.io/docs/transactions#isolation-levels).
+
 ## Contributors
 
 Please read [contributing guidelines here](https://tsed.io/CONTRIBUTING.html)


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

## Usage example

By default, `IsolationLevel.READ_COMMITTED` is used. You can override it, specifying the isolation level for the transaction by supplying it as the `isolationLevel` parameter in the `@Transactional` decorator:

```typescript
@Post("/")
@Transactional({isolationLevel: IsolationLevel.SERIALIZABLE})
create(@BodyParams() user: User): Promise<User> {
  return this.usersService.create(user);
}
```

The MikroORM supports the standard isolation levels such as `SERIALIZABLE` or `REPEATABLE READ`, the full list of available options see [here](https://mikro-orm.io/docs/transactions#isolation-levels).


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation

closes #1979
