### PR TITLE
feat(socketio): allow dynamic namespaces for @SocketService and @Nsp/@Namespace

### DIFF
--- a/docs/tutorials/snippets/socketio/socket-service-dynamic-nsp.ts
+++ b/docs/tutorials/snippets/socketio/socket-service-dynamic-nsp.ts
@@ -1,0 +1,13 @@
+import {Nsp, SocketNsp, Input, SocketService} from "@tsed/socketio";
+import * as SocketIO from "socket.io";
+
+@SocketService(/my-namespace-.+/)
+export class MySocketService {
+  // This will be the parent namespace.
+  @Nsp nsp: SocketIO.Namespace;
+
+  @Input("eventName")
+  async myMethod(@SocketNsp nsp: SocketNsp) {
+    // nsp is the actual namespace of this call.
+  }
+}

--- a/docs/tutorials/socket-io.md
+++ b/docs/tutorials/socket-io.md
@@ -63,6 +63,12 @@ Then, you can inject your socket service into another Service, Controller, etc. 
 
 <<< @/tutorials/snippets/socketio/socket-service-di.ts
 
+### Dynamic Namespaces
+
+> Socket.io [dynamic namespaces](https://socket.io/docs/v4/namespaces/#dynamic-namespaces) can be implemented using @@SocketService@@, @@Namespace@@ and @@Nsp@@
+
+<<< @/tutorials/snippets/socketio/socket-service-dynamic-nsp.ts
+
 ### Declaring an Input Event
 
 @@Input@@ decorator declares a method as a new handler for a specific `event`.
@@ -72,7 +78,8 @@ Then, you can inject your socket service into another Service, Controller, etc. 
 - @@Args@@ &lt;any|any[]&gt;: List of the parameters sent by the input event.
 - @@Socket@@ &lt;SocketIO.Socket&gt;: Socket instance.
 - @@Namespace@@ &lt;[SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#)&gt;: Namespace instance.
-- @@Nps@@ &lt;[SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#)&gt;: Namespace instance.
+- @@Nsp@@ &lt;[SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#)&gt;: Namespace instance.
+- @@SocketNsp@@ &lt;[SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#)&gt;: Namespace instance from socket.
 
 ### Send a response
 

--- a/packages/third-parties/socketio/src/class/SocketHandlersBuilder.spec.ts
+++ b/packages/third-parties/socketio/src/class/SocketHandlersBuilder.spec.ts
@@ -383,11 +383,7 @@ describe("SocketHandlersBuilder", () => {
               filter: SocketFilters.NSP
             }
           },
-          {
-            socket: {
-              nsp: "nsp"
-            }
-          }
+          {nsp: "nsp"}
         );
 
         expect(result).toEqual(["nsp"]);
@@ -446,6 +442,23 @@ describe("SocketHandlersBuilder", () => {
         );
 
         expect(result[0]).toBeInstanceOf(Map);
+      });
+    });
+
+    describe("when SOCKET_NSP", () => {
+      it("should return a list of parameters", () => {
+        const {builder} = createFixture();
+
+        const result = builder.buildParameters(
+          {
+            0: {
+              filter: SocketFilters.SOCKET_NSP
+            }
+          },
+          {socket: {nsp: "socket_nsp"}}
+        );
+
+        expect(result).toEqual(["socket_nsp"]);
       });
     });
   });

--- a/packages/third-parties/socketio/src/class/SocketHandlersBuilder.spec.ts
+++ b/packages/third-parties/socketio/src/class/SocketHandlersBuilder.spec.ts
@@ -383,7 +383,11 @@ describe("SocketHandlersBuilder", () => {
               filter: SocketFilters.NSP
             }
           },
-          {nsp: "nsp"}
+          {
+            socket: {
+              nsp: "nsp"
+            }
+          }
         );
 
         expect(result).toEqual(["nsp"]);

