### PR TITLE
feat(testing-mongoose): add replicaSet option to use ReplicaSet mode

### DIFF
--- a/docs/tutorials/mongoose.md
+++ b/docs/tutorials/mongoose.md
@@ -346,6 +346,47 @@ This example shows you how you can test your Rest API with superagent and a mock
 To increase mocha timeout from 2000ms to 10000ms use option `--timeout 10000`.
 :::
 
+### Testing API with ReplicaSet
+
+A [ReplicaSet](https://github.com/nodkz/mongodb-memory-server#replica-set-start) can be easily started with:
+
+```typescript
+import {PlatformTest} from "@tsed/common";
+import {PlatformExpress} from "@tsed/platform-express";
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import {expect} from "chai";
+import * as SuperTest from "supertest";
+import {Server} from "../Server";
+
+describe("Rest", () => {
+  // bootstrap your Server to load all endpoints before run your test
+  let request: SuperTest.SuperTest<SuperTest.Test>;
+
+  before(
+    TestMongooseContext.bootstrap(Server, {
+      platform: PlatformExpress,
+      mongod: {
+        replicaSet: true
+      }
+    })
+  ); // Create a server with mocked database
+  before((done) => {
+    request = SuperTest(PlatformTest.callback());
+    done();
+  });
+
+  after(TestMongooseContext.reset); // reset database and injector
+
+  describe("GET /rest/calendars", () => {
+    it("should do something", async () => {
+      const response = await request.get("/rest/calendars").expect(200);
+
+      expect(response.body).to.be.an("array");
+    });
+  });
+});
+```
+
 ### Jest additional setup
 
 Add a script to close connection after all unit test. In your jest configuration file add the following line:

--- a/packages/orm/testing-mongoose/readme.md
+++ b/packages/orm/testing-mongoose/readme.md
@@ -78,6 +78,47 @@ describe("Rest", () => {
 To increase mocha timeout from 2000ms to 10000ms use option `--timeout 10000`.
 :::
 
+### Testing server with Replica set
+
+A [ReplicaSet](https://github.com/nodkz/mongodb-memory-server#replica-set-start) can be easily started with:
+
+```typescript
+import {PlatformTest} from "@tsed/common";
+import {PlatformExpress} from "@tsed/platform-express";
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import {expect} from "chai";
+import * as SuperTest from "supertest";
+import {Server} from "../Server";
+
+describe("Rest", () => {
+  // bootstrap your Server to load all endpoints before run your test
+  let request: SuperTest.SuperTest<SuperTest.Test>;
+
+  before(
+    TestMongooseContext.bootstrap(Server, {
+      platform: PlatformExpress,
+      mongod: {
+        replicaSet: true
+      }
+    })
+  ); // Create a server with mocked database
+  before((done) => {
+    request = SuperTest(PlatformTest.callback());
+    done();
+  });
+
+  after(TestMongooseContext.reset); // reset database and injector
+
+  describe("GET /rest/calendars", () => {
+    it("should do something", async () => {
+      const response = await request.get("/rest/calendars").expect(200);
+
+      expect(response.body).to.be.an("array");
+    });
+  });
+});
+```
+
 ## Jest additional setup
 
 Add a script to close connection after all unit test. In your jest configuration file add the following line:

--- a/packages/orm/testing-mongoose/src/TestMongooseContext.ts
+++ b/packages/orm/testing-mongoose/src/TestMongooseContext.ts
@@ -1,6 +1,6 @@
 import {PlatformTest} from "@tsed/common";
 import {MongooseService} from "@tsed/mongoose";
-import {MongoMemoryServer} from "mongodb-memory-server";
+import {MongoMemoryReplSet, MongoMemoryServer} from "mongodb-memory-server";
 import {resolve} from "path";
 import {version} from "mongoose";
 import semver from "semver";
@@ -9,18 +9,18 @@ import {MongoMemoryServerStates} from "mongodb-memory-server-core/lib/MongoMemor
 const downloadDir = resolve(`${require.resolve("mongodb-memory-server")}/../../.cache/mongodb-memory-server/mongodb-binaries`);
 
 export class TestMongooseContext extends PlatformTest {
-  static getMongo(): MongoMemoryServer {
+  static getMongo(): MongoMemoryServer | MongoMemoryReplSet {
     // @ts-ignore
     return global.__MONGOD__;
   }
 
-  static async install(options: any = {binary: {}}) {
+  static async install({replicaSet, ...opts}: {replicaSet?: boolean} & Record<string, any> = {}) {
     if (!TestMongooseContext.getMongo()) {
       // @ts-ignore
-      global.__MONGOD__ = new MongoMemoryServer({
-        ...options,
+      global.__MONGOD__ = new (replicaSet ? MongoMemoryReplSet : MongoMemoryServer)({
+        ...opts,
         binary: {
-          ...(options.binary || {}),
+          ...(opts.binary || {}),
           downloadDir
         }
       });


### PR DESCRIPTION
Closes: #2001

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

## Usage example

A [ReplicaSet](https://github.com/nodkz/mongodb-memory-server#replica-set-start) can be easily started with:

```typescript
import {PlatformTest} from "@tsed/common";
import {PlatformExpress} from "@tsed/platform-express";
import {TestMongooseContext} from "@tsed/testing-mongoose";
import {expect} from "chai";
import * as SuperTest from "supertest";
import {Server} from "../Server";

describe("Rest", () => {
  // bootstrap your Server to load all endpoints before run your test
  let request: SuperTest.SuperTest<SuperTest.Test>;

  before(
    TestMongooseContext.bootstrap(Server, {
      platform: PlatformExpress,
      mongod: {
        replicaSet: true
      }
    })
  ); // Create a server with mocked database
  before((done) => {
    request = SuperTest(PlatformTest.callback());
    done();
  });

  after(TestMongooseContext.reset); // reset database and injector

  describe("GET /rest/calendars", () => {
    it("should do something", async () => {
      const response = await request.get("/rest/calendars").expect(200);

      expect(response.body).to.be.an("array");
    });
  });
});
```

## Todos

- [ ] Tests
- [ ] Coverage
- [x] Example
- [x] Documentation
