### PR TITLE
fix(bullmq): fix breaking configuration type change

### DIFF
--- a/packages/third-parties/bullmq/src/config/config.ts
+++ b/packages/third-parties/bullmq/src/config/config.ts
@@ -21,12 +21,12 @@ export type BullMQConfig = {
    *
    * Can be extended/overridden by `queueOptions`
    */
-  defaultQueueOptions?: Omit<QueueOptions, "connection">;
+  defaultQueueOptions?: Partial<QueueOptions>;
 
   /**
    * Specify additional queue options by queue name
    */
-  queueOptions?: Record<string, Omit<QueueOptions, "connection">>;
+  queueOptions?: Record<string, Partial<QueueOptions>>;
 
   /**
    * Disable the creation of any worker.
@@ -47,12 +47,12 @@ export type BullMQConfig = {
    *
    * Can be extended/overridden by `workerOptions`
    */
-  defaultWorkerOptions?: Omit<WorkerOptions, "connection">;
+  defaultWorkerOptions?: Partial<WorkerOptions>;
 
   /**
    * Specify additional worker options by queue name
    */
-  workerOptions?: Record<string, Omit<WorkerOptions, "connection">>;
+  workerOptions?: Record<string, Partial<WorkerOptions>>;
 };
 
 declare global {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
|Fix | No          |

---

Fix configuration type broken by bullmq 5 update. https://github.com/tsedio/tsed/pull/2570#issuecomment-1898667068

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
