### PR TITLE
feat(bullmq): support bullmq 5

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,4 @@ jest.config.js
 .gitignore
 .idea
 packages
+*.tsbuildinfo

--- a/packages/third-parties/bullmq/.npmignore
+++ b/packages/third-parties/bullmq/.npmignore
@@ -19,3 +19,4 @@ jest.config.js
 .idea
 packages
 .tsbuildinfo
+*.tsbuildinfo

--- a/packages/third-parties/bullmq/package.json
+++ b/packages/third-parties/bullmq/package.json
@@ -35,11 +35,11 @@
     "@tsed/eslint": "7.44.1",
     "@tsed/schema": "7.55.0",
     "@tsed/typescript": "7.44.1",
-    "bullmq": "^4.12.3",
+    "bullmq": "^4.12.3 || ^5.1.1",
     "eslint": "^8.12.0",
     "ts-mockito": "^2.6.1"
   },
   "peerDependencies": {
-    "bullmq": "^4.12.3"
+    "bullmq": "^4.12.3 || ^5.1.1"
   }
 }

--- a/packages/third-parties/bullmq/src/config/config.ts
+++ b/packages/third-parties/bullmq/src/config/config.ts
@@ -21,12 +21,12 @@ export type BullMQConfig = {
    *
    * Can be extended/overridden by `queueOptions`
    */
-  defaultQueueOptions?: QueueOptions;
+  defaultQueueOptions?: Omit<QueueOptions, "connection">;
 
   /**
    * Specify additional queue options by queue name
    */
-  queueOptions?: Record<string, QueueOptions>;
+  queueOptions?: Record<string, Omit<QueueOptions, "connection">>;
 
   /**
    * Disable the creation of any worker.
@@ -47,12 +47,12 @@ export type BullMQConfig = {
    *
    * Can be extended/overridden by `workerOptions`
    */
-  defaultWorkerOptions?: WorkerOptions;
+  defaultWorkerOptions?: Omit<WorkerOptions, "connection">;
 
   /**
    * Specify additional worker options by queue name
    */
-  workerOptions?: Record<string, WorkerOptions>;
+  workerOptions?: Record<string, Omit<WorkerOptions, "connection">>;
 };
 
 declare global {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8306,10 +8306,10 @@ builtins@^5.0.0:
   dependencies:
     semver "^7.0.0"
 
-bullmq@^4.12.3:
-  version "4.12.3"
-  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-4.12.3.tgz#0c649b9a5e48227519c526ee9edd96b982eee22d"
-  integrity sha512-4uPp4NQTALFF+eFK7g8VJM+rt0aiduQdzBomgiEO1OK4OE+TdgC6cjGXooKI/asuB8iDhSZ+pSnGYy5Xyr6qRA==
+"bullmq@^4.12.3 || ^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-5.1.1.tgz#ce07f513fceae580d766fc15e15be4a5ceeb348f"
+  integrity sha512-j3zbNEQWsyHjpqGWiem2XBfmxAjYcArbwsmGlkM1E9MAVcrqB5hQUsXmyy9gEBAdL+PVotMICr7xTquR4Y2sKQ==
   dependencies:
     cron-parser "^4.6.0"
     glob "^8.0.3"


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature|No          |

---

Support bullmq v5, from what I could see there is nothing that requires changing on our part. 

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
