### PR TITLE
feat(terminus): rewrite @tsed/terminus plugin to be more dev friendly

### DIFF
--- a/docs/docs/cache.md
+++ b/docs/docs/cache.md
@@ -73,6 +73,64 @@ const mongooseStore = require("cache-manager-mongoose");
 export class Server {}
 ```
 
+### Sharing IORedis instance
+
+```typescript
+import {Configuration, registerProvider} from "@tsed/di";
+import {Logger} from "@tsed/logger";
+import Redis from "ioredis";
+
+export const REDIS_CONNECTION = Symbol("redis:connection");
+export type REDIS_CONNECTION = Redis;
+
+registerProvider({
+  provide: REDIS_CONNECTION,
+  deps: [Configuration, Logger],
+  async useAsyncFactory(configuration: Configuration, logger: Logger) {
+    const cacheSettings = configuration.get("cache");
+    const redisSettings = configuration.get("redis");
+    const connection = new Redis({...redisSettings, lazyConnect: true});
+
+    cacheSettings.redisInstance = connection;
+
+    try {
+      await connection.connect();
+      logger.info("Connected to redis database...");
+    } catch (error) {
+      logger.error({
+        event: "REDIS_ERROR",
+        error
+      });
+    }
+
+    return connection;
+  },
+  hooks: {
+    $onDestroy(connection: Redis) {
+      return connection.disconnect();
+    }
+  }
+});
+```
+
+Then:
+
+```typescript
+import {Configuration} from "@tsed/common";
+import redisStore from "cache-manager-ioredis";
+
+@Configuration({
+  cache: {
+    ttl: 300, // default TTL
+    store: redisStore
+  },
+  redis: {
+    port: 6379
+  }
+})
+export class Server {}
+```
+
 ## Interacting with the cache store
 
 To interact with the cache manager instance, inject it to your class using the @@PlatformCache@@ token, as follows:

--- a/packages/third-parties/terminus/jest.config.js
+++ b/packages/third-parties/terminus/jest.config.js
@@ -1,0 +1,14 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  ...require("@tsed/jest-config")(__dirname, "terminus"),
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100
+    }
+  }
+};

--- a/packages/third-parties/terminus/package.json
+++ b/packages/third-parties/terminus/package.json
@@ -19,7 +19,8 @@
     "build:cjs": "tsc --build tsconfig.compile.json",
     "build:esm": "tsc --build tsconfig.compile.esm.json",
     "barrels": "yarn barrelsby --delete -d ./src -e \"\\.spec\\.ts\" -e \"__mock__\" -e \".benchmark.ts\"",
-    "start": "ts-node -r tsconfig-paths/register test/app/index.ts"
+    "start": "ts-node -r tsconfig-paths/register test/app/index.ts",
+    "test": "cross-env NODE_ENV=test yarn jest --max-workers=2"
   },
   "dependencies": {
     "tslib": "2.4.0"

--- a/packages/third-parties/terminus/readme.md
+++ b/packages/third-parties/terminus/readme.md
@@ -28,7 +28,7 @@
 
 <hr />
 
-Adds graceful shutdown and Kubernetes readiness / liveness checks for any HTTP applications.
+Adds graceful shutdown and Kubernetes readiness / liveliness checks for any HTTP applications.
 
 ## Installation
 
@@ -74,19 +74,31 @@ export type TerminusSettings = Omit<
 
 ## Usage
 
-### Readiness / liveness checks
+### Readiness / liveliness checks
 
-To create a readiness / liveness checks use the `@Health` decorator.
+To create a readiness / liveliness checks use the `@Health` decorator.
 
 ```ts
 import {Health} from "@tsed/terminus";
+import {Injectable, Inject} from "@tsed/di";
+import {HealthCheckError} from "@godaddy/terminus";
+import {REDIS_CONNECTION} from "./RedisConnection";
 
-@Controller("/mongo")
-class MongoCtrl {
-  @Health("/health")
-  health() {
-    // Here check the mongo health
-    return Promise.resolve();
+@Injectable()
+class RedisClient {
+  @Inject(REDIS_CONNECTION)
+  protected redisConnection: REDIS_CONNECTION;
+
+  @Health("redis")
+  async check() {
+    if (this.redisConnection.status === "ready") {
+      return "OK";
+    }
+
+    // Here check the redis health
+    throw new HealthCheckError("failed", {
+      redis: this.redisConnection.status
+    });
   }
 }
 ```
@@ -95,19 +107,50 @@ You can also create an `HealthCheckError` when an error appear during your check
 
 ```ts
 import {Health} from "@tsed/terminus";
+import {Injectable, Inject} from "@tsed/di";
 import {HealthCheckError} from "@godaddy/terminus";
+import {REDIS_CONNECTION} from "./RedisConnection";
 
-@Controller("/redis")
-class Redis {
-  @Health("/health")
-  health() {
+@Injectable()
+class RedisClient {
+  @Inject(REDIS_CONNECTION)
+  protected redisConnection: REDIS_CONNECTION;
+
+  @Health("redis")
+  async check() {
+    if (this.redisConnection.status === "ready") {
+      return "ok";
+    }
+
     // Here check the redis health
-    return Promise.reject(
-      new HealthCheckError("failed", {
-        redis: "down"
-      })
-    );
+    throw new HealthCheckError("failed", {
+      redis: this.redisConnection.status
+    });
   }
+}
+```
+
+Expected result when calling the "/health":
+
+```json
+{
+  "status": "ok",
+  "info": [
+    {
+      "mongo": "ok"
+    },
+    {
+      "redis": "ok"
+    }
+  ],
+  "details": [
+    {
+      "mongo": "ok"
+    },
+    {
+      "redis": "ok"
+    }
+  ]
 }
 ```
 
@@ -116,35 +159,32 @@ class Redis {
 `@tsed/terminus` package give some decorators to handle Terminus hooks. These hooks allow you to adds graceful shutdown.
 Here is the list of decorators:
 
-- `BeforeShutdown`: Use this hook if you deploy your application with Kubernetes (see more details [here](https://github.com/godaddy/terminus#how-to-set-terminus-up-with-kubernetes)),
-- `OnSignal`: cleanup hook, returning a promise (used to be onSigterm),
-- `OnShutdown`: called right before exiting,
-- `OnSendFailureDuringShutdown`: called before sending each 503 during shutdowns.
+- `$beforeShutdown`: Use this hook if you deploy your application with Kubernetes (see more
+  details [here](https://github.com/godaddy/terminus#how-to-set-terminus-up-with-kubernetes)),
+- `$onSignal`: cleanup hook, returning a promise (used to be onSigterm),
+- `$onShutdown`: called right before exiting,
+- `$onSendFailureDuringShutdown`: called before sending each 503 during shutdowns.
 
 **Example:**
 
 ```typescript
-import {BeforeShutdown, OnSendFailureDuringShutdown, OnShutdown, OnSignal} from "@tsed/terminus";
+import {Injectable} from "@tsed/di";
 
-@Controller("/redis")
+@Injectable()
 class RedisCtrl {
-  @BeforeShutdown()
-  beforeShutdow() {
+  $beforeShutdown() {
     console.log("called before shutdown");
   }
 
-  @OnSignal()
-  OnSignal() {
+  $onSignal() {
     console.log("called on signal");
   }
 
-  @OnShutdown()
-  OnShutdown() {
+  $onShutdown() {
     console.log("called on shutdown");
   }
 
-  @OnSendFailureDuringShutdown()
-  OnSendFailureDuringShutdown() {
+  $onSendFailureDuringShutdown() {
     console.log("on send failure during shutdown");
   }
 }

--- a/packages/third-parties/terminus/src/TerminusModule.spec.ts
+++ b/packages/third-parties/terminus/src/TerminusModule.spec.ts
@@ -1,0 +1,74 @@
+import {Injectable, PlatformTest} from "@tsed/common";
+import {Health} from "./decorators/health";
+import {TerminusModule} from "./TerminusModule";
+
+@Injectable()
+class MyService {
+  @Health("mongo")
+  mongo() {
+    return Promise.resolve("OK");
+  }
+
+  @Health("/redis/health")
+  redis() {
+    return Promise.resolve("OK");
+  }
+}
+
+describe("TerminusModule", () => {
+  beforeEach(() =>
+    PlatformTest.create({
+      terminus: {
+        path: "/health"
+      }
+    })
+  );
+  afterEach(() => PlatformTest.reset());
+
+  it("should load health providers", async () => {
+    const terminusModule = PlatformTest.get<TerminusModule>(TerminusModule);
+
+    const {logger, ...props} = terminusModule.getConfiguration();
+
+    expect(props).toEqual({
+      beforeShutdown: expect.any(Function),
+      healthChecks: {
+        "/mongo/health": expect.any(Function),
+        "/redis/health": expect.any(Function),
+        "/health": expect.any(Function)
+      },
+      onSendFailureDuringShutdown: expect.any(Function),
+      onShutdown: expect.any(Function),
+      onSignal: expect.any(Function)
+    });
+
+    const result = await props.healthChecks["/health"]({});
+
+    expect(result).toEqual([
+      {mongo: "OK"},
+      {"/redis/health": "OK"} // legacy
+    ]);
+
+    logger("event", {message: "message"});
+
+    expect((await terminusModule.$logRoutes([])).map((o) => o.toJSON())).toEqual([
+      {
+        method: "GET",
+        name: "TerminusModule.dispatch",
+        url: "/health"
+      },
+      {
+        method: "GET",
+        name: "MyService.mongo",
+        url: "/mongo/health"
+      },
+      {
+        method: "GET",
+        name: "MyService.redis",
+        url: "/redis/health"
+      }
+    ]);
+
+    await props.onSignal();
+  });
+});

--- a/packages/third-parties/terminus/src/decorators/health.ts
+++ b/packages/third-parties/terminus/src/decorators/health.ts
@@ -20,11 +20,9 @@ import {Store} from "@tsed/core";
  * @terminus
  */
 export function Health(name: string): MethodDecorator {
-  return <Function>(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<Function>) => {
-    if (descriptor.value) {
-      Store.from(target).merge("terminus", {
-        [name]: descriptor.value
-      });
-    }
+  return <Function>(target: Object, propertyKey: string) => {
+    Store.from(target).merge(`terminus:health`, {
+      [propertyKey]: {name}
+    });
   };
 }

--- a/packages/third-parties/terminus/src/decorators/shutdown.ts
+++ b/packages/third-parties/terminus/src/decorators/shutdown.ts
@@ -1,13 +1,8 @@
-import {Store} from "@tsed/core";
-
-function register(name: string) {
-  return <Function>(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<Function>) => {
-    if (descriptor.value) {
-      const store = Store.from(target);
-      const values = store.get(name) || [];
-
-      store.merge(name, [...values, descriptor.value]);
-    }
+export function register(event: string) {
+  return <Function>(target: Object, propertyKey: string, description: PropertyDescriptor) => {
+    Object.defineProperty(target, `$${event}`, {
+      value: description.value
+    });
   };
 }
 
@@ -16,6 +11,7 @@ function register(name: string) {
  *
  * @decorator
  * @terminus
+ * @deprecated Use $BeforeShutdown hook
  */
 export function BeforeShutdown(): MethodDecorator {
   return register("beforeShutdown");
@@ -26,6 +22,7 @@ export function BeforeShutdown(): MethodDecorator {
  *
  * @decorator
  * @terminus
+ * @deprecated Use $onSignal hook
  */
 export function OnSignal(): MethodDecorator {
   return register("onSignal");
@@ -36,6 +33,7 @@ export function OnSignal(): MethodDecorator {
  *
  * @decorator
  * @terminus
+ * @deprecated Use $onShutdown hook
  */
 export function OnShutdown(): MethodDecorator {
   return register("onShutdown");
@@ -46,7 +44,8 @@ export function OnShutdown(): MethodDecorator {
  *
  * @decorator
  * @terminus
+ * @deprecated Use $onSendFailureDuringShutdown hook
  */
 export function OnSendFailureDuringShutdown(): MethodDecorator {
-  return register("onSendFailureDuringShutdown");
+  return register("OnSendFailureDuringShutdown");
 }

--- a/packages/third-parties/terminus/src/interfaces/TerminusSettings.ts
+++ b/packages/third-parties/terminus/src/interfaces/TerminusSettings.ts
@@ -3,4 +3,4 @@ import {TerminusOptions} from "@godaddy/terminus";
 export type TerminusSettings = Omit<
   TerminusOptions,
   "healthChecks" | "onSignal" | "onSendFailureDuringShutdown" | "onShutdown" | "beforeShutdown" | "onSigterm"
->;
+> & {path?: string};

--- a/packages/third-parties/terminus/test/app/Server.ts
+++ b/packages/third-parties/terminus/test/app/Server.ts
@@ -1,59 +1,17 @@
-import {HealthCheckError} from "@godaddy/terminus";
 import "@tsed/ajv";
-import {Controller, PlatformApplication} from "@tsed/common";
+import {PlatformApplication} from "@tsed/common";
 import {Configuration, Inject} from "@tsed/di";
+import "@tsed/terminus";
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import {Application} from "express";
-import {BeforeShutdown, Health, OnSendFailureDuringShutdown, OnShutdown, OnSignal} from "../../src";
+import "./services/MongoClient";
+import "./services/RedisClient";
 
 export const rootDir = __dirname;
 
-@Controller("/mongo")
-class MongoCtrl {
-  @Health("/health")
-  health() {
-    return Promise.resolve();
-  }
-}
-
-@Controller("/redis")
-class RedisCtrl {
-  @Health("/health")
-  health() {
-    return Promise.reject(
-      new HealthCheckError("failed", {
-        redis: "down"
-      })
-    );
-  }
-
-  @BeforeShutdown()
-  beforeShutdow() {
-    console.log("called before shutdown");
-  }
-
-  @OnSignal()
-  onSignal() {
-    console.log("called on signal");
-  }
-
-  @OnShutdown()
-  onShutdown() {
-    console.log("called on shutdown");
-  }
-
-  @OnSendFailureDuringShutdown()
-  onSendFailureDuringShutdown() {
-    console.log("on send failure during shutdown");
-  }
-}
-
 @Configuration({
   port: 8081,
-  mount: {
-    "/": [RedisCtrl, MongoCtrl]
-  },
   terminus: {
     signal: "SIGTERM",
     statusError: 500,

--- a/packages/third-parties/terminus/test/app/services/MongoClient.ts
+++ b/packages/third-parties/terminus/test/app/services/MongoClient.ts
@@ -1,0 +1,10 @@
+import {Injectable} from "@tsed/di";
+import {Health} from "@tsed/terminus";
+
+@Injectable()
+class MongoClient {
+  @Health("mongo")
+  async health() {
+    return "ok";
+  }
+}

--- a/packages/third-parties/terminus/test/app/services/RedisClient.ts
+++ b/packages/third-parties/terminus/test/app/services/RedisClient.ts
@@ -1,0 +1,26 @@
+import {Injectable} from "@tsed/di";
+import {Health} from "@tsed/terminus";
+
+@Injectable()
+class RedisClient {
+  @Health("redis")
+  async health() {
+    return "ok";
+  }
+
+  $beforeShutdown() {
+    console.log("called before shutdown");
+  }
+
+  $onSignal() {
+    console.log("called on signal");
+  }
+
+  $onShutdown() {
+    console.log("called on shutdown");
+  }
+
+  $onSendFailureDuringShutdown() {
+    console.log("on send failure during shutdown");
+  }
+}

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -58,6 +58,7 @@ module.exports = (rootDir) => ({
     "^@tsed/formio$": fixPath(join(packageDir, "third-parties/formio/src")),
     "^@tsed/formio-types$": fixPath(join(packageDir, "third-parties/formio-types/src")),
     "^@tsed/schema-formio$": fixPath(join(packageDir, "third-parties/schema-formio/src")),
+    "^@tsed/terminus$": fixPath(join(packageDir, "third-parties/terminus/src")),
     "^@tsed/stripe$": fixPath(join(packageDir, "third-parties/stripe/src")),
     "^@tsed/socketio$": fixPath(join(packageDir, "third-parties/socketio/src")),
     "^@tsed/socketio-testing$": fixPath(join(packageDir, "third-parties/socketio-testing/src")),


### PR DESCRIPTION
## Information

This PR improve the `@tsed/terminus` usage and clarify how the module should be used.

## Usage example

To create a readiness / liveliness checks use the `@Health` decorator.

```ts
import {Health} from "@tsed/terminus";
import {Injectable, Inject} from "@tsed/di";
import {HealthCheckError} from "@godaddy/terminus";
import {REDIS_CONNECTION} from "./RedisConnection";

@Injectable()
class RedisClient {
  @Inject(REDIS_CONNECTION)
  protected redisConnection: REDIS_CONNECTION;

  @Health("redis")
  async check() {
    if (this.redisConnection.status === "ready") {
      return "OK";
    }

    // Here check the redis health
    throw new HealthCheckError("failed", {
      redis: this.redisConnection.status
    });
  }
}
```

You can also create an `HealthCheckError` when an error appear during your check.

```ts
import {Health} from "@tsed/terminus";
import {Injectable, Inject} from "@tsed/di";
import {HealthCheckError} from "@godaddy/terminus";
import {REDIS_CONNECTION} from "./RedisConnection";

@Injectable()
class RedisClient {
  @Inject(REDIS_CONNECTION)
  protected redisConnection: REDIS_CONNECTION;

  @Health("redis")
  async check() {
    if (this.redisConnection.status === "ready") {
      return "OK";
    }

    // Here check the redis health
    throw new HealthCheckError("failed", {
      redis: this.redisConnection.status
    });
  }
}
```

Expected result when calling the "/health":

```json
{
  "status": "ok",
  "info": [
    {
      "mongo": "ok"
    },
    {
      "redis": "ok"
    }
  ],
  "details": [
    {
      "mongo": "ok"
    },
    {
      "redis": "ok"
    }
  ]
}
```


### Graceful shutdown

`@tsed/terminus` package give some decorators to handle Terminus hooks. These hooks allow you to adds graceful shutdown.
Here is the list of decorators:

- `$beforeShutdown`: Use this hook if you deploy your application with Kubernetes (see more
  details [here](https://github.com/godaddy/terminus#how-to-set-terminus-up-with-kubernetes)),
- `$onSignal`: cleanup hook, returning a promise (used to be onSigterm),
- `$onShutdown`: called right before exiting,
- `$onSendFailureDuringShutdown`: called before sending each 503 during shutdowns.

**Example:**

```typescript
import {Injectable} from "@tsed/di";

@Injectable()
class RedisCtrl {
  $beforeShutdown() {
    console.log("called before shutdown");
  }

  $onSignal() {
    console.log("called on signal");
  }

  $onShutdown() {
    console.log("called on shutdown");
  }

  $onSendFailureDuringShutdown() {
    console.log("on send failure during shutdown");
  }
}
```


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
