### PR TITLE
fix(schema): adjust `examples` schema value placement  when `@Exampe` used in conjunction with `@CollectionOf`

### DIFF
--- a/packages/specs/schema/src/decorators/common/example.spec.ts
+++ b/packages/specs/schema/src/decorators/common/example.spec.ts
@@ -1,5 +1,5 @@
 import {descriptorOf, useDecorators} from "@tsed/core";
-import {Description, getSpec, In, Name, OperationPath, Path, Pattern, SpecTypes} from "@tsed/schema";
+import {CollectionOf, Description, getSpec, In, Name, OperationPath, Path, Pattern, SpecTypes} from "@tsed/schema";
 import {getJsonSchema} from "../../utils/getJsonSchema";
 import {Example} from "./example";
 
@@ -84,6 +84,30 @@ describe("@Example", () => {
         method: {
           examples: ["Examples"],
           type: "string"
+        }
+      },
+      type: "object"
+    });
+  });
+
+  it("should declare description on collection property", () => {
+    // WHEN
+
+    class Model {
+      @Example("Examples")
+      @CollectionOf(String)
+      collection: string[];
+    }
+
+    // THEN
+    expect(getJsonSchema(Model)).toEqual({
+      properties: {
+        collection: {
+          items: {
+            examples: ["Examples"],
+            type: "string"
+          },
+          type: "array"
         }
       },
       type: "object"

--- a/packages/specs/schema/src/decorators/common/example.ts
+++ b/packages/specs/schema/src/decorators/common/example.ts
@@ -13,6 +13,6 @@ import {JsonEntityFn} from "./jsonEntityFn";
  */
 export function Example(...examples: any[]): Function {
   return JsonEntityFn((store: JsonEntityStore) => {
-    store.schema.examples(examples);
+    store.itemSchema.examples(examples);
   });
 }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---


## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/schema";

class Model {
  @Example("Examples")
  @CollectionOf(String)
  collection: string[];
}
```
expected to produce schema

```typescript
{
  properties: {
    collection: {
      items: {
        examples: ["Examples"],
        type: "string"
      },
      type: "array"
    }
  },
  type: "object"
}
```
<!-- 
## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
-->
