### PR TITLE
docs: fixes example controller naming

### DIFF
--- a/docs/docs/providers.md
+++ b/docs/docs/providers.md
@@ -38,7 +38,7 @@ Example with @@Injectable@:
 
 :::
 
-Now we have the service class already done, let's use it inside the `CalendarCtrl`:
+Now we have the service class already done, let's use it inside the `CalendarsController`:
 
 <<< @/docs/snippets/providers/getting-started-controller.ts
 
@@ -48,7 +48,7 @@ Finally, we can load the injector and use it:
 
 ::: tip NOTE
 
-You'll notice that we only import the CalendarsCtrl and not the CalendarsService as that would be the case
+You'll notice that we only import the CalendarsController and not the CalendarsService as that would be the case
 with other DIs (Angular / inversify). Ts.ED will discover automatically services/providers as soon as it is imported
 into your application via an import ES6.
 

--- a/docs/docs/snippets/providers/getting-started-serverloader.ts
+++ b/docs/docs/snippets/providers/getting-started-serverloader.ts
@@ -1,9 +1,9 @@
 import {Configuration} from "@tsed/di";
-import {CalendarsCtrl} from "./controllers/CalendarsCtrl";
+import {CalendarsController} from "./controllers/CalendarsController";
 
 @Configuration({
   mount: {
-    "/rest": [CalendarsCtrl]
+    "/rest": [CalendarsController]
   }
 })
 export class Server {}


### PR DESCRIPTION
The examples provided on the [Services section of Providers documentation](https://tsed.io/docs/providers.html#services) are using multiple names (`CalendarCtrl` and `CalendarsController`) to refer to the same thing.