### PR TITLE
fix(platform-log-middleware): fix ambient file declaration to have logger options from PlatformLogMiddleware

### DIFF
--- a/packages/di/src/common/interfaces/DILoggerOptions.ts
+++ b/packages/di/src/common/interfaces/DILoggerOptions.ts
@@ -45,8 +45,10 @@ export interface DILoggerOptions {
 
 declare global {
   namespace TsED {
+    interface LoggerConfiguration extends DILoggerOptions {}
+
     interface Configuration extends Record<string, any> {
-      logger?: DILoggerOptions;
+      logger?: LoggerConfiguration;
     }
   }
 }

--- a/packages/platform/platform-log-middleware/src/domain/PlatformLogMiddlewareSettings.ts
+++ b/packages/platform/platform-log-middleware/src/domain/PlatformLogMiddlewareSettings.ts
@@ -1,5 +1,3 @@
-import {Context} from "@tsed/platform-params";
-
 export type LoggerRequestFields = ("reqId" | "method" | "url" | "headers" | "body" | "query" | "params" | "duration" | string)[];
 
 export interface PlatformLogMiddlewareSettings {


### PR DESCRIPTION
Closes: #2592

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |
