### PR TITLE
fix(json-mapper): fix serialization and deserialization of optional collections produce [null] when null is passed

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,33 @@
+const globby = require("globby");
+const {basename, dirname} = require("path");
+const pkg = require("./package.json");
+const {RuleConfigSeverity} = require("@commitlint/types");
+
+function findPackages() {
+  const patterns = pkg.workspaces.packages.map((pkgPattern) => {
+    return `${pkgPattern}/package.json`;
+  });
+
+  let pkgs = globby.sync(patterns, {
+    cwd: __dirname
+  });
+
+  return pkgs.map((pkg) => {
+    return basename(pkg.replace("/package.json", ""));
+  });
+}
+
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
+    "scope-enum": [RuleConfigSeverity.Error, "always", findPackages()],
     "header-max-length": [0, "always", 120]
-  }
+  },
+  ignores: [
+    (message) =>
+      message.includes("[skip ci]") ||
+      !!message.match(
+        /^((feat|fix|hotfix|tech|bugfix)\/(([0-9]+)\.?)+(\.[a-zA-Z]+)+) \(#+([0-9]+)\)/g // merge commits (matching a branch name, eg. 'feat/999.bla.bla (#123)')
+      )
+  ]
 };

--- a/packages/platform/platform-log-middleware/src/middlewares/PlatformLogMiddleware.ts
+++ b/packages/platform/platform-log-middleware/src/middlewares/PlatformLogMiddleware.ts
@@ -132,7 +132,7 @@ export class PlatformLogMiddleware implements MiddlewareMethods {
     return {
       method: request.method,
       url: request.url,
-      route: request.route,
+      route: request.route || request.url,
       headers: request.headers,
       body: request.body,
       query: request.query,

--- a/packages/specs/json-mapper/src/domain/JsonDeserializer.spec.ts
+++ b/packages/specs/json-mapper/src/domain/JsonDeserializer.spec.ts
@@ -542,6 +542,33 @@ describe("deserialize()", () => {
         }
       });
     });
+    it("should transform keep array, map, set without nullable value", () => {
+      class Model {
+        @CollectionOf(String)
+        public bars?: string[];
+
+        @CollectionOf(String)
+        public barsSet?: Set<string>;
+
+        @CollectionOf(String)
+        public barsMap?: Map<string, string>;
+      }
+
+      const payload = {
+        bars: null,
+        barsSet: null,
+        barsMap: null
+      };
+
+      const result = deserialize(payload, {type: Model});
+
+      expect(result).toBeInstanceOf(Model);
+      expect(result).toEqual({
+        bars: null,
+        barsSet: null,
+        barsMap: null
+      });
+    });
     it("should transform object to class (date/nullable)", () => {
       class Product {
         @Nullable(Date)

--- a/packages/specs/json-mapper/src/domain/JsonDeserializer.ts
+++ b/packages/specs/json-mapper/src/domain/JsonDeserializer.ts
@@ -348,6 +348,10 @@ export class JsonDeserializer extends JsonMapperCompiler<JsonDeserializerOptions
   }
 
   private mapSet(input: any, options: JsonDeserializerOptions): Set<any> {
+    if (isNil(input)) {
+      return input;
+    }
+
     const obj = new Set<any>();
 
     objectKeys(input).forEach((key) => {
@@ -358,12 +362,20 @@ export class JsonDeserializer extends JsonMapperCompiler<JsonDeserializerOptions
   }
 
   private mapArray(input: any, options: JsonDeserializerOptions) {
+    if (isNil(input)) {
+      return input;
+    }
+
     return [].concat(input).map((item: any) => {
       return this.mapItem(item, options);
     });
   }
 
   private mapMap(input: any, options: JsonDeserializerOptions): Map<string, any> {
+    if (isNil(input)) {
+      return input;
+    }
+
     const obj = new Map<string, any>();
 
     objectKeys(input).forEach((key) => {

--- a/packages/specs/json-mapper/src/domain/JsonSerializer.spec.ts
+++ b/packages/specs/json-mapper/src/domain/JsonSerializer.spec.ts
@@ -658,6 +658,32 @@ describe("JsonSerializer", () => {
         prop4: null
       });
     });
+    it("should transform keep array, map, set without nullable value", () => {
+      class Model {
+        @CollectionOf(String)
+        public bars?: string[];
+
+        @CollectionOf(String)
+        public barsSet?: Set<string>;
+
+        @CollectionOf(String)
+        public barsMap?: Map<string, string>;
+      }
+
+      const payload = {
+        bars: null,
+        barsSet: null,
+        barsMap: null
+      };
+
+      const result = serialize(payload, {type: Model});
+
+      expect(result).toEqual({
+        bars: null,
+        barsSet: null,
+        barsMap: null
+      });
+    });
     it("should serialize array model with alias property", () => {
       class SpaBooking {
         @Required()

--- a/packages/specs/json-mapper/src/domain/JsonSerializer.ts
+++ b/packages/specs/json-mapper/src/domain/JsonSerializer.ts
@@ -266,18 +266,29 @@ export class JsonSerializer extends JsonMapperCompiler<JsonSerializerOptions> {
   }
 
   private mapSet(input: any, options: JsonSerializerOptions) {
+    if (isNil(input)) {
+      return input;
+    }
     return [...input.values()].map((item) => {
       return this.mapItem(item, options);
     });
   }
 
   private mapArray(input: any, options: JsonSerializerOptions) {
+    if (isNil(input)) {
+      return input;
+    }
+
     return [].concat(input).map((item: any) => {
       return this.mapItem(item, options);
     });
   }
 
   private mapMap(input: any, options: JsonSerializerOptions) {
+    if (isNil(input)) {
+      return input;
+    }
+
     return [...input.entries()].reduce((obj, [key, item]) => {
       return {
         ...obj,


### PR DESCRIPTION

Closes: #2465

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

<!--
## Usage example

```typescript
import { CollectionOf } from '@tsed/schema';
import { deserialize } from '@tsed/json-mapper';

class Model {
   @CollectionOf(String)
   public bars?: string[];
}

const payload = { bars: null };

const result = deserialize(payload, {type: Model});

console.log(result) // => Model { bars: null } instead of  Model { bars: [null] }
```
-->

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
