### PR TITLE
:bug: fix: resolve eventemitter2 import error in ESM

### DIFF
--- a/packages/third-parties/event-emitter/src/services/EventEmitterFactory.ts
+++ b/packages/third-parties/event-emitter/src/services/EventEmitterFactory.ts
@@ -1,5 +1,5 @@
 import {Configuration, registerProvider} from "@tsed/di";
-import {ConstructorOptions} from "eventemitter2";
+import type {ConstructorOptions} from "eventemitter2";
 import EventEmitter2 from "eventemitter2";
 
 export const EventEmitterService = EventEmitter2;

--- a/packages/third-parties/event-emitter/src/services/EventEmitterFactory.ts
+++ b/packages/third-parties/event-emitter/src/services/EventEmitterFactory.ts
@@ -1,5 +1,6 @@
 import {Configuration, registerProvider} from "@tsed/di";
-import {ConstructorOptions, EventEmitter2} from "eventemitter2";
+import {ConstructorOptions} from "eventemitter2";
+import EventEmitter2 from "eventemitter2";
 
 export const EventEmitterService = EventEmitter2;
 export type EventEmitterService = EventEmitter2;


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

```
Successfully compiled: 330 files with swc (250.41ms)
file:///Users/duwan/Workspaces/babelcloud/babel-agent-2/node_modules/.pnpm/@tsed+event-emitter@7.67.5_eventemitter2@6.4.9/node_modules/@tsed/event-emitter/lib/esm/services/EventEmitterFactory.js:2
import { EventEmitter2 } from "eventemitter2";
         ^^^^^^^^^^^^^
SyntaxError: The requested module 'eventemitter2' does not provide an export named 'EventEmitter2'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:132:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:214:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
```

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
