### PR TITLE
fix(webpack): use scoped name for webpack library

### DIFF
--- a/tools/webpack/webpack.config.js
+++ b/tools/webpack/webpack.config.js
@@ -11,7 +11,7 @@ exports.create = ({root, name, entry, externals = {}, resolve = {}}) => {
     output: {
       path: `${root}/lib/browser/`,
       filename: `${name}.umd.min.js`,
-      library: name,
+      library: `@tsed/${name}`,
       libraryTarget: "umd"
     },
     resolve: {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | Maybe          |

---

This PR fixes UMD exports to use scoped names on `self` instead of bare names (e.g. `@tsed/core` instead of `core`), since scoped names match what the other packages' UMD exports expect to find on `self`. This may be a breaking change for consumers who are depending on the bare names on `self`.

Resolves https://github.com/tsedio/tsed/issues/2481.