### PR TITLE
feat(exceptions): add base exception classes for 3xx 4xx 5xx

### DIFF
--- a/packages/specs/exceptions/jest.config.js
+++ b/packages/specs/exceptions/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 90.9,
+      branches: 93.75,
       functions: 100,
       lines: 100,
       statements: 100

--- a/packages/specs/exceptions/src/clientErrors/BadMapping.ts
+++ b/packages/specs/exceptions/src/clientErrors/BadMapping.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class BadMapping extends Exception {
+export class BadMapping extends ClientException {
   static readonly STATUS = 421;
   name: string = "BAD_MAPPING";
 

--- a/packages/specs/exceptions/src/clientErrors/BadRequest.ts
+++ b/packages/specs/exceptions/src/clientErrors/BadRequest.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class BadRequest extends Exception {
+export class BadRequest extends ClientException {
   static readonly STATUS = 400;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/Conflict.ts
+++ b/packages/specs/exceptions/src/clientErrors/Conflict.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class Conflict extends Exception {
+export class Conflict extends ClientException {
   static readonly STATUS = 409;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/ExpectationFailed.ts
+++ b/packages/specs/exceptions/src/clientErrors/ExpectationFailed.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class ExpectationFailed extends Exception {
+export class ExpectationFailed extends ClientException {
   static readonly STATUS = 417;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/Forbidden.ts
+++ b/packages/specs/exceptions/src/clientErrors/Forbidden.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class Forbidden extends Exception {
+export class Forbidden extends ClientException {
   static readonly STATUS = 403;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/Gone.ts
+++ b/packages/specs/exceptions/src/clientErrors/Gone.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class Gone extends Exception {
+export class Gone extends ClientException {
   static readonly STATUS = 410;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/ImATeapot.ts
+++ b/packages/specs/exceptions/src/clientErrors/ImATeapot.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class ImATeapot extends Exception {
+export class ImATeapot extends ClientException {
   static readonly STATUS = 418;
   name: string = "IM_A_TEAPOT";
 

--- a/packages/specs/exceptions/src/clientErrors/LengthRequired.ts
+++ b/packages/specs/exceptions/src/clientErrors/LengthRequired.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class LengthRequired extends Exception {
+export class LengthRequired extends ClientException {
   static readonly STATUS = 411;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/MethodNotAllowed.ts
+++ b/packages/specs/exceptions/src/clientErrors/MethodNotAllowed.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class MethodNotAllowed extends Exception {
+export class MethodNotAllowed extends ClientException {
   static readonly STATUS = 405;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/MisdirectedRequest.ts
+++ b/packages/specs/exceptions/src/clientErrors/MisdirectedRequest.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class MisdirectedRequest extends Exception {
+export class MisdirectedRequest extends ClientException {
   static readonly STATUS = 421;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/NotAcceptable.ts
+++ b/packages/specs/exceptions/src/clientErrors/NotAcceptable.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class NotAcceptable extends Exception {
+export class NotAcceptable extends ClientException {
   static readonly STATUS = 406;
 
   constructor(message: string, origin: Error | string | any = "You must accept content-type " + message) {

--- a/packages/specs/exceptions/src/clientErrors/NotFound.ts
+++ b/packages/specs/exceptions/src/clientErrors/NotFound.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class NotFound extends Exception {
+export class NotFound extends ClientException {
   static readonly STATUS = 404;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/PaymentRequired.ts
+++ b/packages/specs/exceptions/src/clientErrors/PaymentRequired.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class PaymentRequired extends Exception {
+export class PaymentRequired extends ClientException {
   static readonly STATUS = 402;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/PreconditionFailed.ts
+++ b/packages/specs/exceptions/src/clientErrors/PreconditionFailed.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class PreconditionFailed extends Exception {
+export class PreconditionFailed extends ClientException {
   static readonly STATUS = 412;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/PreconditionRequired.ts
+++ b/packages/specs/exceptions/src/clientErrors/PreconditionRequired.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class PreconditionRequired extends Exception {
+export class PreconditionRequired extends ClientException {
   static readonly STATUS = 428;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/ProxyAuthentificationRequired.ts
+++ b/packages/specs/exceptions/src/clientErrors/ProxyAuthentificationRequired.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class ProxyAuthentificationRequired extends Exception {
+export class ProxyAuthentificationRequired extends ClientException {
   static readonly STATUS = 407;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/RequestEntityTooLarge.ts
+++ b/packages/specs/exceptions/src/clientErrors/RequestEntityTooLarge.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class RequestEntityTooLarge extends Exception {
+export class RequestEntityTooLarge extends ClientException {
   static readonly STATUS = 413;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/RequestHeaderFieldsTooLarge.ts
+++ b/packages/specs/exceptions/src/clientErrors/RequestHeaderFieldsTooLarge.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class RequestHeaderFieldsTooLarge extends Exception {
+export class RequestHeaderFieldsTooLarge extends ClientException {
   static readonly STATUS = 431;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/RequestRangeUnsatisfiable.ts
+++ b/packages/specs/exceptions/src/clientErrors/RequestRangeUnsatisfiable.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class RequestRangeUnsatisfiable extends Exception {
+export class RequestRangeUnsatisfiable extends ClientException {
   static readonly STATUS = 416;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/RequestTimeout.ts
+++ b/packages/specs/exceptions/src/clientErrors/RequestTimeout.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class RequestTimeout extends Exception {
+export class RequestTimeout extends ClientException {
   static readonly STATUS = 408;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/RequestURITooLong.ts
+++ b/packages/specs/exceptions/src/clientErrors/RequestURITooLong.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class RequestURITooLong extends Exception {
+export class RequestURITooLong extends ClientException {
   static readonly STATUS = 414;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/TooManyRequests.ts
+++ b/packages/specs/exceptions/src/clientErrors/TooManyRequests.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class TooManyRequests extends Exception {
+export class TooManyRequests extends ClientException {
   static readonly STATUS = 429;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/Unauthorized.ts
+++ b/packages/specs/exceptions/src/clientErrors/Unauthorized.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class Unauthorized extends Exception {
+export class Unauthorized extends ClientException {
   static readonly STATUS = 401;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/UnavailableForLegalReasons.ts
+++ b/packages/specs/exceptions/src/clientErrors/UnavailableForLegalReasons.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class UnavailableForLegalReasons extends Exception {
+export class UnavailableForLegalReasons extends ClientException {
   static readonly STATUS = 451;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/UnprocessableEntity.ts
+++ b/packages/specs/exceptions/src/clientErrors/UnprocessableEntity.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class UnprocessableEntity extends Exception {
+export class UnprocessableEntity extends ClientException {
   static readonly STATUS = 422;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/UnsupportedMediaType.ts
+++ b/packages/specs/exceptions/src/clientErrors/UnsupportedMediaType.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class UnsupportedMediaType extends Exception {
+export class UnsupportedMediaType extends ClientException {
   static readonly STATUS = 415;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/clientErrors/UpgradeRequired.ts
+++ b/packages/specs/exceptions/src/clientErrors/UpgradeRequired.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ClientException} from "../core/ClientException";
 
-export class UpgradeRequired extends Exception {
+export class UpgradeRequired extends ClientException {
   static readonly STATUS = 426;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/core/ClientException.ts
+++ b/packages/specs/exceptions/src/core/ClientException.ts
@@ -1,0 +1,8 @@
+import {Exception} from "./Exception";
+import {StatusFamily} from "./StatusFamily";
+
+export class ClientException extends Exception {
+  constructor(status: number, message: string, origin?: Error | string | any) {
+    super(Exception.validate(status, StatusFamily["4xx"]), message, origin);
+  }
+}

--- a/packages/specs/exceptions/src/core/Exception.spec.ts
+++ b/packages/specs/exceptions/src/core/Exception.spec.ts
@@ -1,4 +1,6 @@
 import {Exception, HTTPException} from "./Exception";
+import {StatusFamily} from "./StatusFamily";
+
 describe("Exception", () => {
   it("should use origin", () => {
     const exception = new Exception(undefined, "test", new Error("test"));
@@ -57,5 +59,37 @@ describe("Exception", () => {
     const error = new GatewayUserNotFoundError("test");
 
     expect(error.name).toEqual("GATEWAY_USER_NOT_FOUND_ERROR");
+  });
+
+  it("should throw exception if status code is less than 100", (done) => {
+    try {
+      Exception.validate(90, StatusFamily["4xx"]);
+    } catch (e) {
+      expect(e.message).toContain("between 100 and 599");
+      done();
+    }
+  });
+
+  it("should throw exception if status code is more than 599", (done) => {
+    try {
+      Exception.validate(600, StatusFamily["4xx"]);
+    } catch (e) {
+      expect(e.message).toContain("between 100 and 599");
+      done();
+    }
+  });
+
+  it("should throw exception if status code does not belong to family", (done) => {
+    try {
+      Exception.validate(519, StatusFamily["4xx"]);
+    } catch (e) {
+      expect(e.message).toContain("does not belong to the family");
+      done();
+    }
+  });
+
+  it("should validate the status code", () => {
+    const code = Exception.validate(419, StatusFamily["4xx"]);
+    expect(code).toEqual(419);
   });
 });

--- a/packages/specs/exceptions/src/core/Exception.ts
+++ b/packages/specs/exceptions/src/core/Exception.ts
@@ -1,6 +1,7 @@
 import {classOf, nameOf} from "@tsed/core";
 import {constantCase} from "change-case";
 import statuses from "statuses";
+import {StatusFamily} from "./StatusFamily";
 
 export class Exception extends Error {
   /**
@@ -36,6 +37,18 @@ export class Exception extends Error {
   public headers: {[key: string]: any} = {};
 
   [key: string]: any;
+
+  public static validate(status: number, family: StatusFamily): number {
+    if (status < 100 || status >= 600) {
+      throw new Error("Status must be between 100 and 599");
+    }
+
+    if (status.toString()[0] !== family.charAt(0)) {
+      throw new Error(`Status ${status} does not belong to the family ${family}`);
+    }
+
+    return status;
+  }
 
   constructor(status: number = 500, message: string = "", origin?: Error | string | any) {
     super(message);

--- a/packages/specs/exceptions/src/core/RedirectException.ts
+++ b/packages/specs/exceptions/src/core/RedirectException.ts
@@ -1,0 +1,8 @@
+import {Exception} from "./Exception";
+import {StatusFamily} from "./StatusFamily";
+
+export class RedirectException extends Exception {
+  constructor(status: number, message: string, origin?: Error | string | any) {
+    super(Exception.validate(status, StatusFamily["3xx"]), message, origin);
+  }
+}

--- a/packages/specs/exceptions/src/core/ServerException.ts
+++ b/packages/specs/exceptions/src/core/ServerException.ts
@@ -1,0 +1,8 @@
+import {Exception} from "./Exception";
+import {StatusFamily} from "./StatusFamily";
+
+export class ServerException extends Exception {
+  constructor(status: number, message: string, origin?: Error | string | any) {
+    super(Exception.validate(status, StatusFamily["5xx"]), message, origin);
+  }
+}

--- a/packages/specs/exceptions/src/core/StatusFamily.ts
+++ b/packages/specs/exceptions/src/core/StatusFamily.ts
@@ -1,0 +1,5 @@
+export enum StatusFamily {
+  "3xx" = "3xx",
+  "4xx" = "4xx",
+  "5xx" = "5xx"
+}

--- a/packages/specs/exceptions/src/index.ts
+++ b/packages/specs/exceptions/src/index.ts
@@ -46,5 +46,5 @@ export * from "./serverErrors/NetworkAuthenticationRequired";
 export * from "./serverErrors/NotExtended";
 export * from "./serverErrors/NotImplemented";
 export * from "./serverErrors/ProxyError";
-export * from "./serverErrors/ServiceUnvailable";
+export * from "./serverErrors/ServiceUnavailable";
 export * from "./serverErrors/VariantAlsoNegotiates";

--- a/packages/specs/exceptions/src/redirections/MovedPermanently.ts
+++ b/packages/specs/exceptions/src/redirections/MovedPermanently.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class MovedPermanently extends Exception {
+export class MovedPermanently extends RedirectException {
   static readonly STATUS = 301;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/redirections/MovedTemporarily.ts
+++ b/packages/specs/exceptions/src/redirections/MovedTemporarily.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class MovedTemporarily extends Exception {
+export class MovedTemporarily extends RedirectException {
   static readonly STATUS = 302;
   name: string = "MOVED_TEMPORARILY";
 

--- a/packages/specs/exceptions/src/redirections/MultipleChoices.ts
+++ b/packages/specs/exceptions/src/redirections/MultipleChoices.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class MultipleChoices extends Exception {
+export class MultipleChoices extends RedirectException {
   static readonly STATUS = 300;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/redirections/NotModified.ts
+++ b/packages/specs/exceptions/src/redirections/NotModified.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class NotModified extends Exception {
+export class NotModified extends RedirectException {
   static readonly STATUS = 304;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/redirections/PermanentRedirect.ts
+++ b/packages/specs/exceptions/src/redirections/PermanentRedirect.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class PermanentRedirect extends Exception {
+export class PermanentRedirect extends RedirectException {
   static readonly STATUS = 308;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/redirections/SeeOther.ts
+++ b/packages/specs/exceptions/src/redirections/SeeOther.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class SeeOther extends Exception {
+export class SeeOther extends RedirectException {
   static readonly STATUS = 303;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/redirections/TemporaryRedirect.ts
+++ b/packages/specs/exceptions/src/redirections/TemporaryRedirect.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class TemporaryRedirect extends Exception {
+export class TemporaryRedirect extends RedirectException {
   static readonly STATUS = 307;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/redirections/UseProxy.ts
+++ b/packages/specs/exceptions/src/redirections/UseProxy.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {RedirectException} from "../core/RedirectException";
 
-export class UseProxy extends Exception {
+export class UseProxy extends RedirectException {
   static readonly STATUS = 305;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/BadGateway.ts
+++ b/packages/specs/exceptions/src/serverErrors/BadGateway.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class BadGateway extends Exception {
+export class BadGateway extends ServerException {
   static readonly STATUS = 502;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/BandwidthLimitExceeded.ts
+++ b/packages/specs/exceptions/src/serverErrors/BandwidthLimitExceeded.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class BandwidthLimitExceeded extends Exception {
+export class BandwidthLimitExceeded extends ServerException {
   static readonly STATUS = 509;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/GatewayTimeout.ts
+++ b/packages/specs/exceptions/src/serverErrors/GatewayTimeout.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class GatewayTimeout extends Exception {
+export class GatewayTimeout extends ServerException {
   static readonly STATUS = 504;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/InternalServerError.ts
+++ b/packages/specs/exceptions/src/serverErrors/InternalServerError.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class InternalServerError extends Exception {
+export class InternalServerError extends ServerException {
   static readonly STATUS = 500;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/NetworkAuthenticationRequired.ts
+++ b/packages/specs/exceptions/src/serverErrors/NetworkAuthenticationRequired.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class NetworkAuthenticationRequired extends Exception {
+export class NetworkAuthenticationRequired extends ServerException {
   static readonly STATUS = 511;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/NotExtended.ts
+++ b/packages/specs/exceptions/src/serverErrors/NotExtended.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class NotExtended extends Exception {
+export class NotExtended extends ServerException {
   static readonly STATUS = 510;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/NotImplemented.ts
+++ b/packages/specs/exceptions/src/serverErrors/NotImplemented.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class NotImplemented extends Exception {
+export class NotImplemented extends ServerException {
   static readonly STATUS = 501;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/exceptions/src/serverErrors/ProxyError.ts
+++ b/packages/specs/exceptions/src/serverErrors/ProxyError.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class ProxyError extends Exception {
+export class ProxyError extends ServerException {
   static readonly STATUS = 502;
   name: string = "PROXY_ERROR";
 

--- a/packages/specs/exceptions/src/serverErrors/ServiceUnavailable.ts
+++ b/packages/specs/exceptions/src/serverErrors/ServiceUnavailable.ts
@@ -1,0 +1,9 @@
+import {ServerException} from "../core/ServerException";
+
+export class ServiceUnavailable extends ServerException {
+  static readonly STATUS = 503;
+
+  constructor(message: string, origin?: Error | string | any) {
+    super(ServiceUnavailable.STATUS, message, origin);
+  }
+}

--- a/packages/specs/exceptions/src/serverErrors/ServiceUnvailable.ts
+++ b/packages/specs/exceptions/src/serverErrors/ServiceUnvailable.ts
@@ -1,9 +1,0 @@
-import {Exception} from "../core/Exception";
-
-export class ServiceUnvailable extends Exception {
-  static readonly STATUS = 503;
-
-  constructor(message: string, origin?: Error | string | any) {
-    super(ServiceUnvailable.STATUS, message, origin);
-  }
-}

--- a/packages/specs/exceptions/src/serverErrors/VariantAlsoNegotiates.ts
+++ b/packages/specs/exceptions/src/serverErrors/VariantAlsoNegotiates.ts
@@ -1,6 +1,6 @@
-import {Exception} from "../core/Exception";
+import {ServerException} from "../core/ServerException";
 
-export class VariantAlsoNegotiates extends Exception {
+export class VariantAlsoNegotiates extends ServerException {
   static readonly STATUS = 506;
 
   constructor(message: string, origin?: Error | string | any) {

--- a/packages/specs/schema/jest.config.js
+++ b/packages/specs/schema/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 99.45,
-      branches: 96.18,
+      branches: 96.19,
       functions: 100,
       lines: 99.45
     }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| -------------    | --------------- |
| Feature | Yes     |

---

Wraps each of the 3xx, 4xx, and 5xx error with their own base class exception. This allows to filter out by 3xx, 4xx, 5xx error exceptions using these base classes

```ts
const error = new NotFound();

if (error instanceof ClientException) {
  // comes out as true
}
```

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
