### PR TITLE
Chore: update json schema for common package from 0.2.0 to 0.4.0

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -49,7 +49,7 @@
     "@tsed/logger": "5.5.3",
     "@types/json-schema": "7.0.6",
     "globby": "11.0.1",
-    "json-schema": "^0.2.3",
+    "json-schema": "^0.4.0",
     "normalize-path": "3.0.0",
     "on-finished": "2.3.0",
     "rxjs": "^6.5.2",

--- a/packages/platform-test-utils/package.json
+++ b/packages/platform-test-utils/package.json
@@ -17,7 +17,6 @@
     "@tsed/multipartfiles": "5.62.5",
     "@tsed/passport": "5.62.5",
     "@tsed/seq": "5.62.5",
-    "@tsed/servestatic": "5.62.5",
     "@tsed/swagger": "5.62.5",
     "@tsed/testing-mongoose": "5.62.5",
     "@tsed/typeorm": "5.62.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9641,6 +9641,11 @@ json-schema@^0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.5.tgz#97997f50972dd0500214e208c407efa4b5d7063b"
   integrity sha512-gWJOWYFrhQ8j7pVm0EM8Slr+EPVq1Phf6lvzvD/WCeqkrx/f2xBI0xOsRRS9xCn3I4vKtP519dvs3TP09r24wQ==
 
+json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,13 +2306,6 @@
   dependencies:
     tslib "1.11.0"
 
-"@tsed/servestatic@5.62.5":
-  version "5.62.5"
-  resolved "https://registry.yarnpkg.com/@tsed/servestatic/-/servestatic-5.62.5.tgz#91032172f4cd7ab13f16ee5188ecb833b5455b3f"
-  integrity sha512-JdcdPYR+tH7FwHW0iuBBhGDLugVvDlK/BVDgkFKZkBZWgBbDfNcFxacprt6R/Cqw42g5qGkomYRsSoWAJtPaEw==
-  dependencies:
-    tslib "1.11.0"
-
 "@tsed/swagger@5.62.5":
   version "5.62.5"
   resolved "https://registry.yarnpkg.com/@tsed/swagger/-/swagger-5.62.5.tgz#8f140ca89ec30b95484d500a5a958288b7ded2db"


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Chore | No          |

## Description
Updates json schema because it contains a prototype pollution to latest version 0.4

## Todos

- [x] Tests
- [x] Coverage
