### PR TITLE
fix(exceptions): allow custom status code creation when creating a custom Exception

### DIFF
--- a/packages/specs/exceptions/src/core/Exception.spec.ts
+++ b/packages/specs/exceptions/src/core/Exception.spec.ts
@@ -1,4 +1,4 @@
-import {Exception} from "@tsed/exceptions";
+import {Exception, HTTPException} from "@tsed/exceptions";
 
 describe("Exception", () => {
   it("should use origin", () => {
@@ -44,5 +44,19 @@ describe("Exception", () => {
 
     expect(exception.status).toEqual(203);
     expect(exception.toString()).toEqual("NON_AUTHORITATIVE_INFORMATION(203):");
+  });
+
+  it("should allow declaring custom status", () => {
+    class GatewayUserNotFoundError extends HTTPException {
+      public static readonly STATUS = 524;
+
+      constructor(message: string, origin?: Error | string | any) {
+        super(GatewayUserNotFoundError.STATUS, message, origin);
+      }
+    }
+
+    const error = new GatewayUserNotFoundError("test");
+
+    expect(error.name).toEqual("GATEWAY_USER_NOT_FOUND_ERROR");
   });
 });

--- a/packages/specs/exceptions/src/core/Exception.ts
+++ b/packages/specs/exceptions/src/core/Exception.ts
@@ -1,9 +1,6 @@
+import {classOf, nameOf} from "@tsed/core";
 import {constantCase} from "change-case";
 import statuses from "statuses";
-
-function getStatusConstant(status: number) {
-  return status === 200 ? "SUCCESS" : constantCase(String(statuses(status)));
-}
 
 export class Exception extends Error {
   /**
@@ -45,7 +42,7 @@ export class Exception extends Error {
 
     this.status = status;
     this.message = message;
-    this.name = getStatusConstant(status);
+    this.name = this.#getStatusConstant();
 
     this.setOrigin(origin);
   }
@@ -81,6 +78,14 @@ export class Exception extends Error {
 
   toString() {
     return `${this.name}(${this.status}): ${this.message} `.trim();
+  }
+
+  #getStatusConstant() {
+    try {
+      return this.status === 200 ? "SUCCESS" : constantCase(String(statuses(this.status)));
+    } catch (er) {
+      return constantCase(nameOf(classOf(this)));
+    }
   }
 }
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
 class GatewayUserNotFoundError extends HTTPException {
      public static readonly STATUS = 524;

      constructor(message: string, origin?: Error | string | any) {
        super(GatewayUserNotFoundError.STATUS, message, origin);
      }
    }

    const error = new GatewayUserNotFoundError("test");

    expect(error.name).toEqual("GATEWAY_USER_NOT_FOUND_ERROR");
```

fix the following error:

```
Error: invalid status code: 524
```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [ ] Documentation
