### PR TITLE
build(mikro-orm): bump mikro-orm from 5.4.2 to 5.9.8

### DIFF
--- a/packages/orm/mikro-orm/package.json
+++ b/packages/orm/mikro-orm/package.json
@@ -22,8 +22,8 @@
     "tslib": "2.6.1"
   },
   "devDependencies": {
-    "@mikro-orm/core": "5.4.2",
-    "@mikro-orm/mongodb": "5.4.2",
+    "@mikro-orm/core": "5.9.8",
+    "@mikro-orm/mongodb": "5.9.8",
     "@tsed/common": "workspace:*",
     "@tsed/core": "workspace:*",
     "@tsed/di": "workspace:*",

--- a/packages/orm/mikro-orm/test/integration.spec.ts
+++ b/packages/orm/mikro-orm/test/integration.spec.ts
@@ -17,7 +17,7 @@ describe("MikroOrm integration", () => {
   let spiedHooks!: Hooks;
 
   beforeEach(async () => {
-    await TestMongooseContext.install();
+    await TestMongooseContext.install({replicaSet: true});
     const {url: clientUrl} = await TestMongooseContext.getMongooseOptions();
     const bstrp = PlatformTest.bootstrap(Server, {
       disableComponentScan: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,16 +3959,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mikro-orm/core@npm:5.4.2":
-  version: 5.4.2
-  resolution: "@mikro-orm/core@npm:5.4.2"
+"@mikro-orm/core@npm:5.9.8":
+  version: 5.9.8
+  resolution: "@mikro-orm/core@npm:5.9.8"
   dependencies:
     acorn-loose: "npm:8.3.0"
     acorn-walk: "npm:8.2.0"
-    dotenv: "npm:16.0.2"
-    fs-extra: "npm:10.1.0"
-    globby: "npm:11.0.4"
-    mikro-orm: "npm:~5.4.2"
+    dotenv: "npm:16.3.1"
+    fs-extra: "npm:11.1.1"
+    globby: "npm:11.1.0"
+    mikro-orm: "npm:5.9.8"
     reflect-metadata: "npm:0.1.13"
   peerDependencies:
     "@mikro-orm/better-sqlite": ^5.0.0
@@ -4002,16 +4002,16 @@ __metadata:
       optional: true
     "@mikro-orm/sqlite":
       optional: true
-  checksum: 10/3c4f7b83c210291d3ba6b34b2ced35859d1b4d52d90faeba0eef061386cdfd3896bd0bc344ea3c0cb2a9ba2c591494e47a419e8c96523b49efc61a6f9df299d9
+  checksum: 10/e47e07b1f53a9e207f6b9ec6831f33bb10191751a972be92dd205d522cd97567cca5c19a1476a95e12151bf10e1ce4b1ed61aecb5a170552a1bdc26524d9ed0d
   languageName: node
   linkType: hard
 
-"@mikro-orm/mongodb@npm:5.4.2":
-  version: 5.4.2
-  resolution: "@mikro-orm/mongodb@npm:5.4.2"
+"@mikro-orm/mongodb@npm:5.9.8":
+  version: 5.9.8
+  resolution: "@mikro-orm/mongodb@npm:5.9.8"
   dependencies:
-    bson: "npm:^4.7.0"
-    mongodb: "npm:4.9.1"
+    bson: "npm:^5.4.0"
+    mongodb: "npm:5.8.1"
   peerDependencies:
     "@mikro-orm/core": ^5.0.0
     "@mikro-orm/entity-generator": ^5.0.0
@@ -4027,7 +4027,7 @@ __metadata:
       optional: true
     "@mikro-orm/seeder":
       optional: true
-  checksum: 10/a847e8e1f170903bc1fb831c686f5097293652052a045f31c5702d8f4b51e0bb24785505f5cbf32ad5a55cbc5107f86a821bf2c6f4d071c7d003947d2e0b35d1
+  checksum: 10/238aa17302c6f833bae99d11a20d0588e24b3303160c81264fe5c0f87044690c525438d6552685ad5d6927514dc3c3f6db27cfbf07854a3e99837abced1d1f5b
   languageName: node
   linkType: hard
 
@@ -6998,8 +6998,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tsed/mikro-orm@workspace:packages/orm/mikro-orm"
   dependencies:
-    "@mikro-orm/core": "npm:5.4.2"
-    "@mikro-orm/mongodb": "npm:5.4.2"
+    "@mikro-orm/core": "npm:5.9.8"
+    "@mikro-orm/mongodb": "npm:5.9.8"
     "@tsed/common": "workspace:*"
     "@tsed/core": "workspace:*"
     "@tsed/di": "workspace:*"
@@ -11653,12 +11653,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bson@npm:^4.6.5, bson@npm:^4.7.0, bson@npm:^4.7.2":
+"bson@npm:^4.6.5, bson@npm:^4.7.2":
   version: 4.7.2
   resolution: "bson@npm:4.7.2"
   dependencies:
     buffer: "npm:^5.6.0"
   checksum: 10/9bc1a5c0e3774d171f291b5d44bcc6dacbdbba14184893eb810a5ca889b0dbcae5e0870fb2c731b069ce8ee77f3ebe3750669ed952d30de6a087baca59359781
+  languageName: node
+  linkType: hard
+
+"bson@npm:^5.4.0":
+  version: 5.5.1
+  resolution: "bson@npm:5.5.1"
+  checksum: 10/4f72f0e68694cf422e990d301594e1eb81300ad7bd547244bbd5c2d12ec721cf4765a254376dd21e922b0ac8b5f89549d37423bdea11d5e645afbd37b433dc90
   languageName: node
   linkType: hard
 
@@ -14400,17 +14407,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:16.0.2":
-  version: 16.0.2
-  resolution: "dotenv@npm:16.0.2"
-  checksum: 10/688fa2358ba09440164e18057b2fe3f75aeeb94b455e1901345786942ca4a48da677aa81a6361d83af4945b8230ca2b0fe186c2bea27bf4f8d58fe0508e6e23c
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:16.0.3":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
   checksum: 10/d6788c8e40b35ad9a9ca29249dccf37fa6b3ad26700fcbc87f2f41101bf914f5193a04e36a3d23de70b1dcb8e5d5a3b21e151debace2c4cd08d868be500a1b29
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:16.3.1, dotenv@npm:~16.3.1":
+  version: 16.3.1
+  resolution: "dotenv@npm:16.3.1"
+  checksum: 10/dbb778237ef8750e9e3cd1473d3c8eaa9cc3600e33a75c0e36415d0fa0848197f56c3800f77924c70e7828f0b03896818cd52f785b07b9ad4d88dba73fbba83f
   languageName: node
   linkType: hard
 
@@ -14425,13 +14432,6 @@ __metadata:
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 10/31d7b5c010cebb80046ba6853d703f9573369b00b15129536494f04b0af4ea0060ce8646e3af58b455af2f6f1237879dd261a5831656410ec92561ae1ea44508
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:~16.3.1":
-  version: 16.3.1
-  resolution: "dotenv@npm:16.3.1"
-  checksum: 10/dbb778237ef8750e9e3cd1473d3c8eaa9cc3600e33a75c0e36415d0fa0848197f56c3800f77924c70e7828f0b03896818cd52f785b07b9ad4d88dba73fbba83f
   languageName: node
   linkType: hard
 
@@ -15597,7 +15597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
   version: 3.2.11
   resolution: "fast-glob@npm:3.2.11"
   dependencies:
@@ -16291,17 +16291,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:10.1.0, fs-extra@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10/05ce2c3b59049bcb7b52001acd000e44b3c4af4ec1f8839f383ef41ec0048e3cfa7fd8a637b1bddfefad319145db89be91f4b7c1db2908205d38bf91e7d1d3b7
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:11.1.1, fs-extra@npm:^11.1.0, fs-extra@npm:^11.1.1":
   version: 11.1.1
   resolution: "fs-extra@npm:11.1.1"
@@ -16332,6 +16321,17 @@ __metadata:
     jsonfile: "npm:^4.0.0"
     universalify: "npm:^0.1.0"
   checksum: 10/6fb12449f5349be724a138b4a7b45fe6a317d2972054517f5971959c26fbd17c0e145731a11c7324460262baa33e0a799b183ceace98f7a372c95fbb6f20f5de
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "fs-extra@npm:10.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10/05ce2c3b59049bcb7b52001acd000e44b3c4af4ec1f8839f383ef41ec0048e3cfa7fd8a637b1bddfefad319145db89be91f4b7c1db2908205d38bf91e7d1d3b7
   languageName: node
   linkType: hard
 
@@ -16912,20 +16912,6 @@ __metadata:
     merge2: "npm:^1.4.1"
     slash: "npm:^4.0.0"
   checksum: 10/cbf1a949aa5543c52ef00054ec29582bacdb2639eda79993da83fc8ac4f51d94c90018cd3ee50b22b76d357575c75bb9a9746ab010b8e0dd0f2bab7544154538
-  languageName: node
-  linkType: hard
-
-"globby@npm:11.0.4":
-  version: 11.0.4
-  resolution: "globby@npm:11.0.4"
-  dependencies:
-    array-union: "npm:^2.1.0"
-    dir-glob: "npm:^3.0.1"
-    fast-glob: "npm:^3.1.1"
-    ignore: "npm:^5.1.4"
-    merge2: "npm:^1.3.0"
-    slash: "npm:^3.0.0"
-  checksum: 10/118c5ac92c2914342dec05648d217c8f31b0ccbfd3eb24d8722d350aa3003200dd4ae1b573b894cc4759e85156eb3bab35c5873f98ae9301572e22f656641964
   languageName: node
   linkType: hard
 
@@ -17915,7 +17901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.4, ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 10/30283f05fb7d867ee0e08faebb3e69caba2c6c55092042cd061eac1b37a3e78db72bfcfbb08b3598999344fba3d93a9c693b5401da5faaecc0fb7c2dce87beb4
@@ -18203,16 +18189,6 @@ __metadata:
     redis-parser: "npm:^3.0.0"
     standard-as-callback: "npm:^2.1.0"
   checksum: 10/0140f055ef81d28e16ca8400b99dabb9ce82009f54afd83cba952c7d0c5d736841e43247765b8ee1af1f02843531c5b8df240af18bd3d7e2ca3d60b36e76213f
-  languageName: node
-  linkType: hard
-
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: "npm:1.1.0"
-    sprintf-js: "npm:^1.1.3"
-  checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
   languageName: node
   linkType: hard
 
@@ -19769,13 +19745,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10/9e22d80b4d0105b9899135365f746d47466ed53ef4223c529b3c0f7a39907743fdbd3c4379f94f1106f02755b5e90b2faaf84801a891135544e1ea475d1a1379
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 10/bebe7ae829bbd586ce8cbe83501dd8cb8c282c8902a8aeeed0a073a89dc37e8103b1244f3c6acd60278bcbfe12d93a3f83c9ac396868a3b3bbc3c5e5e3b648ef
   languageName: node
   linkType: hard
 
@@ -21932,10 +21901,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mikro-orm@npm:~5.4.2":
-  version: 5.4.2
-  resolution: "mikro-orm@npm:5.4.2"
-  checksum: 10/e374ca42e508a0452d57ff63fd2945eb92963803da9952f8adb4c7614aaf43d73467e8f0d985341ce720a09951c0f80bbd744d01a45f8aab02470ab5fb5e406f
+"mikro-orm@npm:5.9.8":
+  version: 5.9.8
+  resolution: "mikro-orm@npm:5.9.8"
+  checksum: 10/28aafcf174f2b99545eec3206e8409a90d2cdfed9a3993189d362eb9721e9feda23b3d83ff5b566d366e1d392fff37d75757d1315bd831a53d2270347699948b
   languageName: node
   linkType: hard
 
@@ -22396,7 +22365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb-connection-string-url@npm:^2.5.2, mongodb-connection-string-url@npm:^2.5.3, mongodb-connection-string-url@npm:^2.6.0":
+"mongodb-connection-string-url@npm:^2.5.2, mongodb-connection-string-url@npm:^2.6.0":
   version: 2.6.0
   resolution: "mongodb-connection-string-url@npm:2.6.0"
   dependencies:
@@ -22473,19 +22442,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb@npm:4.9.1":
-  version: 4.9.1
-  resolution: "mongodb@npm:4.9.1"
+"mongodb@npm:5.8.1":
+  version: 5.8.1
+  resolution: "mongodb@npm:5.8.1"
   dependencies:
-    bson: "npm:^4.7.0"
-    denque: "npm:^2.1.0"
-    mongodb-connection-string-url: "npm:^2.5.3"
-    saslprep: "npm:^1.0.3"
-    socks: "npm:^2.7.0"
+    "@mongodb-js/saslprep": "npm:^1.1.0"
+    bson: "npm:^5.4.0"
+    mongodb-connection-string-url: "npm:^2.6.0"
+    socks: "npm:^2.7.1"
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.188.0
+    "@mongodb-js/zstd": ^1.0.0
+    kerberos: ^1.0.0 || ^2.0.0
+    mongodb-client-encryption: ">=2.3.0 <3"
+    snappy: ^7.2.2
   dependenciesMeta:
-    saslprep:
+    "@mongodb-js/saslprep":
       optional: true
-  checksum: 10/dcfc870808a7d99f9b3c7547bd08e832fec7ece6f29dd58c6e702187643aa07faad20e989535ee784c5c48ebc58620a0d3c16777f20fe78a237fbf37414bed3b
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+  checksum: 10/425bea3cbcce444146abc946cfaf7d91fe92854945d17eb5912589ac12f926c5c073263f0948c0ba2dff154eab3a4746b2aaac5408de80296e4e35fdd01e8879
   languageName: node
   linkType: hard
 
@@ -27102,16 +27087,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.7.0":
-  version: 2.8.1
-  resolution: "socks@npm:2.8.1"
-  dependencies:
-    ip-address: "npm:^9.0.5"
-    smart-buffer: "npm:^4.2.0"
-  checksum: 10/a3cc38e0716ab53a2db3fa00c703ca682ad54dbbc9ed4c7461624a999be6fa7cdc79fc904c411618e698d5eff55a55aa6d9329169a7db11636d0200814a2b5aa
-  languageName: node
-  linkType: hard
-
 "sort-keys@npm:^2.0.0":
   version: 2.0.0
   resolution: "sort-keys@npm:2.0.0"
@@ -27372,13 +27347,6 @@ __metadata:
   version: 1.1.2
   resolution: "sprintf-js@npm:1.1.2"
   checksum: 10/0044322a252b36bffc3d8a462a4882de57830e18d37d1cc000104ff4744b512d6a9b1ca6240e7ad141a987a1eaad071668fe12d11c496c11d3641c4797a6cf3f
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: 10/e7587128c423f7e43cc625fe2f87e6affdf5ca51c1cc468e910d8aaca46bb44a7fbcfa552f787b1d3987f7043aeb4527d1b99559e6621e01b42b3f45e5a24cbb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #2640
relates-to: mikro-orm/mikro-orm#3992



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated ORM package versions to enhance database interaction stability and performance.
- **Tests**
	- Modified integration tests to support replica set configurations, ensuring more robust testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->