### PR TITLE
fix(json-mapper): add implementation on PrimitiveMapper.serialize method

### DIFF
--- a/packages/specs/json-mapper/src/components/PrimitiveMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/PrimitiveMapper.spec.ts
@@ -125,7 +125,7 @@ describe("PrimitiveMapper", () => {
     });
     it("should return value (null => boolean)", () => {
       const mapper = new PrimitiveMapper();
-      const ctx = {
+      const ctx: any = {
         type: Boolean,
         collectionType: undefined,
         next: Sinon.stub()
@@ -136,12 +136,44 @@ describe("PrimitiveMapper", () => {
     });
   });
   describe("serialize()", () => {
-    it("should return value", () => {
+    it("should return value (string to string)", () => {
       const mapper = new PrimitiveMapper();
 
-      const value = mapper.serialize("1");
+      const value = mapper.serialize("1", {type: String} as any);
 
       expect(value).toEqual("1");
+    });
+
+    it("should return value (string to number)", () => {
+      const mapper = new PrimitiveMapper();
+
+      const value = mapper.serialize("1", {type: Number} as any);
+
+      expect(value).toEqual(1);
+    });
+
+    it("should return value (object)", () => {
+      const mapper = new PrimitiveMapper();
+
+      // in this case it's probably intended to be an object (or an error but we can decide for the developer and we can broke the code)
+      // TODO: for the major version, we can return undefined or throw an error?
+      const value = mapper.serialize({"1": "1"} as any, {type: Number} as any);
+
+      expect(value).toEqual({"1": "1"});
+    });
+
+    it("should return value (null)", () => {
+      const mapper = new PrimitiveMapper();
+      const value = mapper.serialize(null as any, {type: Number} as any);
+
+      expect(value).toEqual(null);
+    });
+
+    it("should return value (undefined)", () => {
+      const mapper = new PrimitiveMapper();
+      const value = mapper.serialize(undefined as any, {type: Number} as any);
+
+      expect(value).toEqual(undefined);
     });
   });
 });

--- a/packages/specs/json-mapper/src/components/PrimitiveMapper.ts
+++ b/packages/specs/json-mapper/src/components/PrimitiveMapper.ts
@@ -25,8 +25,8 @@ export class PrimitiveMapper implements JsonMapperMethods {
     return (this as any)[nameOf(ctx.type)] ? (this as any)[nameOf(ctx.type)](data, ctx) : undefined;
   }
 
-  serialize(object: string | number | boolean | BigInt): string | number | boolean | BigInt {
-    return object;
+  serialize(object: string | number | boolean | BigInt, ctx: JsonMapperCtx): string | number | boolean | BigInt {
+    return (this as any)[nameOf(ctx?.type)] && typeof object !== "object" ? (this as any)[nameOf(ctx.type)](object, ctx) : object;
   }
 
   protected String(data: any) {
@@ -44,6 +44,7 @@ export class PrimitiveMapper implements JsonMapperMethods {
 
   protected Number(data: any) {
     if (isNullish(data)) return null;
+    if (data === undefined) return data;
 
     const n = +data;
 

--- a/packages/specs/json-mapper/src/domain/JsonSerializer.ts
+++ b/packages/specs/json-mapper/src/domain/JsonSerializer.ts
@@ -121,7 +121,12 @@ export class JsonSerializer extends JsonMapperCompiler<JsonSerializerOptions> {
 
     types.forEach((mapper, model) => {
       if (![Array, Set, Map].includes(model as any)) {
-        this.addTypeMapper(model as any, mapper.serialize.bind(mapper));
+        this.addTypeMapper(model as any, (value: any, options: any) =>
+          mapper.serialize(value, {
+            ...options,
+            type: model
+          })
+        );
       }
     });
 

--- a/packages/specs/json-mapper/src/utils/serialize.spec.ts
+++ b/packages/specs/json-mapper/src/utils/serialize.spec.ts
@@ -1,4 +1,5 @@
 import "../components/PrimitiveMapper";
+import {Property} from "@tsed/schema";
 import {serialize} from "./serialize";
 
 describe("serialize()", () => {
@@ -14,5 +15,21 @@ describe("serialize()", () => {
     expect(serialize(0)).toEqual(0);
     expect(serialize(1)).toEqual(1);
     expect(serialize(BigInt(1n))).toEqual(BigInt(1));
+
+    class Entity {
+      @Property()
+      num: number;
+    }
+
+    expect(
+      serialize(
+        {
+          num: "1"
+        },
+        {type: Entity}
+      )
+    ).toEqual({
+      num: 1
+    });
   });
 });

--- a/packages/specs/swagger/test/swagger.integration.spec.ts
+++ b/packages/specs/swagger/test/swagger.integration.spec.ts
@@ -81,11 +81,11 @@ describe("Swagger integration", () => {
 
       expect(result.body).toEqual([
         {
-          id: 1,
+          id: "1",
           name: "name"
         },
         {
-          id: 2,
+          id: "2",
           name: "name"
         }
       ]);
@@ -113,11 +113,11 @@ describe("Swagger integration", () => {
 
       expect(result.body).toEqual([
         {
-          id: 1,
+          id: "1",
           name: "name"
         },
         {
-          id: 2,
+          id: "2",
           name: "name"
         }
       ]);


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

This PR adds the explicit mapping of primitive types according to the model defined by the developer. This avoids having a value of another type than that expected by the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the serialization functionality to support more data types including objects, null, and undefined values.
	- Modified the `PrimitiveMapper` class to handle a `JsonMapperCtx` parameter and conditionally call a method based on the context type.
	- Updated how type mappers are added in the `JsonSerializer` class.
	- Added a new class `Entity` with a `num` property decorated with `@Property()` for testing serialization.
- **Tests**
	- Added new test cases to verify serialization of various data types like string to number, objects, null, and undefined values.
- **Bug Fixes**
	- Improved handling of undefined data in the serialization process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->