### PR TITLE
fix(@tsed/socketio): avoid rollup bundling errors (#2165)

### DIFF
--- a/packages/third-parties/socketio/src/services/SocketIOService.ts
+++ b/packages/third-parties/socketio/src/services/SocketIOService.ts
@@ -1,5 +1,5 @@
 import {InjectorService, Provider, Service} from "@tsed/common";
-import SocketIO from "socket.io"; // tslint:disable-line: no-unused-variable
+import * as SocketIO from "socket.io"; // tslint:disable-line: no-unused-variable
 import {SocketHandlersBuilder} from "../class/SocketHandlersBuilder";
 import {SocketProviderMetadata} from "../class/SocketProviderMetadata";
 import {IO} from "../decorators/io";


### PR DESCRIPTION
By default, webpack and babel use the cjs export of socket.io, while rollup uses the esm export; Use aggregate import instead of default import to fix bundling errors caused by this difference.

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix                   | No              |

---

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
