### PR TITLE
feat(di): allow controllers to be scoped to environment

### DIFF
--- a/docs/docs/controllers.md
+++ b/docs/docs/controllers.md
@@ -105,6 +105,13 @@ See the following example:
 
 In order to avoid such side-effects, simply move `findAll()` method above `findOne()`.
 
+### Environment scoped controllers
+
+Sometimes you have controllers that you want to only serve locally for development purposes, for this you can specify the environments in which they should be run.
+These environments are then checked against the `NODE_ENV`
+
+<<< @/docs/snippets/controllers/development-only-controller.ts
+
 ## Request
 
 ### Decorators

--- a/docs/docs/snippets/controllers/development-only-controller.ts
+++ b/docs/docs/snippets/controllers/development-only-controller.ts
@@ -1,0 +1,13 @@
+import {Get} from "@tsed/schema";
+import {Controller} from "@tsed/di";
+
+@Controller({
+  path: "local",
+  environments: ["development"]
+})
+export class LocalCtrl {
+  @Get()
+  index(): string {
+    return [];
+  }
+}

--- a/packages/di/src/common/decorators/controller.spec.ts
+++ b/packages/di/src/common/decorators/controller.spec.ts
@@ -8,7 +8,7 @@ class Test {}
 class Dep {}
 
 describe("@Controller", () => {
-  afterAll(() => {
+  afterEach(() => {
     GlobalProviders.delete(Test);
   });
   it("should register a controller with his path and Dependency", () => {
@@ -39,5 +39,40 @@ describe("@Controller", () => {
     expect(provider.scope).toEqual(ProviderScope.REQUEST);
     expect(provider.path).toEqual("/test");
     expect(provider.children).toEqual([Dep]);
+  });
+
+  describe("environments", () => {
+    it("should not register the controller on an invalid environment", () => {
+      Controller({
+        path: "/test",
+        environments: ["development"]
+      })(Test);
+
+      const provider = GlobalProviders.get(Test);
+
+      expect(provider).toBeUndefined();
+    });
+
+    it("should register the controller for the current environment", () => {
+      Controller({
+        path: "/test",
+        environments: [process.env.NODE_ENV]
+      })(Test);
+
+      const provider = GlobalProviders.get(Test);
+
+      expect(provider).not.toBeUndefined();
+    });
+
+    it("should register the controller when at least one environment matches", () => {
+      Controller({
+        path: "/test",
+        environments: ["development", process.env.NODE_ENV]
+      })(Test);
+
+      const provider = GlobalProviders.get(Test);
+
+      expect(provider).not.toBeUndefined();
+    });
   });
 });

--- a/packages/di/src/common/decorators/controller.ts
+++ b/packages/di/src/common/decorators/controller.ts
@@ -15,6 +15,7 @@ export interface ControllerOptions extends Partial<ProviderOpts<any>> {
   path?: PathType;
   children?: Type<any>[];
   middlewares?: Partial<ControllerMiddlewares>;
+  environments?: string[];
 }
 
 function mapOptions(options: any): ControllerOptions {
@@ -56,7 +57,13 @@ function mapOptions(options: any): ControllerOptions {
  * @classDecorator
  */
 export function Controller(options: PathType | ControllerOptions): ClassDecorator {
-  const {children = [], path, ...opts} = mapOptions(options);
+  const {children = [], path, environments = [process.env.NODE_ENV as string], ...opts} = mapOptions(options);
+
+  const controllerIsForCurrentEnvironment = environments.includes(process.env.NODE_ENV as string);
+
+  if (!controllerIsForCurrentEnvironment) {
+    return useDecorators();
+  }
 
   return useDecorators(
     (target: Type) => {

--- a/packages/third-parties/bullmq/.npmignore
+++ b/packages/third-parties/bullmq/.npmignore
@@ -19,3 +19,4 @@ jest.config.js
 .idea
 packages
 .tsbuildinfo
+*.tsbuildinfo


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

Allow controllers to be scoped to an environment.

```ts
import {Get} from "@tsed/schema";
import {Controller} from "@tsed/di";

@Controller({
  path: "local",
  environments: ["development"]
})
export class LocalCtrl {
  @Get()
  index(): string {
    return [];
  }
}
```

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [X] Tests
- [X] Coverage
- [X] Example
- [X] Documentation
