### PR TITLE
feat(objection): add UUID PK column support

### DIFF
--- a/docs/tutorials/objection.md
+++ b/docs/tutorials/objection.md
@@ -80,7 +80,7 @@ export class User extends Model {
 
 ## Relationships
 
-Ts.ED enables you to define relationships between models on properties directly, using decorators such as @@BelongsToOne@@, @@HasMany@@, @@HasOne@@, @@HasOneThroughRelationship@@, @@ManyToMany@@ or @@RelatesTo@@.
+Ts.ED enables you to define relationships between models on properties directly, using decorators such as @@BelongsToOne@@, @@HasMany@@, @@HasOne@@, @@HasOneThroughRelation@@, @@ManyToMany@@ or @@RelatesTo@@.
 
 You can supply a configuration object via (@@RelationshipOpts@@) into the decorator factor to override the default join keys and configure a relationship like you normally would via `relationMappings`. For collection-type relationships, you must also specify the model you wish to use and we will also apply the @@CollectionOf@@ decorator for you automatically.
 

--- a/packages/orm/objection/src/components/createIdColumn.spec.ts
+++ b/packages/orm/objection/src/components/createIdColumn.spec.ts
@@ -1,6 +1,7 @@
 import {Entity, IdColumn} from "@tsed/objection";
-import {createTableStub} from "../../test/helpers/knex/table";
+
 import {createColumns} from "../utils/createColumns";
+import {createTableStub} from "../../test/helpers/knex/table";
 
 describe("createIdColumn", () => {
   it("should create table from a given class (bigIncrements)", async () => {
@@ -27,5 +28,18 @@ describe("createIdColumn", () => {
     createColumns(table, User);
 
     expect(table.increments).toHaveBeenCalledWith("id");
+  });
+
+  it("should create table from a given class (uuid)", async () => {
+    @Entity("users")
+    class User {
+      @IdColumn("uuid")
+      id: string;
+    }
+
+    const table = createTableStub();
+    createColumns(table, User);
+
+    expect(table.uuid).toHaveBeenCalledWith("id");
   });
 });

--- a/packages/orm/objection/src/components/createIdColumn.ts
+++ b/packages/orm/objection/src/components/createIdColumn.ts
@@ -1,15 +1,21 @@
-import type {Knex} from "knex";
-import {ColumnTypesContainer} from "../services/ColumnTypesContainer";
 import {ColumnCtx} from "../utils/getColumnCtx";
+import {ColumnTypesContainer} from "../services/ColumnTypesContainer";
+import type {Knex} from "knex";
+import {randomUUID} from "crypto";
 
 /**
  * @ignore
  */
 export function createIdColumn(table: Knex.TableBuilder, {entity, options}: ColumnCtx) {
-  if (options.type === "bigIncrements") {
-    table.bigIncrements(entity.propertyName).primary();
-  } else {
-    table.increments(entity.propertyName).primary();
+  switch (options.type) {
+    case "bigIncrements":
+      table.bigIncrements(entity.propertyName).primary();
+      break;
+    case "increments":
+      table.increments(entity.propertyName).primary();
+      break;
+    case "uuid":
+      table.uuid(entity.propertyName).primary().defaultTo(randomUUID());
   }
 }
 

--- a/packages/orm/objection/src/decorators/idColumn.ts
+++ b/packages/orm/objection/src/decorators/idColumn.ts
@@ -1,7 +1,7 @@
-import {useDecorators} from "@tsed/core";
+import {ColumnOptions} from "./columnOptions";
 import {Property} from "@tsed/schema";
 import {defineStaticGetter} from "../utils/defineStaticGetter";
-import {ColumnOptions} from "./columnOptions";
+import {useDecorators} from "@tsed/core";
 
 /**
  *
@@ -9,7 +9,7 @@ import {ColumnOptions} from "./columnOptions";
  * @decorator
  * @objection
  */
-export function IdColumn(type: "increments" | "bigIncrements" = "increments"): PropertyDecorator {
+export function IdColumn(type: "uuid" | "increments" | "bigIncrements" = "increments"): PropertyDecorator {
   return useDecorators(
     Property(),
     ColumnOptions({

--- a/packages/orm/objection/test/helpers/knex/table.ts
+++ b/packages/orm/objection/test/helpers/knex/table.ts
@@ -7,6 +7,8 @@ export function createTableStub() {
     primary: jest.fn().mockReturnThis(),
     string: jest.fn().mockReturnThis(),
     decimal: jest.fn().mockReturnThis(),
-    boolean: jest.fn().mockReturnThis()
+    boolean: jest.fn().mockReturnThis(),
+    uuid: jest.fn().mockReturnThis(),
+    defaultTo: jest.fn().mockReturnThis()
   } as unknown as Knex.TableBuilder;
 }


### PR DESCRIPTION
## Information

Add UUID primary key column support and fix-up decorator reference in docs from previous PR I had merged in.

| Type                      | Breaking change |
| ----------------- | ----------------- |
| Feature                 | No                         |

---

## Usage example

```typescript
import { Entity, IdColumn } from "@tsed/objection";

@Entity("users")
class User {
  @IdColumn("uuid")
  id!: string;
}

/**
 * Inside Knex migration file
 */
export async function up(knex: Knex): Promise<any> {
  return knex.schema.createTable(User.tableName, async (table: Knex.TableBuilder) =>
    createColumns(table, User));
}

export async function down(knex: Knex): Promise<any> {
  return knex.schema.dropTable("users");
}
```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
