### PR TITLE
feat(bullmq): extend configuration

### DIFF
--- a/docs/tutorials/bullmq.md
+++ b/docs/tutorials/bullmq.md
@@ -53,7 +53,7 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
     // All other worker configuration will be ignored
     disableWorker: true,
     // Specify for which queues to start a worker for.
-    // Defaultly for every queue added in the `queues` parameter
+    // When undefined falls back to all queues specified.
     workerQueues: ["default"],
     defaultWorkerOptions: {
       // Default worker options which are applied to every worker

--- a/docs/tutorials/bullmq.md
+++ b/docs/tutorials/bullmq.md
@@ -49,6 +49,9 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
         // Specify additional queue options by queue name
       }
     },
+    // Disable the creation of any worker.
+    // All other worker configuration will be ignored
+    disableWorker: true,
     // Specify for which queues to start a worker for.
     // Defaultly for every queue added in the `queues` parameter
     workerQueues: ["default"],

--- a/docs/tutorials/bullmq.md
+++ b/docs/tutorials/bullmq.md
@@ -12,7 +12,7 @@ meta:
 
 ## Feature
 
-The [BullMQ](https://bullmq.io) Module for Ts.ED allows you to decorate a class using the `@Job` decorator and implement the `Job` interface provided by the module.
+The [BullMQ](https://bullmq.io) Module for Ts.ED allows you to decorate a class using the `@JobController` decorator and implement the `JobMethods` interface provided by the module.
 Repeatable Jobs can also be defined using this decorator.
 
 For more information about BullMQ look at the documentation [here](https://docs.bullmq.io/);
@@ -35,16 +35,32 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
 
 @Configuration({
   bullmq: {
-    queues: ["default", "special"];
+    // Specify queue name's to create
+    queues: ["default", "special"],
     connection: {
       // redisio connection options
-    };
-    // optional default job options
-    defaultJobOptions: {};
-    disableWorker: false;
-    // optionally specify for which queues to start a worker for
-    // in case not all queues should be worked on
-    workerQueues: ["default"];
+    },
+    defaultQueueOptions: {
+      // Default queue options which are applied to every queue
+      // Can be extended/overridden by `queueOptions`
+    },
+    queueOptions: {
+      special: {
+        // Specify additional queue options by queue name
+      }
+    },
+    // Specify for which queues to start a worker for.
+    // Defaultly for every queue added in the `queues` parameter
+    workerQueues: ["default"],
+    defaultWorkerOptions: {
+      // Default worker options which are applied to every worker
+      // Can be extended/overridden by `workerOptions`
+    },
+    workerOptions: {
+      special: {
+        // Specify additional worker options by queue name
+      }
+    }
   }
 })
 export class Server {}
@@ -52,7 +68,7 @@ export class Server {}
 
 ## Define a Job
 
-A job is defined as a class decorated with the `@Job` decorator and implementing the `Job` interface of the `@tsed/bullmq` package
+A job is defined as a class decorated with the `@JobController` decorator and implementing the `Job` interface of the `@tsed/bullmq` package
 
 ```ts
 import {JobController, JobMethods} from "@tsed/bullmq";
@@ -82,7 +98,8 @@ class OtherExampleJob implements JobMethods {
 
 ## Defining a repeating job
 
-Jobs that should be run regularly on a schedule can also easily defined using the `@Job` decorator
+Jobs that should be run regularly on a schedule can also easily defined using the `@JobController` decorator.
+Doing so will automatically dispatch it without any data.
 
 ```ts
 import {JobController, JobMethods} from "@tsed/bullmq";
@@ -146,9 +163,13 @@ class MyService {
   constructor(private readonly dispatcher: JobDispatcher) {}
 
   public async doingSomething() {
-    await this.dispatcher.dispatch(ExampleJob, {msg: "this message is part of the payload for the job"}, {
-      delay: 600_000 // 10 minutes in milliseconds
-    });
+    await this.dispatcher.dispatch(
+      ExampleJob,
+      {msg: "this message is part of the payload for the job"},
+      {
+        delay: 600_000 // 10 minutes in milliseconds
+      }
+    );
 
     console.info("I just dispatched a job!");
   }

--- a/packages/third-parties/bullmq/README.md
+++ b/packages/third-parties/bullmq/README.md
@@ -71,7 +71,7 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
     // All other worker configuration will be ignored
     disableWorker: true,
     // Specify for which queues to start a worker for.
-    // Defaultly for every queue added in the `queues` parameter
+    // When undefined falls back to all queues specified.
     workerQueues: ["default"],
     defaultWorkerOptions: {
       // Default worker options which are applied to every worker

--- a/packages/third-parties/bullmq/README.md
+++ b/packages/third-parties/bullmq/README.md
@@ -33,7 +33,7 @@ A package of Ts.ED framework. See website: https://tsed.io
 
 ## Feature
 
-The `@tsed/bullmq` package allows you to define jobs using the `@Job` decorator and the `JobMethods` interface and have them picked up by the `BullMQ` worker.
+The `@tsed/bullmq` package allows you to define jobs using the `@JobController` decorator and the `JobMethods` interface and have them picked up by the `BullMQ` worker.
 
 ## Installation
 
@@ -53,16 +53,32 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
 
 @Configuration({
   bullmq: {
-    queues: ["default", "special"];
+    // Specify queue name's to create
+    queues: ["default", "special"],
     connection: {
       // redisio connection options
-    };
-    // optional default job options
-    defaultJobOptions: {};
-    disableWorker: false;
-    // optionally specify for which queues to start a worker for
-    // in case not all queues should be worked on
-    workerQueues: ["default"];
+    },
+    defaultQueueOptions: {
+      // Default queue options which are applied to every queue
+      // Can be extended/overridden by `queueOptions`
+    },
+    queueOptions: {
+      special: {
+        // Specify additional queue options by queue name
+      }
+    },
+    // Specify for which queues to start a worker for.
+    // Defaultly for every queue added in the `queues` parameter
+    workerQueues: ["default"],
+    defaultWorkerOptions: {
+      // Default worker options which are applied to every worker
+      // Can be extended/overridden by `workerOptions`
+    },
+    workerOptions: {
+      special: {
+        // Specify additional worker options by queue name
+      }
+    }
   }
 })
 export class Server {}
@@ -100,7 +116,8 @@ class OtherExampleJob implements JobMethods {
 
 ## Defining a repeating job
 
-Jobs that should be run regularly on a schedule can also easily defined using the `@AsJob` decorator
+Jobs that should be run regularly on a schedule can also easily defined using the `@JobController` decorator.
+Doing so will automatically dispatch it without any data
 
 ```ts
 import {JobController, JobMethods} from "@tsed/bullmq";

--- a/packages/third-parties/bullmq/README.md
+++ b/packages/third-parties/bullmq/README.md
@@ -67,6 +67,9 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
         // Specify additional queue options by queue name
       }
     },
+    // Disable the creation of any worker.
+    // All other worker configuration will be ignored
+    disableWorker: true,
     // Specify for which queues to start a worker for.
     // Defaultly for every queue added in the `queues` parameter
     workerQueues: ["default"],

--- a/packages/third-parties/bullmq/jest.config.js
+++ b/packages/third-parties/bullmq/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 82.85,
+      branches: 86.48,
       functions: 100,
       lines: 100,
       statements: 100

--- a/packages/third-parties/bullmq/jest.config.js
+++ b/packages/third-parties/bullmq/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 86.48,
+      branches: 87.17,
       functions: 100,
       lines: 100,
       statements: 100

--- a/packages/third-parties/bullmq/src/BullMQModule.spec.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.spec.ts
@@ -151,6 +151,30 @@ describe("BullMQModule", () => {
       });
     });
 
+    describe("disableWorker", () => {
+      const config = {
+        queues: ["default", "foo", "bar"],
+        connection: {},
+        disableWorker: true
+      } as BullMQConfig;
+
+      beforeEach(async () => {
+        await PlatformTest.create({
+          bullmq: config,
+          imports: [
+            {
+              token: JobDispatcher,
+              use: instance(dispatcher)
+            }
+          ]
+        });
+      });
+
+      it("should not create any workers", () => {
+        expect(workerConstructorSpy).toHaveBeenCalledTimes(0);
+      });
+    });
+
     describe("without", () => {
       it("skips initialization", async () => {
         await PlatformTest.create({

--- a/packages/third-parties/bullmq/src/BullMQModule.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.ts
@@ -20,7 +20,9 @@ export class BullMQModule implements BeforeInit {
       return;
     }
 
-    this.buildWorkers();
+    if (!this.bullmq.disableWorker) {
+      this.buildWorkers();
+    }
     this.buildQueues();
 
     this.injector.getMany<JobMethods>("bullmq:cron").map((job) => this.dispatcher.dispatch(getComputedType(job)));

--- a/packages/third-parties/bullmq/src/BullMQModule.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.ts
@@ -2,7 +2,7 @@ import {BeforeInit, DIContext, runInContext} from "@tsed/common";
 import {Constant, InjectorService, Module} from "@tsed/di";
 import {deepMerge} from "@tsed/core";
 import {getComputedType} from "@tsed/schema";
-import {Job, Queue, QueueOptions, Worker, WorkerOptions} from "bullmq";
+import {Job, Queue, type QueueOptions, Worker, type WorkerOptions} from "bullmq";
 import {v4} from "uuid";
 import {BullMQConfig} from "./config/config";
 import {JobMethods} from "./contracts";

--- a/packages/third-parties/bullmq/src/config/config.ts
+++ b/packages/third-parties/bullmq/src/config/config.ts
@@ -1,13 +1,51 @@
-import {type ConnectionOptions, type DefaultJobOptions} from "bullmq";
+import type {ConnectionOptions, DefaultJobOptions, QueueOptions, WorkerOptions} from "bullmq";
 
 export type BullMQConfig = {
+  /**
+   * Specify queue name's to create
+   */
   queues: string[];
+
+  /**
+   * Default connection to use for queue's and worker's
+   */
   connection: ConnectionOptions;
+
+  /**
+   * @deprecated Use defaultQueueOptions instead. Will be removed in the next major release
+   */
   defaultJobOptions?: DefaultJobOptions;
-  disableWorker?: boolean;
-  // optionally specify for which queues to start a worker for
-  // in case not all queues should be worked on
+
+  /**
+   * Default queue options which are applied to every queue
+   *
+   * Can be extended/overridden by `queueOptions`
+   */
+  defaultQueueOptions?: QueueOptions;
+
+  /**
+   * Specify additional queue options by queue name
+   */
+  queueOptions?: Record<string, QueueOptions>;
+
+  /**
+   * Specify for which queues to start a worker for.
+   *
+   * Defaultly for every queue added in the `queues` parameter
+   */
   workerQueues?: string[];
+
+  /**
+   * Default worker options which are applied to every worker
+   *
+   * Can be extended/overridden by `workerOptions`
+   */
+  defaultWorkerOptions?: WorkerOptions;
+
+  /**
+   * Specify additional worker options by queue name
+   */
+  workerOptions?: Record<string, WorkerOptions>;
 };
 
 declare global {

--- a/packages/third-parties/bullmq/src/config/config.ts
+++ b/packages/third-parties/bullmq/src/config/config.ts
@@ -29,6 +29,13 @@ export type BullMQConfig = {
   queueOptions?: Record<string, QueueOptions>;
 
   /**
+   * Disable the creation of any worker.
+   *
+   * All other worker configuration will be ignored
+   */
+  disableWorker?: boolean;
+
+  /**
    * Specify for which queues to start a worker for.
    *
    * Defaultly for every queue added in the `queues` parameter

--- a/packages/third-parties/bullmq/src/contracts/JobMethods.ts
+++ b/packages/third-parties/bullmq/src/contracts/JobMethods.ts
@@ -1,3 +1,5 @@
-export interface JobMethods {
-  handle(payload: unknown): unknown;
+import {Job} from "bullmq";
+
+export interface JobMethods<DataType = unknown, ReturnType = unknown> {
+  handle(payload: DataType, job: Job<DataType, ReturnType>): ReturnType | Promise<ReturnType>;
 }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature|No          |

---

closes #2534 

### What changed?

- Added functionality to `disableWorker` (this option was unused, i would not say it is a breaking change 🤔)
- Deprecated `defaultJobOptions`
- Added `defaultJobOptions`, `queueOptions`, `defaultWorkerOptions` & `workerOptions`
- Deep merge the configuration of queues and workers by the connection, default options and specific options
- Improved typing
- Updated docs

<hr>

I don't know how i can test the option merge correctly 🤔 If needed please guide me on how to get the call args there.