### PR TITLE
Fixes In decorator parameter usage snippet

### DIFF
--- a/docs/tutorials/snippets/swagger/endpoint-extra-in-params.ts
+++ b/docs/tutorials/snippets/swagger/endpoint-extra-in-params.ts
@@ -6,7 +6,7 @@ import {CalendarModel} from "./models/Calendar";
 @Controller("/calendars")
 export class CalendarCtrl {
   @Post("/")
-  @In("authorization").Type(String).Description("Bearer authorization")
+  @In("header").Name("authorization").Type(String).Description("Bearer authorization")
   @Security("oidc")
   async createCalendar(@BodyParams() body: any): Promise<CalendarModel> {
     return {};


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

Fixes snippet with an example of usage of In decorator.

According to https://api-docs.tsed.io/api/specs/schema/types/decorators/operations/In.html, its parameter should be a `JsonParameterTypes` or a plain string indicating where the input should be put in (header, body, path, query, cookie...)