### PR TITLE
feat(bullmq): add hooks for graceful shutdown

### DIFF
--- a/packages/third-parties/bullmq/jest.config.js
+++ b/packages/third-parties/bullmq/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   ...require("@tsed/jest-config"),
   coverageThreshold: {
     global: {
-      branches: 94.66,
+      branches: 95,
       functions: 100,
       lines: 100,
       statements: 100


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature| No         |

---
Add tsed lifecycle hooks for graceful shutdown of bullmq queues and workers.
<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
