### PR TITLE
It fixes the Constant values section on the Models documentation (Json Schema)

### DIFF
--- a/docs/docs/model.md
+++ b/docs/docs/model.md
@@ -336,7 +336,7 @@ United States for export reasons:
   </Tab>
   <Tab label="Json schema">
 
-<<< @/docs/snippets/model/constant-values.ts
+<<< @/docs/snippets/model/constant-values.json
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Information
Fix the JsonSchema link, it was pointing to the TS file.
Doc link: https://tsed.io/docs/model.html#constant-values

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos
- [x] Documentation
