### PR TITLE
feat(platform-views): add `$alterRenderOptions` hook on response.render method

### DIFF
--- a/docs/docs/templating.md
+++ b/docs/docs/templating.md
@@ -209,15 +209,33 @@ It's also possible to render a view by injecting and using @@PlatformResponse@@ 
 
 ### With PlatformViews
 
-Ts.ED provides the @@PlatformViews@@ service to render views. In fact, @@View@@ decorator uses `PlatformResponse.render()` method which itself uses the `PlatformViews.render()` method.
+Ts.ED provides the @@PlatformViews@@ service to render views. In fact, @@View@@ decorator
+uses `PlatformResponse.render()` method which itself uses the `PlatformViews.render()` method.
 It is useful if you want to render a template from a service.
 
 <<< @/docs/snippets/templating/template-platform-views.ts
 
+## Alter render options
+
+You can alter the render options before rendering the view. Listen the `$alterRenderOptions` hook to inject
+data:
+
+```typescript
+@Injectable()
+class AlterOptions {
+  async $alterRenderOptions(options: any) {
+    // only called when the response.render is called by your code
+    options.alter = "alter";
+    return options;
+  }
+}
+```
+
 ## Caching
 
 To enable caching, simply pass `{ cache: true }` to the @@View@@ decorator.
-All engines that `consolidate.js` / [`@tsed/engines`](https://github.com/tsedio/tsed-engines) implements I/O for, will cache the file contents, ideal for production environments.
+All engines that `consolidate.js` / [`@tsed/engines`](https://github.com/tsedio/tsed-engines) implements I/O for, will
+cache the file contents, ideal for production environments.
 
 <<< @/docs/snippets/templating/template-cache.ts
 

--- a/packages/platform/platform-views/jest.config.js
+++ b/packages/platform/platform-views/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 86.95,
+      branches: 83.33,
       functions: 84.61,
       lines: 95.68,
       statements: 95.68

--- a/packages/platform/platform-views/src/services/PlatformViews.spec.ts
+++ b/packages/platform/platform-views/src/services/PlatformViews.spec.ts
@@ -1,6 +1,14 @@
-import {PlatformTest} from "@tsed/common";
+import {Injectable, PlatformTest} from "@tsed/common";
 import {requires} from "@tsed/engines";
 import {PlatformViews} from "./PlatformViews";
+
+@Injectable()
+class AlterOptions {
+  async $alterRenderOptions(options: any) {
+    options.alter = "alter";
+    return options;
+  }
+}
 
 describe("PlatformViews", () => {
   beforeEach(() =>
@@ -36,6 +44,7 @@ describe("PlatformViews", () => {
       expect(result).toEqual("HTML");
       expect(engine.render).toBeCalledWith("views.ejs", {
         cache: false,
+        alter: "alter",
         global: "global",
         requires: "requires"
       });
@@ -53,6 +62,7 @@ describe("PlatformViews", () => {
         cache: false,
         global: "global",
         test: "test",
+        alter: "alter",
         requires: "requires"
       });
     });

--- a/packages/platform/platform-views/src/services/PlatformViews.ts
+++ b/packages/platform/platform-views/src/services/PlatformViews.ts
@@ -1,5 +1,5 @@
 import {Env, getValue} from "@tsed/core";
-import {Constant, Module} from "@tsed/di";
+import {Constant, Inject, InjectorService, Module} from "@tsed/di";
 import {engines, getEngine, requires} from "@tsed/engines";
 import Fs from "fs";
 import {extname, join, resolve} from "path";
@@ -53,6 +53,9 @@ export class PlatformViews {
 
   @Constant("views.options", {})
   protected engineOptions: Record<string, PlatformViewsEngineOptions>;
+
+  @Inject()
+  protected injector: InjectorService;
 
   #extensions: Map<string, string>;
   #engines = new Map<string, PlatformViewEngine>();
@@ -116,6 +119,8 @@ export class PlatformViews {
   }
 
   async render(viewPath: string, options: any = {}): Promise<string | PlatformViewWritableStream> {
+    options = await this.injector.alterAsync("$alterRenderOptions", options);
+
     const {path, extension} = this.#cachePaths.get(viewPath) || this.#cachePaths.set(viewPath, this.resolve(viewPath)).get(viewPath)!;
     const engine = this.getEngine(extension);
 


### PR DESCRIPTION

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | Yes/No          |

---

<!--
## Usage example

## Alter render options

You can alter the render options before rendering the view. Listen the `$alterRenderOptions` hook to inject
data:

```typescript
@Injectable()
class AlterOptions {
  async $alterRenderOptions(options: any) {
    // only called when the response.render is called by your code
    options.alter = "alter";
    return options;
  }
}
```
## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
