### PR TITLE
feat(bullmq): improve dispatch job type for better payload type hinting

### DIFF
--- a/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.ts
+++ b/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.ts
@@ -8,7 +8,7 @@ export class JobDispatcher {
   constructor(private readonly injector: InjectorService) {}
 
   // eslint-disable-next-line require-await
-  public async dispatch<T extends JobMethods>(job: Type<JobMethods>, payload: Parameters<T["handle"]>[0] = {}): Promise<BullMQJob> {
+  public async dispatch<T extends JobMethods>(job: Type<T>, payload: Parameters<T["handle"]>[0] = {}): Promise<BullMQJob> {
     const store = Store.from(job).get<JobStore>("bullmq");
 
     const queue = this.injector.getMany<Queue>("bullmq:queue").find((queue) => queue.name === store.queue);


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

Using the generic type `T` when typing the job allows for easier autocompletion when specifying the payload for a job without having to explicitly set the generic parameter. 

With a job like

```ts
import {JobController, JobMethods} from '@tsed/bullmq';

@JobController('example')
export default class ExampleJob implements JobMethods {
  handle(payload: { msg: string }) {
    console.info(payload)
  }
}
```

Instead of having to explicitly declare the generic type like this
```ts
import {JobDispatcher} from "@tsed/bullmq";
import ExampleJob from "../../jobs/ExampleJob";

export class ExampleService {

  constructor(
    private readonly dispatcher: JobDispatcher,
  ) {
  }

  async doStuff() {
    return this.dispatcher.dispatch<ExampleJob>(ExampleJob, {msg: 'Hello World'});
  }
}
```

typescript can now infer the type from the first job parameter. 

```ts
import {JobDispatcher} from "@tsed/bullmq";
import ExampleJob from "../../jobs/ExampleJob";

export class ExampleService {

  constructor(
    private readonly dispatcher: JobDispatcher,
  ) {
  }

  async doStuff() {
    return this.dispatcher.dispatch(ExampleJob, {msg: 'Hello World'});
  }
}
```
![CleanShot 2023-10-18 at 09 33 45](https://github.com/tsedio/tsed/assets/7523903/c75b7b1c-619e-4cd6-a27a-cf8306716293)



<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
