### PR TITLE
fix(bullmq): invalid name used for job retrieval

### DIFF
--- a/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.spec.ts
+++ b/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.spec.ts
@@ -35,7 +35,7 @@ describe("JobDispatcher", () => {
     queue = mock(Queue);
     when(queue.name).thenReturn("default");
     when(injector.get("bullmq.queue.default")).thenReturn(instance(queue));
-    when(injector.get("bullmq.job.example-job")).thenReturn(new ExampleTestJob());
+    when(injector.get("bullmq.job.default.example-job")).thenReturn(new ExampleTestJob());
 
     dispatcher = new JobDispatcher(instance(injector));
   });
@@ -117,7 +117,7 @@ describe("JobDispatcher", () => {
     let job: ExampleJobWithCustomJobIdFromJobMethods;
     beforeEach(() => {
       job = new ExampleJobWithCustomJobIdFromJobMethods();
-      when(injector.get("bullmq.job.example-job-with-custom-id-from-job-methods")).thenReturn(job);
+      when(injector.get("bullmq.job.default.example-job-with-custom-id-from-job-methods")).thenReturn(job);
     });
 
     it("should allow setting the job id from within the job", async () => {

--- a/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.ts
+++ b/packages/third-parties/bullmq/src/dispatchers/JobDispatcher.ts
@@ -60,7 +60,7 @@ export class JobDispatcher {
   }
 
   private async retrieveJobOptionsFromClassBasedJob(store: JobStore, payload: unknown): Promise<JobsOptions> {
-    const job = this.injector.get<JobMethods>(`bullmq.job.${store.name}`);
+    const job = this.injector.get<JobMethods>(`bullmq.job.${store.queue}.${store.name}`);
     if (!job) {
       return store.opts;
     }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
|Fix|No          |

---
Used the wrong key for retrieving the job in the dispatcher
<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [X] Tests
- [X] Coverage
- [ ] Example
- [ ] Documentation
