### PR TITLE
docs(bullmq): add missing trailing comma

### DIFF
--- a/docs/.vuepress/config.base.js
+++ b/docs/.vuepress/config.base.js
@@ -427,7 +427,7 @@ module.exports = ({title, description, base = "", url, apiRedirectUrl = "", them
               {title: "IORedis", path: base + "/tutorials/ioredis"},
               {title: "Objection.js", path: base + "/tutorials/objection"},
               {title: "Vite plugin ssr", path: base + "/tutorials/vite-plugin-ssr"},
-              {title: "Temporal", path: base + "/tutorials/temporal"}
+              {title: "Temporal", path: base + "/tutorials/temporal"},
               {title: "BullMQ", path: base + "/tutorials/bullmq"}
             ].sort((a, b) => (a.title < b.title ? -1 : 1))
           },


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix/Doc | No          |

---

Add missing trailing comma in doc config

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
