### PR TITLE
feat(bullmq): add more context to logger context

### DIFF
--- a/packages/third-parties/bullmq/src/BullMQModule.spec.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.spec.ts
@@ -297,7 +297,8 @@ describe("BullMQModule", () => {
         const job = {
           name: "regular",
           queueName: "default",
-          data: {test: "test"}
+          data: {test: "test"},
+          attemptsMade: 1
         };
 
         jest.spyOn(PlatformTest.injector.logger, "error");
@@ -308,6 +309,10 @@ describe("BullMQModule", () => {
 
         expect(worker.handle).toHaveBeenCalledWith({test: "test"}, job);
         expect(PlatformTest.injector.logger.error).toHaveBeenCalledWith({
+          attempt: 1,
+          name: "regular",
+          queue: "default",
+          logType: "bullmq",
           duration: expect.any(Number),
           event: "BULLMQ_JOB_ERROR",
           message: "error",


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature|No          |

---
Add more context to context for more context in logs.
<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
