### PR TITLE
chore(contrib): add myself as a contributor

### DIFF
--- a/team.json
+++ b/team.json
@@ -63,5 +63,15 @@
     "country": "Germany",
     "city": "NoWhere",
     "role": "Contributor"
+  },
+  {
+    "title": "Ralph Khreish",
+    "job": "Developer Fullstack",
+    "src": "https://avatars.githubusercontent.com/u/35776126?v=4",
+    "github": "Crunchyman-ralph",
+    "twitter": "RalphEcom",
+    "country": "France",
+    "city": "Paris",
+    "role": "Contributor"
   }
 ]


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Chore | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

Since I contributed with this pr: https://github.com/tsedio/tsed/pull/2183

I forgot to add myself as a contributor

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
