### PR TITLE
feat(schema): add deprecated decorator for params and props

### DIFF
--- a/packages/specs/schema/src/decorators/operations/deprecated.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/deprecated.spec.ts
@@ -1,5 +1,6 @@
 import {Deprecated, getSpec, OperationPath, Returns, SpecTypes} from "@tsed/schema";
 import {QueryParams} from "@tsed/platform-params";
+import {catchError} from "@tsed/core";
 
 describe("Deprecated", () => {
   it("should store metadata (swagger)", () => {
@@ -207,5 +208,15 @@ describe("Deprecated", () => {
         }
       }
     });
+  });
+  it("should throw an error when the decorator is as static func decorator", () => {
+    const error = catchError(() => {
+      class Model {
+        @Deprecated(true)
+        static myStaticFunc() {}
+      }
+    });
+
+    expect(error?.message).toEqual("Deprecated cannot be used as method.static decorator on Model.myStaticFunc");
   });
 });

--- a/packages/specs/schema/src/decorators/operations/deprecated.ts
+++ b/packages/specs/schema/src/decorators/operations/deprecated.ts
@@ -1,4 +1,4 @@
-import {decorateMethodsOf, DecoratorTypes, UnsupportedDecoratorType} from "@tsed/core";
+import {decorateMethodsOf, decoratorTypeOf, DecoratorTypes, UnsupportedDecoratorType} from "@tsed/core";
 import {JsonEntityFn} from "../common/jsonEntityFn";
 import {JsonPropertyStore} from "../../domain/JsonPropertyStore";
 import {JsonParameterStore} from "../../domain/JsonParameterStore";
@@ -27,7 +27,7 @@ import {JsonParameterStore} from "../../domain/JsonParameterStore";
  */
 export function Deprecated(deprecated: boolean = true) {
   return JsonEntityFn((store, args) => {
-    switch (store.decoratorType) {
+    switch (decoratorTypeOf(args)) {
       case DecoratorTypes.METHOD:
         store.operation!.deprecated(deprecated);
         break;

--- a/packages/specs/schema/src/decorators/operations/deprecated.ts
+++ b/packages/specs/schema/src/decorators/operations/deprecated.ts
@@ -1,6 +1,7 @@
 import {decorateMethodsOf, DecoratorTypes, UnsupportedDecoratorType} from "@tsed/core";
 import {JsonEntityFn} from "../common/jsonEntityFn";
-import {JsonParameterStore, JsonPropertyStore} from "@tsed/schema";
+import {JsonPropertyStore} from "../../domain/JsonPropertyStore";
+import {JsonParameterStore} from "../../domain/JsonParameterStore";
 
 /**
  * Add deprecated metadata on the decorated element.

--- a/packages/specs/schema/src/decorators/operations/deprecated.ts
+++ b/packages/specs/schema/src/decorators/operations/deprecated.ts
@@ -1,5 +1,6 @@
 import {decorateMethodsOf, DecoratorTypes, UnsupportedDecoratorType} from "@tsed/core";
 import {JsonEntityFn} from "../common/jsonEntityFn";
+import {JsonParameterStore, JsonPropertyStore} from "@tsed/schema";
 
 /**
  * Add deprecated metadata on the decorated element.
@@ -31,6 +32,12 @@ export function Deprecated(deprecated: boolean = true) {
         break;
       case DecoratorTypes.CLASS:
         decorateMethodsOf(args[0], Deprecated(deprecated));
+        break;
+      case DecoratorTypes.PARAM:
+        (store as JsonParameterStore).parameter.set("deprecated", deprecated);
+        break;
+      case DecoratorTypes.PROP:
+        (store as JsonPropertyStore).schema.set("deprecated", deprecated);
         break;
 
       default:


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---
**Params**
```typescript
import {Controller, Get, QueryParams} from '@tsed/common';
import {Deprecated} from "@tsed/schema";

@Controller('/model')
class ModelController {
    @Get()
    handler(@QueryParams('filter') @Deprecated() filter: string) {
        // ...
    }
}
```
Will produce the following OAS
```
"/model": {
    "get": {
        "parameters": [
            {
                "deprecated": true,
                "in": "query",
                "name": "filter",
                "required": false,
                "schema": {
                    "type": "string"
                }
            },
        ]
    },
}
```

**Props**
```typescript
import {Deprecated} from "@tsed/schema";
class Model {
    @Deprecated()
    title: string;
}
```
Will produce the following OAS
```
"Model": {
    "type": "object",
    "properties": {
         "newsTitle": {
             "type": "string",
             "deprecated": true
         }
    }
}    
```


## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
