### PR TITLE
ci: prevent push pipeline on prs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ name: Build & Release
 
 on:
   push:
+    branches: [production, alpha, beta, rc]
   pull_request:
     branches: [production]
     types: [opened, synchronize, closed]

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches: [production]
     paths-ignore:
       - "**.md"
       - "docs"


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature| No          |

---
Currently the build jobs run twice, triggered by both the push and the pr update, this prevent the push pipeline from running in prs. 
<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
