### PR TITLE
fix(json-mapper): support BigInt type

### DIFF
--- a/packages/specs/json-mapper/src/components/PrimitiveMapper.ts
+++ b/packages/specs/json-mapper/src/components/PrimitiveMapper.ts
@@ -2,20 +2,29 @@ import {BadRequest} from "@tsed/exceptions";
 import {JsonMapper} from "../decorators/jsonMapper";
 import {JsonMapperCtx, JsonMapperMethods} from "../interfaces/JsonMapperMethods";
 
+function isNullish(data: any) {
+  return [null, "null"].includes(data);
+}
+
 /**
- * Mapper for the `String`, `Number` and `Boolean` types.
+ * Mapper for the `String`, `Number`, `BigInt` and `Boolean` types.
  * @jsonmapper
  * @component
  */
-@JsonMapper(String, Number, Boolean)
+@JsonMapper(String, Number, Boolean, BigInt)
 export class PrimitiveMapper implements JsonMapperMethods {
-  deserialize<T>(data: any, ctx: JsonMapperCtx): string | number | boolean | void | null {
+  deserialize<T>(data: any, ctx: JsonMapperCtx): string | number | boolean | void | null | BigInt {
     switch (ctx.type) {
       case String:
         return data === null ? null : "" + data;
 
+      case BigInt:
+        if (isNullish(data)) return null;
+
+        return BigInt(data);
+
       case Number:
-        if ([null, "null"].includes(data)) return null;
+        if (isNullish(data)) return null;
 
         const n = +data;
 
@@ -28,14 +37,14 @@ export class PrimitiveMapper implements JsonMapperMethods {
       case Boolean:
         if (["true", "1", true].includes(data)) return true;
         if (["false", "0", false].includes(data)) return false;
-        if ([null, "null"].includes(data)) return null;
+        if (isNullish(data)) return null;
         if (data === undefined) return undefined;
 
         return !!data;
     }
   }
 
-  serialize(object: string | number | boolean): string | number | boolean {
+  serialize(object: string | number | boolean | BigInt): string | number | boolean | BigInt {
     return object;
   }
 }

--- a/packages/specs/json-mapper/src/utils/deserialize.spec.ts
+++ b/packages/specs/json-mapper/src/utils/deserialize.spec.ts
@@ -70,6 +70,12 @@ describe("deserialize()", () => {
       expect(deserialize(["1"], {type: String})).toEqual(["1"]);
     });
   });
+  describe("BigInt", () => {
+    it("should deserialize a big int", () => {
+      expect(deserialize(1n, {type: BigInt})).toEqual(BigInt(1n));
+      expect(deserialize(null, {type: BigInt})).toEqual(null);
+    });
+  });
   describe("Array<primitive>", () => {
     it("should transform value", () => {
       const options = {type: String, collectionType: Array};

--- a/packages/specs/json-mapper/src/utils/serialize.spec.ts
+++ b/packages/specs/json-mapper/src/utils/serialize.spec.ts
@@ -26,6 +26,7 @@ describe("serialize()", () => {
       expect(serialize("1")).toEqual("1");
       expect(serialize(0)).toEqual(0);
       expect(serialize(1)).toEqual(1);
+      expect(serialize(BigInt(1n))).toEqual(BigInt(1));
     });
   });
   describe("Object", () => {


### PR DESCRIPTION
Closes: #2099


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `BigInt` in the serialization and deserialization processes.
	- Updated mappable types to include `BigInt`.

- **Bug Fixes**
	- Improved null checks for `BigInt`, `Number`, and `Boolean` types.

- **Tests**
	- Introduced new test cases for deserializing and serializing `BigInt` values, ensuring correct handling of this data type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->