### PR TITLE
fix(prisma): fix long running prisma generate

### DIFF
--- a/packages/orm/prisma/src/generator/utils/isCircularRef.ts
+++ b/packages/orm/prisma/src/generator/utils/isCircularRef.ts
@@ -22,7 +22,8 @@ function hasModelInFields(model: DMMF.Model, relation: string, ctx: TransformCon
       const nextModel = ctx.modelsMap.get(field.type);
 
       if (nextModel) {
-        return hasModelInFields(nextModel, relation, ctx, [...inspected, field.type]);
+        inspected = [...inspected, field.type];
+        return hasModelInFields(nextModel, relation, ctx, inspected);
       }
     }
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

## Issue

Currently, when running `npx prisma generate` with a large schema with many relationships the command takes many minutes to run, with exponential increases as the schema complexity increases.  The issue was fixed by updating the list of inspected fields before recursing the `hasModelInFields` function used by `isCircularRef`

Existing tests continue to pass.