### PR TITLE
fix(prisma): fix prisma @tsED.Ignore() parsing

### DIFF
--- a/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.spec.ts
+++ b/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.spec.ts
@@ -21,6 +21,16 @@ describe("parseDocumentationAttributes", () => {
     ]);
   });
 
+  it("should parse @TsED.Ignore()", () => {
+    expect(parseDocumentationAttributes("/// @TsED.Ignore()")).toEqual([
+      {
+        arguments: [],
+        content: "@TsED.Ignore()",
+        name: "Ignore"
+      }
+    ]);
+  });
+
   it('should parse @TsED.Groups("!creation")', () => {
     expect(parseDocumentationAttributes('/// @TsED.Groups("!creation")')).toEqual([
       {

--- a/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.ts
+++ b/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.ts
@@ -55,7 +55,7 @@ export function parseDocumentationAttributes(documentation: string | undefined):
 
         return {
           ...options,
-          arguments: [`(value: any, ctx: any) => ${args}`]
+          arguments: args.length > 0 ? [`(value: any, ctx: any) => ${args}`] : []
         };
       }
       return options;


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
|Fix | No          |

---


## Issue
Related issue : [2089](https://github.com/tsedio/tsed/issues/2089)

## Proposed solution
Currently, when no arguments are passed to the decorator, an error is raised.
I fixed the issue by returning an empty array 

## Todos

- [x] Tests
- [x] Implement the bugfix
