### PR TITLE
feat(agenda): add drainJobsBeforeClose option to agenda settings

### DIFF
--- a/docs/tutorials/agenda.md
+++ b/docs/tutorials/agenda.md
@@ -40,6 +40,8 @@ const mongoConnectionString = "mongodb://127.0.0.1/agenda";
 @Configuration({
   agenda: {
     enabled: true, // Enable Agenda jobs for this instance.
+    // drainJobsBeforeStop: true, // Wait for jobs to finish before stopping the agenda process.
+    // disableJobProcessing: true, // Prevents jobs from being processed.
     // pass any options that you would normally pass to new Agenda(), e.g.
     db: {
       address: mongoConnectionString

--- a/packages/third-parties/agenda/jest.config.js
+++ b/packages/third-parties/agenda/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 100,
-      branches: 91.48,
+      branches: 91.66,
       functions: 100,
       lines: 100
     }

--- a/packages/third-parties/agenda/package.json
+++ b/packages/third-parties/agenda/package.json
@@ -35,10 +35,10 @@
     "@tsed/di": "7.53.0",
     "@tsed/eslint": "7.44.1",
     "@tsed/typescript": "7.44.1",
-    "agenda": "^4.1.3",
+    "agenda": "^5.0.0",
     "eslint": "^8.12.0"
   },
   "peerDependencies": {
-    "agenda": "^4.1.3"
+    "agenda": ">=4"
   }
 }

--- a/packages/third-parties/agenda/readme.md
+++ b/packages/third-parties/agenda/readme.md
@@ -61,6 +61,8 @@ const mongoConnectionString = "mongodb://127.0.0.1/agenda";
 @Configuration({
   agenda: {
     enabled: true, // Enable Agenda jobs for this instance.
+    // drainJobsBeforeStop: true, // Wait for jobs to finish before stopping the agenda process.
+    // disableJobProcessing: true, // Prevents jobs from being processed.
     // pass any options that you would normally pass to new Agenda(), e.g.
     db: {
       address: mongoConnectionString

--- a/packages/third-parties/agenda/src/AgendaModule.spec.ts
+++ b/packages/third-parties/agenda/src/AgendaModule.spec.ts
@@ -11,6 +11,7 @@ jest.mock("agenda", () => {
     Agenda: class {
       close = jest.fn();
       stop = jest.fn();
+      drain = jest.fn();
       define = jest.fn();
       every = jest.fn();
       schedule = jest.fn();
@@ -131,11 +132,32 @@ describe("AgendaModule", () => {
 
         await agendaModule.$onDestroy();
 
+        expect(agendaModule.agenda.stop).toHaveBeenCalledWith();
         expect(agendaModule.agenda.close).toHaveBeenCalledWith({force: true});
       });
     });
   });
+  describe("when agenda is enabled and drainJobsBeforeClose = true", () => {
+    beforeEach(() =>
+      PlatformTest.create({
+        agenda: {
+          enabled: true,
+          drainJobsBeforeClose: true
+        }
+      })
+    );
+    afterEach(() => PlatformTest.reset());
+    describe("$onDestroy()", () => {
+      it("should close agenda", async () => {
+        const agendaModule = PlatformTest.get<any>(AgendaModule)!;
 
+        await agendaModule.$onDestroy();
+
+        expect(agendaModule.agenda.drain).toHaveBeenCalledWith();
+        expect(agendaModule.agenda.close).toHaveBeenCalledWith({force: true});
+      });
+    });
+  });
   describe("when agenda is enabled but disableJobProcessing = true", () => {
     beforeEach(() =>
       PlatformTest.create({

--- a/packages/third-parties/agenda/src/AgendaModule.ts
+++ b/packages/third-parties/agenda/src/AgendaModule.ts
@@ -56,7 +56,7 @@ export class AgendaModule implements OnDestroy, AfterListen {
 
   async $onDestroy(): Promise<any> {
     if (this.enabled) {
-      if (this.drainJobsBeforeClose) {
+      if (this.drainJobsBeforeClose && "drain" in this.agenda) {
         this.logger.info({
           event: "AGENDA_DRAIN",
           message: "Agenda is draining all jobs before close"
@@ -120,7 +120,7 @@ export class AgendaModule implements OnDestroy, AfterListen {
     Object.entries(store.define).forEach(([propertyKey, {name, ...options}]) => {
       const instance = this.injector.get(provider.token);
 
-      const jobProcessor: Processor = instance[propertyKey].bind(instance) as Processor;
+      const jobProcessor: Processor<unknown> = instance[propertyKey].bind(instance) as Processor<unknown>;
       const jobName = this.getNameForJob(propertyKey, store.namespace, name);
 
       this.define(jobName, options, jobProcessor);

--- a/packages/third-parties/agenda/src/interfaces/interfaces.ts
+++ b/packages/third-parties/agenda/src/interfaces/interfaces.ts
@@ -9,6 +9,7 @@ declare global {
          */
         enabled?: boolean;
         disableJobProcessing?: boolean;
+        drainJobsBeforeClose?: boolean;
       } & AgendaConfig;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6941,17 +6941,17 @@ adm-zip@^0.5.9:
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
   integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
 
-agenda@^4.1.3:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agenda/-/agenda-4.2.1.tgz#3bf1e039d47502e0974657b611e6bbde268d98ad"
-  integrity sha512-6DRPa1j4GPQ+tJNJLr1wWC7qbuqqdc6+adcPXDlNQucpMfLKpWr+Vl6IPkaHJe2lIO1Zh7iyU6W61au+K4Rpyg==
+agenda@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/agenda/-/agenda-5.0.0.tgz#1b22b8c7710e5d973498f354713665bfd5e51c33"
+  integrity sha512-jOoa7PvARpst/y2PI8h0wph4NmcjYJ/4wzFhQcHUbNgN+Hte/9h/MzKE0ZmHfIwdsSlnv3rhbBQ3Zd/gwFkThg==
   dependencies:
-    cron-parser "^3.0.0"
+    cron-parser "^3.5.0"
     date.js "~0.3.3"
-    debug "~4.3.0"
-    human-interval "~2.0.0"
-    moment-timezone "~0.5.27"
-    mongodb "^4.1.0"
+    debug "~4.3.4"
+    human-interval "~2.0.1"
+    moment-timezone "~0.5.37"
+    mongodb "^4.11.0"
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -9667,7 +9667,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cron-parser@^3.0.0:
+cron-parser@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-3.5.0.tgz#b1a9da9514c0310aa7ef99c2f3f1d0f8c235257c"
   integrity sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==
@@ -9904,7 +9904,7 @@ db-errors@^0.2.3:
   resolved "https://registry.yarnpkg.com/db-errors/-/db-errors-0.2.3.tgz#a6a38952e00b20e790f2695a6446b3c65497ffa2"
   integrity sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng==
 
-debug@*, debug@4, debug@4.3.4, debug@4.x, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.0, debug@~4.3.1, debug@~4.3.2:
+debug@*, debug@4, debug@4.3.4, debug@4.x, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -12925,7 +12925,7 @@ https-proxy-agent@5.0.1, https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
-human-interval@~2.0.0:
+human-interval@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/human-interval/-/human-interval-2.0.1.tgz#655baf606c7067bb26042dcae14ec777b099af15"
   integrity sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==
@@ -16513,17 +16513,29 @@ module-not-found-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
   integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
-moment-timezone@^0.5.34, moment-timezone@~0.5.27:
+moment-timezone@^0.5.34:
   version "0.5.37"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.37.tgz#adf97f719c4e458fdb12e2b4e87b8bec9f4eef1e"
   integrity sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==
   dependencies:
     moment ">= 2.9.0"
 
+moment-timezone@~0.5.37:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
+  dependencies:
+    moment "^2.29.4"
+
 moment@2.29.4, "moment@>= 2.9.0", moment@^2.29.1, moment@^2.9.0:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
+moment@^2.29.4:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 mongodb-connection-string-url@^2.5.2:
   version "2.5.2"
@@ -16570,7 +16582,7 @@ mongodb-memory-server@^8.15.1:
     mongodb-memory-server-core "8.15.1"
     tslib "^2.6.1"
 
-mongodb@*, mongodb@^4.1.0, mongodb@^4.1.1, mongodb@^4.3.0:
+mongodb@*, mongodb@^4.1.1, mongodb@^4.3.0:
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.16.0.tgz#8b0043de7b577c6a7e0ce44a2ca7315b9c0a7927"
   integrity sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==
@@ -16605,6 +16617,18 @@ mongodb@4.8.1:
     socks "^2.6.2"
   optionalDependencies:
     saslprep "^1.0.3"
+
+mongodb@^4.11.0:
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.17.2.tgz#237c0534e36a3449bd74c6bf6d32f87a1ca7200c"
+  integrity sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==
+  dependencies:
+    bson "^4.7.2"
+    mongodb-connection-string-url "^2.6.0"
+    socks "^2.7.1"
+  optionalDependencies:
+    "@aws-sdk/credential-providers" "^3.186.0"
+    "@mongodb-js/saslprep" "^1.1.0"
 
 mongodb@^4.16.0:
   version "4.17.1"


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

Use agenda.drain() instead of agenda.stop() if the `drainJobsBeforeClose` option is `true`.