### PR TITLE
fix(adapters-redis): handle empty object returns from hgetall

### DIFF
--- a/packages/orm/adapters-redis/src/adapters/RedisAdapter.spec.ts
+++ b/packages/orm/adapters-redis/src/adapters/RedisAdapter.spec.ts
@@ -104,6 +104,13 @@ describe("RedisAdapter", () => {
       expect(result?._id).toBe(client._id);
       expect(result?.name).toBe(base.name);
     });
+    it("should handle no item found by id (get)", async () => {
+      const {adapter} = await createAdapterFixture({});
+
+      const result = await adapter.findById("does not exist");
+
+      expect(result).toBeFalsy();
+    });
     it("should find item by id (hgetall)", async () => {
       const {adapter} = await createAdapterFixture<any>({
         collectionName: "AuthorizationCode",
@@ -118,6 +125,16 @@ describe("RedisAdapter", () => {
       const result = await adapter.findById(token._id);
 
       expect(result.key).toEqual(token.key);
+    });
+    it("should handle no item found by id (hgetall)", async () => {
+      const {adapter} = await createAdapterFixture<any>({
+        collectionName: "AuthorizationCode",
+        model: Object
+      });
+
+      const result = await adapter.findById("does not exist");
+
+      expect(result).toBeFalsy();
     });
   });
   describe("findOne()", () => {

--- a/packages/orm/adapters-redis/src/adapters/RedisAdapter.ts
+++ b/packages/orm/adapters-redis/src/adapters/RedisAdapter.ts
@@ -106,7 +106,8 @@ export class RedisAdapter<Model extends AdapterModel> extends Adapter<Model> {
 
     const item = this.useHash ? await this.db.hgetall(key) : await this.db.get(key);
 
-    if (!item) {
+    // hgetall returns an empty object when there are no results, so we need to check for that.
+    if (!item || (this.useHash && Object.keys(item).length === 0 && item.constructor === Object)) {
       return undefined;
     }
 

--- a/packages/orm/adapters-redis/src/adapters/RedisAdapter.ts
+++ b/packages/orm/adapters-redis/src/adapters/RedisAdapter.ts
@@ -1,5 +1,5 @@
 import {Adapter, AdapterConstructorOptions, AdapterModel} from "@tsed/adapters";
-import {cleanObject, Hooks, isString} from "@tsed/core";
+import {cleanObject, Hooks, isObject, isString} from "@tsed/core";
 import {Configuration, Inject, Opts} from "@tsed/di";
 import {IORedis, IOREDIS_CONNECTIONS} from "@tsed/ioredis";
 import type {ChainableCommander, Redis} from "ioredis";
@@ -107,7 +107,7 @@ export class RedisAdapter<Model extends AdapterModel> extends Adapter<Model> {
     const item = this.useHash ? await this.db.hgetall(key) : await this.db.get(key);
 
     // hgetall returns an empty object when there are no results, so we need to check for that.
-    if (!item || (this.useHash && Object.keys(item).length === 0 && item.constructor === Object)) {
+    if (!item || (this.useHash && isObject(item) && Object.keys(item).length === 0)) {
       return undefined;
     }
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

This is a bug fix for for https://github.com/tsedio/tsed/issues/2161. It introduces additional tests to confirm the issue so the new code is covered.

The existing Examples and Documentation should handle this functionality as it resolves an issue rather than introduce new functionality.

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
