### PR TITLE
feat(bullmq): allow setting custom jobs options when dispatching

### DIFF
--- a/docs/tutorials/bullmq.md
+++ b/docs/tutorials/bullmq.md
@@ -133,6 +133,28 @@ class MyService {
 }
 ```
 
+In addition to statically defined job options when declaring the job, custom job options can also be set when dispatching the job.
+This allows to for example delay the job from when it has originally been dispatched.
+
+```ts
+import {Service} from "@tsed/di";
+import {JobDispatcher} from "@tsed/bullmq";
+import {ExampleJob} from "./jobs/ExampleJob";
+
+@Service()
+class MyService {
+  constructor(private readonly dispatcher: JobDispatcher) {}
+
+  public async doingSomething() {
+    await this.dispatcher.dispatch(ExampleJob, {msg: "this message is part of the payload for the job"}, {
+      delay: 600_000 // 10 minutes in milliseconds
+    });
+
+    console.info("I just dispatched a job!");
+  }
+}
+```
+
 ## Authors
 
 <GithubContributors :users="['abenerd']"/>

--- a/packages/third-parties/bullmq/jest.config.js
+++ b/packages/third-parties/bullmq/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 81.25,
+      branches: 81.81,
       functions: 100,
       lines: 100,
       statements: 100

--- a/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.ts
+++ b/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.ts
@@ -1,14 +1,14 @@
 import {InjectorService, Service} from "@tsed/di";
 import {JobMethods, type JobStore} from "../contracts";
 import {Store, Type} from "@tsed/core";
-import {Job as BullMQJob, Queue} from "bullmq";
+import {Job as BullMQJob, JobsOptions, Queue} from "bullmq";
 
 @Service()
 export class JobDispatcher {
   constructor(private readonly injector: InjectorService) {}
 
   // eslint-disable-next-line require-await
-  public async dispatch<T extends JobMethods>(job: Type<T>, payload: Parameters<T["handle"]>[0] = {}): Promise<BullMQJob> {
+  public async dispatch<T extends JobMethods>(job: Type<T>, payload: Parameters<T["handle"]>[0] = {}, options: JobsOptions = {}): Promise<BullMQJob> {
     const store = Store.from(job).get<JobStore>("bullmq");
 
     const queue = this.injector.getMany<Queue>("bullmq:queue").find((queue) => queue.name === store.queue);
@@ -17,6 +17,9 @@ export class JobDispatcher {
       throw new Error(`Queue(${store.queue}) not defined`);
     }
 
-    return queue.add(store.name, payload, store.opts);
+    return queue.add(store.name, payload, {
+      ...store.opts,
+      ...options,
+    });
   }
 }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

Allow setting job options when dispatching a job

```ts
import {Service} from "@tsed/di";
import {JobDispatcher} from "@tsed/bullmq";
import {ExampleJob} from "./jobs/ExampleJob";

@Service()
class MyService {
  constructor(private readonly dispatcher: JobDispatcher) {}

  public async doingSomething() {
    await this.dispatcher.dispatch(ExampleJob, {msg: "this message is part of the payload for the job"}, {
      delay: 600_000 // 10 minutes in milliseconds
    });

    console.info("I just dispatched a job!");
  }
}
```

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [X] Tests
- [X] Coverage
- [X] Example
- [X] Documentation
