### PR TITLE
docs: Fixes decorator name

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -40,7 +40,7 @@ To avoid that, we can create a decorator which apply all of these instructions a
 <<< @/docs/snippets/authentication/auth-decorator-example.ts
 
 ::: tip
-Additionally, you can use the Operation decorator to add automatically the `Authorization` header field in the swagger spec:
+Additionally, you can use the `In` decorator to add automatically the `Authorization` header field in the swagger spec:
 
 <<< @/docs/snippets/authentication/auth-decorator-example-2.ts
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

---

Fixes authentication docs

Replaces reference to `Operation` decorator with a reference to the `In` decorator.

This is in line with the comment https://github.com/tsedio/tsed/issues/1053#issuecomment-723181198 and fixes what may be the cause of one of the questions about the `Operation` decorator.