### PR TITLE
2254 discriminator + deserialize does not appropriately create objects when used with arrays

### DIFF
--- a/packages/specs/json-mapper/src/utils/deserialize.ts
+++ b/packages/specs/json-mapper/src/utils/deserialize.ts
@@ -182,8 +182,8 @@ function mapPropStoreOptions(store: JsonPropertyStore, options: JsonDeserializer
     type: store.computedType
   };
 
-  if (store.schema.isDiscriminator) {
-    itemOpts.type = store.schema.discriminator();
+  if (store.itemSchema.isDiscriminator) {
+    itemOpts.type = store.itemSchema.discriminator();
   }
 
   if (store.schema.hasGenerics) {

--- a/packages/specs/json-mapper/test/integration/discriminator.integration.spec.ts
+++ b/packages/specs/json-mapper/test/integration/discriminator.integration.spec.ts
@@ -1,7 +1,17 @@
 import {Controller} from "@tsed/di";
 import {deserialize, serialize} from "@tsed/json-mapper";
 import {BodyParams, PathParams} from "@tsed/platform-params";
-import {DiscriminatorKey, DiscriminatorValue, getSpec, JsonParameterStore, OneOf, Property, Put, Required, Returns} from "@tsed/schema";
+import {
+  CollectionOf,
+  DiscriminatorKey,
+  DiscriminatorValue,
+  JsonParameterStore,
+  OneOf,
+  Property,
+  Put,
+  Required,
+  Returns
+} from "@tsed/schema";
 
 class Event {
   @DiscriminatorKey() // declare this property as discriminator key
@@ -44,9 +54,37 @@ class Tracking {
   data: PageView | Action;
 }
 
+class TrackingWithArray {
+  @OneOf(PageView, Action)
+  data: (PageView | Action)[];
+}
+
 describe("Discriminator", () => {
   describe("deserialize()", () => {
     it("should deserialize object according to the discriminator key (model with property discriminator)", () => {
+      const list = {
+        data: {
+          type: "page_view",
+          value: "value",
+          url: "https://url",
+          metaSub: "sub"
+        }
+      };
+      const result = deserialize(list, {
+        type: Tracking
+      });
+
+      expect(result).toEqual({
+        data: {
+          type: "page_view",
+          metaSub: "sub",
+          url: "https://url",
+          value: "value"
+        }
+      });
+      expect(result.data).toBeInstanceOf(PageView);
+    });
+    it("should deserialize object according to the discriminator key (model with property discriminator - array)", () => {
       const list = {
         data: [
           {
@@ -74,7 +112,7 @@ describe("Discriminator", () => {
         ]
       };
       const result = deserialize(list, {
-        type: Tracking
+        type: TrackingWithArray
       });
 
       expect(result).toEqual({
@@ -207,6 +245,7 @@ describe("Discriminator", () => {
         @Property()
         value: string;
       }
+
       @Controller("/")
       class Test {
         @Put("/:id")

--- a/packages/specs/schema/test/discriminator.integration.spec.ts
+++ b/packages/specs/schema/test/discriminator.integration.spec.ts
@@ -125,6 +125,79 @@ describe("Discriminator", () => {
         type: "object"
       });
     });
+    it("should generate the json schema as expected (strict declaration - array)", () => {
+      class Tracking {
+        @OneOf(PageView, Action)
+        data: (PageView | Action)[];
+      }
+
+      expect(getJsonSchema(Tracking)).toEqual({
+        definitions: {
+          Action: {
+            properties: {
+              event: {
+                minLength: 1,
+                type: "string"
+              },
+              meta: {
+                type: "string"
+              },
+              type: {
+                enum: ["action", "click_action"],
+                examples: ["action", "click_action"],
+                type: "string"
+              },
+              value: {
+                type: "string"
+              }
+            },
+            required: ["event"],
+            type: "object"
+          },
+          PageView: {
+            properties: {
+              type: {
+                const: "page_view",
+                examples: ["page_view"],
+                type: "string"
+              },
+              meta: {
+                type: "string"
+              },
+              url: {
+                minLength: 1,
+                type: "string"
+              },
+              value: {
+                type: "string"
+              }
+            },
+            required: ["url"],
+            type: "object"
+          }
+        },
+        properties: {
+          data: {
+            items: {
+              discriminator: {
+                propertyName: "type"
+              },
+              oneOf: [
+                {
+                  $ref: "#/definitions/PageView"
+                },
+                {
+                  $ref: "#/definitions/Action"
+                }
+              ],
+              required: ["type"]
+            },
+            type: "array"
+          }
+        },
+        type: "object"
+      });
+    });
     it("should generate the json schema as expected (automatic introspection on children classes)", () => {
       class Tracking {
         @OneOf(Event)


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| fix | No          |

---

Closes: #2254 

## Todos

- [x] Tests
- [x] Coverage
