### PR TITLE
feat(bullmq): skip initialization on missing config

### DIFF
--- a/packages/third-parties/bullmq/jest.config.js
+++ b/packages/third-parties/bullmq/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 81.81,
+      branches: 82.85,
       functions: 100,
       lines: 100,
       statements: 100

--- a/packages/third-parties/bullmq/src/BullMQModule.spec.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.spec.ts
@@ -1,7 +1,7 @@
-import {PlatformTest} from "@tsed/common";
+import {InjectorService, PlatformTest} from "@tsed/common";
 import {catchAsyncError} from "@tsed/core";
 import {Queue, Worker} from "bullmq";
-import {instance, mock, verify, when} from "ts-mockito";
+import {anyString, anything, instance, mock, verify, when} from "ts-mockito";
 
 import "./BullMQModule";
 import {BullMQModule} from "./BullMQModule";
@@ -181,4 +181,24 @@ describe("module", () => {
       expect(error?.message).toEqual("error");
     });
   });
+});
+
+it('skips initialization when no config is provided', async () => {
+  const injector = mock(InjectorService)
+  const dispatcher = mock(JobDispatcher);
+  await PlatformTest.create({
+    imports: [
+      {
+        token: InjectorService,
+        use: instance(injector),
+      },
+      {
+        token: JobDispatcher,
+        use: instance(dispatcher)
+      }
+    ]
+  })
+
+  verify(injector.add(anyString(), anything())).never();
+  verify(dispatcher.dispatch(anything())).never()
 });

--- a/packages/third-parties/bullmq/src/BullMQModule.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.ts
@@ -15,6 +15,10 @@ export class BullMQModule implements BeforeInit {
   constructor(private readonly injector: InjectorService, private readonly dispatcher: JobDispatcher) {}
 
   $beforeInit() {
+    if (!this.bullmq) {
+      return;
+    }
+
     this.buildWorkers();
     this.buildQueues();
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature| No          |

---

Should the bullmq config not be provided skip the initialization of any queues and workers. 

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [X] Tests
- [X] Coverage
- [ ] Example
- [ ] Documentation