--- a/packages/third-parties/socketio/src/class/SocketHandlersBuilder.ts
+++ b/packages/third-parties/socketio/src/class/SocketHandlersBuilder.ts
@@ -52,7 +52,7 @@ export class SocketHandlersBuilder {
    *
    * @returns {any}
    */
-  public build(nsps: Map<string, Namespace>) {
+  public build(nsps: Map<string | RegExp, Namespace>) {
     const instance = this.injector.get(this.provider.token);
     const {injectNamespaces, namespace} = this.socketProviderMetadata;
     const nsp = nsps.get(namespace);
@@ -243,7 +243,7 @@ export class SocketHandlersBuilder {
           return scope.socket;
 
         case SocketFilters.NSP:
-          return scope.nsp;
+          return scope.socket.nsp;
 
         case SocketFilters.ERR:
           return scope.error;

--- a/packages/third-parties/socketio/src/class/SocketHandlersBuilder.ts
+++ b/packages/third-parties/socketio/src/class/SocketHandlersBuilder.ts
@@ -243,7 +243,7 @@ export class SocketHandlersBuilder {
           return scope.socket;
 
         case SocketFilters.NSP:
-          return scope.socket.nsp;
+          return scope.nsp;
 
         case SocketFilters.ERR:
           return scope.error;
@@ -251,6 +251,9 @@ export class SocketHandlersBuilder {
         case SocketFilters.SESSION:
           const instance = this.injector.get(this.provider.token);
           return instance._nspSession.get(scope.socket.id);
+
+        case SocketFilters.SOCKET_NSP:
+          return scope.socket.nsp;
       }
     });
   }

--- a/packages/third-parties/socketio/src/class/SocketProviderMetadata.ts
+++ b/packages/third-parties/socketio/src/class/SocketProviderMetadata.ts
@@ -4,7 +4,7 @@ import {SocketProviderTypes} from "../interfaces/SocketProviderTypes";
 
 export class SocketProviderMetadata {
   public type: SocketProviderTypes;
-  public namespace: string;
+  public namespace: string | RegExp;
   public error: boolean = false;
   public injectNamespaces: SocketInjectableNsp[] = [];
   public useBefore: any[] = [];

--- a/packages/third-parties/socketio/src/decorators/nsp.spec.ts
+++ b/packages/third-parties/socketio/src/decorators/nsp.spec.ts
@@ -40,7 +40,7 @@ describe("Nsp", () => {
   });
 
   describe("when it used as property decorator with parameters", () => {
-    it("should set metadata", () => {
+    it("should set metadata (string)", () => {
       class Test {
         @Nsp("/test")
         property: any;
@@ -49,6 +49,20 @@ describe("Nsp", () => {
       const store = Store.from(Test);
       expect(store.get("socketIO")).toEqual({
         injectNamespaces: [{propertyKey: "property", nsp: "/test"}]
+      });
+    });
+
+    it("should set metadata (RegExp)", () => {
+      const regexp = new RegExp(/test/);
+
+      class Test {
+        @Nsp(regexp)
+        property: any;
+      }
+
+      const store = Store.from(Test);
+      expect(store.get("socketIO")).toEqual({
+        injectNamespaces: [{propertyKey: "property", nsp: regexp}]
       });
     });
   });

--- a/packages/third-parties/socketio/src/decorators/nsp.ts
+++ b/packages/third-parties/socketio/src/decorators/nsp.ts
@@ -8,6 +8,7 @@ export type Nsp = NamespaceType;
 
 /**
  * Inject the [SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#namespaces) instance in the decorated parameter.
+ * Note that when using dynamic namespaces, when injecting a parameter, you may want to consider using @SocketNsp instead.
  *
  * ### Example
  *
@@ -44,6 +45,7 @@ export function Nsp(target: any, propertyKey?: string, index?: number): any {
 
 /**
  * Inject the [SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#namespaces) instance in the decorated parameter.
+ * Note that when using dynamic namespaces, when injecting a parameter, you may want to consider using @SocketNsp instead.
  *
  * ### Example
  *

--- a/packages/third-parties/socketio/src/decorators/nsp.ts
+++ b/packages/third-parties/socketio/src/decorators/nsp.ts
@@ -1,4 +1,4 @@
-import {decoratorTypeOf, DecoratorTypes, Store} from "@tsed/core";
+import {decoratorTypeOf, DecoratorTypes, Store, isRegExp} from "@tsed/core";
 import {Namespace as NamespaceType} from "socket.io";
 import {SocketFilters} from "../interfaces/SocketFilters";
 import {SocketFilter} from "./socketFilter";
@@ -22,6 +22,9 @@ export type Nsp = NamespaceType;
  *
  *   @Nsp("/my-other-namespace")
  *   nspOther: SocketIO.Namespace; // communication between two namespace
+ *
+ *   @Nsp(/regexp/)
+ *   nspDynamic: SocketIO.Namespace; // will inject a dynamic namespace (not available on constructor)
  *
  *   @Input("event")
  *   myMethod(@Nsp namespace: SocketIO.Namespace) {
@@ -50,11 +53,14 @@ export function Nsp(target: any, propertyKey?: string, index?: number): any {
  * @SocketService("/nsp")
  * export class MyWS {
  *
- *   @Nsp
- *   nsp: Namespace; // will inject SocketIO.Namespace (not available on constructor)
+ *   @Namespace
+ *   nsp: SocketIO.Namespace; // will inject SocketIO.Namespace (not available on constructor)
  *
- *   @Nsp("/my-other-namespace")
- *   nspOther: Namespace; // communication between two namespace
+ *   @Namespace("/my-other-namespace")
+ *   nspOther: SocketIO.Namespace; // communication between two namespace
+ *
+ *   @Namespace(/regexp/)
+ *   nspDynamic: SocketIO.Namespace; // will inject a dynamic namespace (not available on constructor)
  *
  *   @Input("event")
  *   myMethod(@Namespace namespace: Namespace) {
@@ -70,8 +76,8 @@ export function Nsp(target: any, propertyKey?: string, index?: number): any {
  * @decorator
  */
 export function Namespace(target: any, propertyKey?: string, index?: number): any {
-  if (typeof target === "string") {
-    const nsp = target as string;
+  if (typeof target === "string" || isRegExp(target)) {
+    const nsp = target as string | RegExp;
 
     return (target: any, propertyKey: string) => {
       Store.from(target).merge("socketIO", {

--- a/packages/third-parties/socketio/src/decorators/socketNsp.spec.ts
+++ b/packages/third-parties/socketio/src/decorators/socketNsp.spec.ts
@@ -1,0 +1,25 @@
+import {Store} from "@tsed/core";
+import {SocketNsp} from "../index";
+
+describe("SocketNsp", () => {
+  it("should set metadata", () => {
+    class Test {}
+
+    SocketNsp(Test, "test", 0);
+
+    const store = Store.from(Test);
+
+    expect(store.get("socketIO")).toEqual({
+      handlers: {
+        test: {
+          parameters: {
+            "0": {
+              filter: "socket_nsp",
+              mapIndex: undefined
+            }
+          }
+        }
+      }
+    });
+  });
+});

--- a/packages/third-parties/socketio/src/decorators/socketNsp.ts
+++ b/packages/third-parties/socketio/src/decorators/socketNsp.ts
@@ -4,6 +4,29 @@ import {SocketFilter} from "./socketFilter";
 
 export type SocketNsp = Namespace;
 
+/**
+ * Inject the [SocketIO.Namespace](https://socket.io/docs/rooms-and-namespaces/#namespaces) instance in the decorated parameter.
+ * This namespace may differ from the default namespace when using dynamic namespaces.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * @SocketService(/nsp-.+/)
+ * export class MyWS {
+ *
+ *   @Input("event")
+ *   myMethod(@SocketNsp nsp: SocketNsp) {
+ *
+ *   }
+ * }
+ * ```
+ *
+ * @experimental
+ * @param target
+ * @param {string} propertyKey
+ * @param {number} index
+ * @decorator
+ */
 export function SocketNsp(target: any, propertyKey: string, index: number): any {
   return SocketFilter(SocketFilters.SOCKET_NSP)(target, propertyKey, index);
 }

--- a/packages/third-parties/socketio/src/decorators/socketNsp.ts
+++ b/packages/third-parties/socketio/src/decorators/socketNsp.ts
@@ -1,0 +1,9 @@
+import {Namespace} from "./nsp";
+import {SocketFilters} from "../interfaces/SocketFilters";
+import {SocketFilter} from "./socketFilter";
+
+export type SocketNsp = Namespace;
+
+export function SocketNsp(target: any, propertyKey: string, index: number): any {
+  return SocketFilter(SocketFilters.SOCKET_NSP)(target, propertyKey, index);
+}

--- a/packages/third-parties/socketio/src/decorators/socketService.spec.ts
+++ b/packages/third-parties/socketio/src/decorators/socketService.spec.ts
@@ -26,4 +26,18 @@ describe("SocketService", () => {
       });
     });
   });
+  describe("case 3", () => {
+    class Test {}
+    it("should set metadata", () => {
+      const regexp = new RegExp(/test/);
+
+      SocketService(regexp)(Test);
+      const store = Store.from(Test);
+
+      expect(store.get("socketIO")).toEqual({
+        namespace: regexp,
+        type: "service"
+      });
+    });
+  });
 });

--- a/packages/third-parties/socketio/src/decorators/socketService.ts
+++ b/packages/third-parties/socketio/src/decorators/socketService.ts
@@ -9,11 +9,11 @@ import {PROVIDER_TYPE_SOCKET_SERVICE} from "../constants/constants";
  *
  * > `@SocketService()` use the `reflect-metadata` to collect and inject service on controllers or other services.
  *
- * @param {string} namespace
+ * @param namespace
  * @returns {Function}
  * @decorator
  */
-export function SocketService(namespace = "/") {
+export function SocketService(namespace: string | RegExp = "/") {
   return useDecorators(
     StoreMerge("socketIO", {namespace, type: SocketProviderTypes.SERVICE}),
     Injectable({

--- a/packages/third-parties/socketio/src/index.ts
+++ b/packages/third-parties/socketio/src/index.ts
@@ -22,6 +22,7 @@ export * from "./decorators/socketEventName";
 export * from "./decorators/socketFilter";
 export * from "./decorators/socketMiddleware";
 export * from "./decorators/socketMiddlewareError";
+export * from "./decorators/socketNsp";
 export * from "./decorators/socketReturns";
 export * from "./decorators/socketService";
 export * from "./decorators/socketSession";

--- a/packages/third-parties/socketio/src/interfaces/SocketFilters.ts
+++ b/packages/third-parties/socketio/src/interfaces/SocketFilters.ts
@@ -7,5 +7,6 @@ export enum SocketFilters {
   EVENT_NAME = "eventName",
   NSP = "nsp",
   SESSION = "session",
-  ERR = "error"
+  ERR = "error",
+  SOCKET_NSP = "socket_nsp"
 }

--- a/packages/third-parties/socketio/src/interfaces/SocketInjectableNsp.ts
+++ b/packages/third-parties/socketio/src/interfaces/SocketInjectableNsp.ts
@@ -1,4 +1,4 @@
 export interface SocketInjectableNsp {
   propertyKey: string;
-  nsp?: string;
+  nsp?: string | RegExp;
 }

--- a/packages/third-parties/socketio/src/registries/NspSessionRegistry.ts
+++ b/packages/third-parties/socketio/src/registries/NspSessionRegistry.ts
@@ -2,9 +2,9 @@
  *
  * @type {Map<any, any>}
  */
-const SESSIONS: Map<string, Map<string, any>> = new Map();
+const SESSIONS: Map<string | RegExp, Map<string, any>> = new Map();
 
-export function getNspSession(namespace: string = "/") {
+export function getNspSession(namespace: string | RegExp = "/") {
   if (!SESSIONS.has(namespace)) {
     SESSIONS.set(namespace, new Map());
   }

--- a/packages/third-parties/socketio/src/services/SocketIOService.spec.ts
+++ b/packages/third-parties/socketio/src/services/SocketIOService.spec.ts
@@ -32,7 +32,7 @@ describe("SocketIOService", () => {
   beforeEach(() => PlatformTest.create());
   afterEach(() => PlatformTest.reset());
 
-  describe("getNsp()", () => {
+  describe("getNsp(string)", () => {
     it("should call io.of and create namespace", async () => {
       const {service, namespace, ioStub, socket, instance} = await createServiceFixture();
 
@@ -43,6 +43,25 @@ describe("SocketIOService", () => {
       socket.on.mock.calls[0][1]();
 
       expect(ioStub.of).toBeCalledWith("/");
+      expect(namespace.on).toBeCalledWith("connection", expect.any(Function));
+      expect(instance.onConnection).toBeCalledWith(socket, namespace);
+      expect(socket.on).toBeCalledWith("disconnect", expect.any(Function));
+      expect(instance.onDisconnect).toBeCalledWith(socket, namespace);
+    });
+  });
+
+  describe("getNsp(RegExp)", () => {
+    it("should call io.of and create namespace", async () => {
+      const {service, namespace, ioStub, socket, instance} = await createServiceFixture();
+      const regexp = new RegExp(/test/);
+
+      const nspConf = service.getNsp(regexp);
+      nspConf.instances.push(instance);
+
+      namespace.on.mock.calls[0][1](socket);
+      socket.on.mock.calls[0][1]();
+
+      expect(ioStub.of).toBeCalledWith(regexp);
       expect(namespace.on).toBeCalledWith("connection", expect.any(Function));
       expect(instance.onConnection).toBeCalledWith(socket, namespace);
       expect(socket.on).toBeCalledWith("disconnect", expect.any(Function));

--- a/packages/third-parties/socketio/src/services/SocketIOService.ts
+++ b/packages/third-parties/socketio/src/services/SocketIOService.ts
@@ -13,7 +13,7 @@ export class SocketIOService {
    *
    * @type {Map<any, any>}
    */
-  private namespaces: Map<string, {nsp: SocketIO.Namespace; instances: any}> = new Map();
+  private namespaces: Map<string | RegExp, {nsp: SocketIO.Namespace; instances: any}> = new Map();
 
   constructor(private injector: InjectorService, @IO private io: SocketIO.Server) {}
 
@@ -22,7 +22,7 @@ export class SocketIOService {
    * @param {string} namespace
    * @returns {SocketIO.Namespace}
    */
-  public getNsp(namespace: string = "/"): {nsp: SocketIO.Namespace; instances: any[]} {
+  public getNsp(namespace: string | RegExp = "/"): {nsp: SocketIO.Namespace; instances: any[]} {
     if (!this.namespaces.has(namespace)) {
       const conf = {nsp: this.io.of(namespace), instances: []};
 

--- a/packages/third-parties/socketio/test/socket.integration.spec.ts
+++ b/packages/third-parties/socketio/test/socket.integration.spec.ts
@@ -1,6 +1,6 @@
 import {Inject, PlatformTest} from "@tsed/common";
 import {PlatformExpress} from "@tsed/platform-express";
-import {Emit, Input, SocketIOServer, SocketService, SocketSession, SocketUseBefore} from "@tsed/socketio";
+import {Emit, Input, Nsp, SocketIOServer, SocketService, SocketSession, SocketUseBefore} from "@tsed/socketio";
 import {SocketClientService} from "@tsed/socketio-testing";
 import {Namespace, Socket as IOSocket} from "socket.io";
 import {ConverterUserSocketMiddleware} from "./app/middlewares/ConverterUserSocketMiddleware";
@@ -20,6 +20,25 @@ export class TestWS {
   @SocketUseBefore(ConverterUserSocketMiddleware)
   async scenario1(@SocketSession session: Map<any, any>) {
     return "my Message " + session.get("test");
+  }
+}
+
+@SocketService(/test-.+/)
+export class TestWS2 {
+  @Inject()
+  private io: SocketIOServer;
+
+  @Nsp nsp: Namespace;
+
+  $onConnection(socket: IOSocket, nsp: Namespace) {}
+
+  $onDisconnect(socket: IOSocket, nsp: Namespace) {}
+
+  @Input("input:scenario2")
+  @Emit("output:scenario2")
+  @SocketUseBefore(ConverterUserSocketMiddleware)
+  async scenario2(@Nsp nsp: Nsp) {
+    return "namespace:" + nsp.name;
   }
 }
 
@@ -87,6 +106,51 @@ describe("Socket integration: custom path", () => {
 
         client.emit("input:scenario1");
       });
+    });
+  });
+});
+
+describe("Socket integration: Dynamic Namespace", () => {
+  beforeAll(
+    PlatformTest.bootstrap(Server, {
+      platform: PlatformExpress,
+      listen: true,
+      httpPort: 8999,
+      componentsScan: [],
+      mount: {},
+      disableComponentScan: true,
+      imports: [TestWS2]
+    })
+  );
+  afterAll(PlatformTest.reset);
+
+  describe("RoomWS: eventName (Dynamic Namespace)", () => {
+    it("should return the data", async () => {
+      const service = PlatformTest.get<SocketClientService>(SocketClientService);
+      const client = await service.get("/test-1");
+      const client2 = await service.get("/test-2");
+
+      expect(client).not.toEqual(client2);
+
+      return Promise.all([
+        new Promise((resolve: any) => {
+          client.on("output:scenario2", (result) => {
+            expect(result).toEqual("namespace:/test-1");
+            resolve();
+          });
+
+          client.emit("input:scenario2");
+        }),
+
+        new Promise((resolve: any) => {
+          client2.on("output:scenario2", (result) => {
+            expect(result).toEqual("namespace:/test-2");
+            resolve();
+          });
+
+          client2.emit("input:scenario2");
+        })
+      ]);
     });
   });
 });

--- a/packages/third-parties/socketio/test/socket.integration.spec.ts
+++ b/packages/third-parties/socketio/test/socket.integration.spec.ts
@@ -1,6 +1,6 @@
 import {Inject, PlatformTest} from "@tsed/common";
 import {PlatformExpress} from "@tsed/platform-express";
-import {Emit, Input, Nsp, SocketIOServer, SocketService, SocketSession, SocketUseBefore} from "@tsed/socketio";
+import {Emit, Input, Nsp, SocketNsp, SocketIOServer, SocketService, SocketSession, SocketUseBefore} from "@tsed/socketio";
 import {SocketClientService} from "@tsed/socketio-testing";
 import {Namespace, Socket as IOSocket} from "socket.io";
 import {ConverterUserSocketMiddleware} from "./app/middlewares/ConverterUserSocketMiddleware";
@@ -37,7 +37,7 @@ export class TestWS2 {
   @Input("input:scenario2")
   @Emit("output:scenario2")
   @SocketUseBefore(ConverterUserSocketMiddleware)
-  async scenario2(@Nsp nsp: Nsp) {
+  async scenario2(@SocketNsp nsp: SocketNsp) {
     return "namespace:" + nsp.name;
   }
 }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

Fixes #2061

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";
```
-->

Allows the use of dynamic namespaces for socket.io:

```typescript
//// MySocketService.ts
import { SocketService, Input, Emit } from "@tsed/socketio";

@SocketService(/test-.+/)
export class MySocketService
{
    @Input('event')
    @Emit('data')
    async dataEvent(@Nsp nsp: Nsp) {
        return nsp.name;
    }
}

//// Client
const socket1 = io('http://localhost:8083/test-1');
socket1.on('data', (namespace) => {
    console.log(namespace); // => "/test-1"
});

const socket2 = io('http://localhost:8083/test-2');
socket2.on('data', (namespace) => {
    console.log(namespace); // => "/test-2"
});

socket1.emit('event');
socket2.emit('event');
```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
