### PR TITLE
docs(introduction): add a production-ready template to Introduction examples

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -6,6 +6,9 @@ projects:
   - title: Kit basic
     href: https://github.com/tsedio/tsed-getting-started
     src: /tsed.png
+  - title: Kit production-ready template
+    href: https://github.com/borjapazr/express-typescript-skeleton
+    src: /tsed.png
   - title: Kit React
     href: https://github.com/tsedio/tsed-example-react
     src: /react.png

--- a/docs/getting-started/start-with-cli.md
+++ b/docs/getting-started/start-with-cli.md
@@ -6,6 +6,9 @@ projects:
   - title: Kit basic
     href: https://github.com/tsedio/tsed-getting-started
     src: /tsed.png
+  - title: Kit production-ready template
+    href: https://github.com/borjapazr/express-typescript-skeleton
+    src: /tsed.png
   - title: Kit React
     href: https://github.com/tsedio/tsed-example-react
     src: /react.png

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -3,6 +3,9 @@ projects:
   - title: Kit basic
     href: https://github.com/tsedio/tsed-getting-started
     src: /tsed.png
+  - title: Kit production-ready template
+    href: https://github.com/borjapazr/express-typescript-skeleton
+    src: /tsed.png
   - title: Kit React
     href: https://github.com/tsedio/tsed-example-react
     src: /react.png


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc| No          |

---

Add a [production-ready template](https://github.com/borjapazr/express-typescript-skeleton) to the Introduction examples.

Is it necessary to provide a customized image?

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
