### PR TITLE
fix(core): deepClone did not clone RegExp objects correctly

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export * from "./utils/objects/isPlainObject";
 export * from "./utils/objects/isPrimitive";
 export * from "./utils/objects/isPromise";
 export * from "./utils/objects/isProtectedKey";
+export * from "./utils/objects/isRegExp";
 export * from "./utils/objects/isSerializable";
 export * from "./utils/objects/isStream";
 export * from "./utils/objects/isString";

--- a/packages/core/src/utils/objects/deepClone.spec.ts
+++ b/packages/core/src/utils/objects/deepClone.spec.ts
@@ -39,7 +39,8 @@ describe("deepClone", () => {
       h: Infinity,
       i: externalObject,
       j: new Test("test"),
-      k: [new Test("test"), false, 1, Test]
+      k: [new Test("test"), false, 1, Test],
+      l: new RegExp(/test/i)
     };
 
     const cloned = deepClone(original);
@@ -55,6 +56,10 @@ describe("deepClone", () => {
     expect(cloned.k.length).toBe(4);
     expect(cloned.k[0]).toBeInstanceOf(Test);
     expect(cloned.k[3]).toBe(Test);
+
+    expect(cloned.l).toBeInstanceOf(RegExp);
+    expect(cloned.l.source).toBe("test");
+    expect(cloned.l.flags).toBe("i");
 
     expect(deepClone(new Test("test"))).toBeInstanceOf(Test);
   });

--- a/packages/core/src/utils/objects/deepClone.ts
+++ b/packages/core/src/utils/objects/deepClone.ts
@@ -5,6 +5,7 @@ import {isNil} from "./isNil";
 import {isPrimitive} from "./isPrimitive";
 import {isSymbol} from "./isSymbol";
 import {isBuffer} from "./isBuffer";
+import {isRegExp} from "./isRegExp";
 
 const isBasicType = (source: any) => isNil(source) || isPrimitive(source) || isSymbol(source) || isFunction(source);
 
@@ -28,6 +29,10 @@ export function deepClone(source: any, stack = new WeakMap()): any {
 
   if (isDate(source)) {
     return new Date(source);
+  }
+
+  if (isRegExp(source)) {
+    return new RegExp(source);
   }
 
   const stacked = stack.get(source);

--- a/packages/core/src/utils/objects/isRegExp.ts
+++ b/packages/core/src/utils/objects/isRegExp.ts
@@ -1,0 +1,3 @@
+export function isRegExp(target: any): target is RegExp {
+  return target instanceof RegExp;
+}


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

Fixes an issue where deepClone won't clone RegExp instances correctly.

Required for #2061 to work as the Store deepClones values on `Store.merge()`

Note that I did not look closely at deepMerge.

## Todos

- [x] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
