### PR TITLE
fix(di): reimplement imports option correctly on DITest.create()

### DIFF
--- a/packages/di/src/common/services/InjectorService.ts
+++ b/packages/di/src/common/services/InjectorService.ts
@@ -293,7 +293,8 @@ export class InjectorService extends Container {
 
     // allow mocking or changing provider instance before loading injector
     this.settings.imports = this.settings.imports
-      ?.map((meta) => {
+      ?.filter((meta) => meta.token !== InjectorService)
+      .map((meta) => {
         if ("token" in meta && "use" in meta) {
           const {token, use} = meta;
           const provider = this.getProvider(token);

--- a/packages/di/src/node/services/DITest.spec.ts
+++ b/packages/di/src/node/services/DITest.spec.ts
@@ -1,0 +1,63 @@
+import {Inject, Injectable, InjectorService, registerProvider} from "../../index";
+import {DITest} from "../services/DITest";
+
+@Injectable()
+export class MyService {
+  @Inject("TOKEN")
+  token: any;
+}
+
+registerProvider({
+  provide: "TOKEN",
+  useFactory() {
+    return {token: "token"};
+  }
+});
+describe("DITest", () => {
+  describe("create()", () => {
+    beforeEach(() =>
+      DITest.create({
+        imports: [
+          {
+            token: "TOKEN",
+            use: {token: "test"}
+          },
+          {
+            token: InjectorService, // not possible to override the injector
+            use: "test"
+          }
+        ]
+      })
+    );
+    afterEach(() => DITest.reset());
+
+    it("should return a service with pre mocked dependencies", () => {
+      const service = DITest.get<MyService>(MyService);
+
+      expect(service.token).toEqual({
+        token: "test"
+      });
+    });
+
+    it("should return a service with pre mocked dependencies (invoke)", async () => {
+      const service = await DITest.invoke<MyService>(MyService);
+
+      expect(service.token).toEqual({
+        token: "test"
+      });
+    });
+
+    it("should return a service with pre mocked dependencies (invoke + mock)", async () => {
+      const service = await DITest.invoke<MyService>(MyService, [
+        {
+          token: "TOKEN",
+          use: {token: "test2"}
+        }
+      ]);
+
+      expect(service.token).toEqual({
+        token: "test2"
+      });
+    });
+  });
+});

--- a/packages/di/src/node/services/DITest.ts
+++ b/packages/di/src/node/services/DITest.ts
@@ -1,6 +1,6 @@
 import {Env, getValue, isClass, isPromise, setValue} from "@tsed/core";
 import {$log} from "@tsed/logger";
-import {createContainer, InjectorService, LocalsContainer, OnInit, TokenProvider, TokenProviderOpts} from "../../common/index";
+import {createContainer, InjectorService, LocalsContainer, OnInit, Provider, TokenProvider, TokenProviderOpts} from "../../common/index";
 import {DIContext} from "../domain/DIContext";
 import {setLoggerConfiguration} from "../utils/setLoggerConfiguration";
 


### PR DESCRIPTION
Closes: #2660

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {PlatformTest} from "@tsed/common";
import {registerProvider} from "@tsed/common";

registerProvider({
  provide: "TOKEN",
  useFactory() {
    return {token: "token"};
  }
});

describe("OnInit Invoke", () => {
  beforeEach(() =>
    PlatformTest.create({
      imports: [
        {
          token: "TOKEN",
          use: {token: "test"}
        }
      ]
    })
  );
  afterEach(() => PlatformTest.reset()); 
 //....
})

```

## Todos

- [x] Tests

