### PR TITLE
feat(common): add route to PlatformRequest.route to get the matched r…

### DIFF
--- a/packages/platform/common/src/services/PlatformRequest.spec.ts
+++ b/packages/platform/common/src/services/PlatformRequest.spec.ts
@@ -1,5 +1,4 @@
 import {PlatformTest} from "@tsed/common";
-import {createSandbox} from "sinon";
 import {PlatformRequest} from "./PlatformRequest";
 
 function createRequest() {
@@ -8,7 +7,6 @@ function createRequest() {
   return {req: $ctx.request.request, request: $ctx.request};
 }
 
-const sandbox = createSandbox();
 describe("PlatformRequest", () => {
   beforeEach(() => PlatformTest.create());
   afterEach(() => PlatformTest.reset());
@@ -36,6 +34,16 @@ describe("PlatformRequest", () => {
 
       $ctx.request.request.secure = true;
       expect($ctx.request.secure).toEqual(true);
+    });
+  });
+
+  describe("route()", () => {
+    it("should return route", () => {
+      const $ctx = PlatformTest.createRequestContext();
+
+      $ctx.request.raw.route = {path: "/id"};
+
+      expect($ctx.request.route).toEqual("/id");
     });
   });
 

--- a/packages/platform/common/src/services/PlatformRequest.ts
+++ b/packages/platform/common/src/services/PlatformRequest.ts
@@ -110,6 +110,10 @@ export class PlatformRequest<T extends {[key: string]: any} = any> {
     return this.raw.files;
   }
 
+  get route() {
+    return this.raw?.route?.path;
+  }
+
   /**
    * Return the original request framework instance
    */

--- a/packages/platform/platform-koa/src/services/PlatformKoaRequest.spec.ts
+++ b/packages/platform/platform-koa/src/services/PlatformKoaRequest.spec.ts
@@ -3,7 +3,7 @@ import {PlatformKoaRequest} from "@tsed/platform-koa";
 
 function createRequest() {
   const request = PlatformTest.createRequest();
-  const koaCtx = {
+  const koaCtx: any = {
     request: {
       protocol: "http",
       req: request
@@ -27,7 +27,7 @@ function createRequest() {
     RequestKlass: PlatformKoaRequest
   });
 
-  return {req: request, request: ctx.request};
+  return {req: request, request: ctx.request, koaCtx};
 }
 
 describe("PlatformKoaRequest", () => {
@@ -75,6 +75,16 @@ describe("PlatformKoaRequest", () => {
     });
   });
 
+  describe("route()", () => {
+    it("should return the host", () => {
+      const {req, koaCtx, request} = createRequest();
+
+      koaCtx._matchedRoute = "/id";
+
+      expect(request.route).toEqual("/id");
+    });
+  });
+
   describe("cookies", () => {
     it("should get cookies from cookies", () => {
       const {req, request} = createRequest();
@@ -91,7 +101,7 @@ describe("PlatformKoaRequest", () => {
   });
   describe("session", () => {
     it("should get session", () => {
-      const {req, request} = createRequest();
+      const {request} = createRequest();
 
       expect(request.session).toEqual({test: "test"});
     });

--- a/packages/platform/platform-koa/src/services/PlatformKoaRequest.ts
+++ b/packages/platform/platform-koa/src/services/PlatformKoaRequest.ts
@@ -48,6 +48,10 @@ export class PlatformKoaRequest extends PlatformRequest<Koa.Request> {
     return this.#ctx.session;
   }
 
+  get route() {
+    return this.#ctx._matchedRoute;
+  }
+
   getReq(): IncomingMessage {
     return this.raw.req;
   }

--- a/packages/platform/platform-log-middleware/src/middlewares/PlatformLogMiddleware.spec.ts
+++ b/packages/platform/platform-log-middleware/src/middlewares/PlatformLogMiddleware.spec.ts
@@ -42,7 +42,8 @@ describe("PlatformLogMiddleware", () => {
       it("should configure request and create context logger", async () => {
         // GIVEN
         const {request, ctx, middleware} = await createMiddlewareFixture();
-        request.originalUrl = "originalUrl";
+        request.originalUrl = "/originalUrl";
+        ctx.request.raw.route = {path: "/:id"};
         // WHEN
         middleware.use(ctx);
 
@@ -55,7 +56,8 @@ describe("PlatformLogMiddleware", () => {
             event: "request.start",
             method: "GET",
             reqId: "id",
-            url: "originalUrl"
+            url: "/originalUrl",
+            route: "/:id"
           })
         );
         expect(PlatformTest.injector.logger.info).toHaveBeenCalledWith(
@@ -63,7 +65,8 @@ describe("PlatformLogMiddleware", () => {
             event: "request.end",
             method: "GET",
             reqId: "id",
-            url: "originalUrl",
+            url: "/originalUrl",
+            route: "/:id",
             status: 200
           })
         );

--- a/packages/platform/platform-log-middleware/src/middlewares/PlatformLogMiddleware.ts
+++ b/packages/platform/platform-log-middleware/src/middlewares/PlatformLogMiddleware.ts
@@ -9,7 +9,7 @@ import type {LoggerRequestFields} from "../domain/PlatformLogMiddlewareSettings"
  */
 @Middleware()
 export class PlatformLogMiddleware implements MiddlewareMethods {
-  @Constant("logger.requestFields", ["reqId", "method", "url", "duration"])
+  @Constant("logger.requestFields", ["reqId", "method", "url", "duration", "route"])
   protected requestFields: LoggerRequestFields;
 
   @Constant("logger.logRequest", true)
@@ -103,6 +103,7 @@ export class PlatformLogMiddleware implements MiddlewareMethods {
     return {
       method: request.method,
       url: request.url,
+      route: request.route,
       headers: request.headers,
       body: request.body,
       query: request.query,


### PR DESCRIPTION
…oute path

Closes: #1994

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature/Fix/Doc/Chore | Yes/No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
