### PR TITLE
fix(schema): fix default schema/json-mapper groups behavior

### DIFF
--- a/docs/docs/json-mapper.md
+++ b/docs/docs/json-mapper.md
@@ -23,6 +23,7 @@ to a plain javascript object to your consumer.
   jsonMapper: {
     additionalProperties: false,
     disableUnsecureConstructor: false,
+    strictGroups: false
   }
 })
 ```
@@ -44,6 +45,14 @@ class MyModel {
   }
 }
 ```
+
+### jsonMapper.strictGroups
+
+Enable strict mode for `@Groups` decorator. By default, `false`. See [Groups](/docs/models#groups-strict-mode) for more information.
+
+::: warning
+The `strictGroups` option is enabled by default in the next major version of Ts.ED.
+:::
 
 ## Usage
 

--- a/packages/platform/common/jest.config.js
+++ b/packages/platform/common/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 99.03,
-      branches: 92.32,
+      branches: 92.14,
       functions: 97.08,
       lines: 99.03
     }

--- a/packages/platform/common/src/config/interfaces/PlatformJsonMapperSettings.ts
+++ b/packages/platform/common/src/config/interfaces/PlatformJsonMapperSettings.ts
@@ -1,13 +1,6 @@
-export interface PlatformJsonMapperSettings {
-  /**
-   * JsonMapper additional property policy. (see [JsonMapper](/docs/json-mapper.md))
-   */
-  additionalProperties?: boolean;
-  /**
-   * Disable the unsecure constructor injection when the deserialize function is used (by default: false)
-   */
-  disableUnsecureConstructor?: boolean;
-}
+import {JsonMapperGlobalOptions} from "@tsed/json-mapper";
+
+export interface PlatformJsonMapperSettings extends JsonMapperGlobalOptions {}
 
 declare global {
   namespace TsED {

--- a/packages/platform/common/src/config/services/PlatformConfiguration.spec.ts
+++ b/packages/platform/common/src/config/services/PlatformConfiguration.spec.ts
@@ -152,12 +152,9 @@ describe("PlatformConfiguration", () => {
     it("should return jsonMapper settings", () => {
       expect(settings.jsonMapper).toEqual({
         disableUnsecureConstructor: true,
-        additionalProperties: false
+        additionalProperties: false,
+        strictGroups: false
       });
-    });
-
-    it("should return jsonMapper settings", () => {
-      expect(settings.jsonMapper).toEqual({additionalProperties: false, disableUnsecureConstructor: true});
     });
 
     it("should return controllerScope", () => {

--- a/packages/platform/common/src/config/services/PlatformConfiguration.ts
+++ b/packages/platform/common/src/config/services/PlatformConfiguration.ts
@@ -81,6 +81,7 @@ export class PlatformConfiguration extends DIConfiguration {
   }
 
   set jsonMapper(options: Partial<PlatformJsonMapperSettings>) {
+    JsonMapperSettings.strictGroups = Boolean(options.strictGroups);
     JsonMapperSettings.disableUnsecureConstructor = Boolean(options.disableUnsecureConstructor);
     JsonMapperSettings.additionalProperties = Boolean(
       isBoolean(options.additionalProperties) ? options.additionalProperties : options.additionalProperties === "accept"

--- a/packages/platform/common/test/integration/groups.spec.ts
+++ b/packages/platform/common/test/integration/groups.spec.ts
@@ -1,0 +1,730 @@
+import "@tsed/ajv";
+import {BodyParams, Configuration, Controller, Get, PlatformTest} from "@tsed/common";
+import {JsonMapperSettings} from "@tsed/json-mapper";
+import {PlatformExpress} from "@tsed/platform-express";
+import {PlatformTestSdk} from "@tsed/platform-test-sdk";
+import {getSpec, Groups, Post, Property, Required, Returns, SpecTypes} from "@tsed/schema";
+import bodyParser from "body-parser";
+import compress from "compression";
+import cookieParser from "cookie-parser";
+import filedirname from "filedirname";
+import methodOverride from "method-override";
+import SuperTest from "supertest";
+
+// FIXME remove when esm is ready
+const [, rootDir] = filedirname();
+
+class MyModel {
+  @Groups("!creation")
+  id: string;
+
+  @Groups("group.summary")
+  @Required()
+  prop1: string;
+
+  @Groups("group.extended")
+  @Required()
+  prop2: string;
+
+  @Property()
+  @Required()
+  prop3: string;
+
+  constructor(opts: Partial<MyModel>) {
+    Object.assign(this, opts);
+  }
+}
+
+@Controller("/groups")
+class GroupsIntegrationController {
+  @Get("/scenario-1")
+  @Returns(200, MyModel)
+  scenario1() {
+    return new MyModel({
+      id: "id",
+      prop1: "prop1",
+      prop2: "prop2",
+      prop3: "prop3"
+    });
+  }
+
+  @Get("/scenario-2")
+  @Returns(200, MyModel).Groups("summary")
+  scenario2() {
+    return new MyModel({
+      id: "id",
+      prop1: "prop1",
+      prop2: "prop2",
+      prop3: "prop3"
+    });
+  }
+
+  @Get("/scenario-3")
+  @Returns(200, MyModel).Groups("creation")
+  scenario3() {
+    return new MyModel({
+      id: "id",
+      prop1: "prop1",
+      prop2: "prop2",
+      prop3: "prop3"
+    });
+  }
+
+  @Post("/scenario-4")
+  scenario4(@BodyParams() model: MyModel) {
+    return {...model};
+  }
+
+  @Post("/scenario-5")
+  scenario5(@BodyParams() @Groups("group.summary") model: MyModel) {
+    return {...model};
+  }
+
+  @Post("/scenario-6")
+  @Returns(201, MyModel)
+  scenario6(@BodyParams() model: MyModel) {
+    return model;
+  }
+}
+
+@Configuration({
+  port: 8081,
+  middlewares: [cookieParser(), compress({}), methodOverride(), bodyParser.json()],
+  mount: {
+    "/rest": [GroupsIntegrationController]
+  }
+})
+export class Server {}
+
+const utils = PlatformTestSdk.create({
+  rootDir,
+  platform: PlatformExpress,
+  server: Server,
+  logger: {
+    level: "off"
+  }
+});
+
+describe("Groups", () => {
+  let request: SuperTest.Agent;
+  describe("jsonMapper.strictGroups = false", () => {
+    beforeEach(
+      utils.bootstrap({
+        jsonMapper: {
+          disableUnsecureConstructor: true
+        }
+      })
+    );
+    beforeEach(() => {
+      request = SuperTest(PlatformTest.callback());
+    });
+
+    afterEach(utils.reset);
+
+    describe("OS3", () => {
+      it("should return open spec", () => {
+        const response = getSpec(GroupsIntegrationController, {specType: SpecTypes.OPENAPI});
+
+        expect(response).toEqual({
+          components: {
+            schemas: {
+              MyModel: {
+                properties: {
+                  id: {
+                    type: "string"
+                  },
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop3"],
+                type: "object"
+              },
+              MyModelCreation: {
+                properties: {
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop3"],
+                type: "object"
+              },
+              MyModelGroupSummary: {
+                properties: {
+                  id: {
+                    type: "string"
+                  },
+                  prop1: {
+                    minLength: 1,
+                    type: "string"
+                  },
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop1", "prop3"],
+                type: "object"
+              },
+              MyModelSummary: {
+                properties: {
+                  id: {
+                    type: "string"
+                  },
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop3"],
+                type: "object"
+              }
+            }
+          },
+          paths: {
+            "/groups/scenario-1": {
+              get: {
+                operationId: "groupsIntegrationControllerScenario1",
+                parameters: [],
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModel"
+                        }
+                      }
+                    },
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-2": {
+              get: {
+                operationId: "groupsIntegrationControllerScenario2",
+                parameters: [],
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModelSummary"
+                        }
+                      }
+                    },
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-3": {
+              get: {
+                operationId: "groupsIntegrationControllerScenario3",
+                parameters: [],
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModelCreation"
+                        }
+                      }
+                    },
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-4": {
+              post: {
+                operationId: "groupsIntegrationControllerScenario4",
+                parameters: [],
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/MyModel"
+                      }
+                    }
+                  },
+                  required: false
+                },
+                responses: {
+                  "200": {
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-5": {
+              post: {
+                operationId: "groupsIntegrationControllerScenario5",
+                parameters: [],
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/MyModelGroupSummary"
+                      }
+                    }
+                  },
+                  required: false
+                },
+                responses: {
+                  "200": {
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-6": {
+              post: {
+                operationId: "groupsIntegrationControllerScenario6",
+                parameters: [],
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/MyModel"
+                      }
+                    }
+                  },
+                  required: false
+                },
+                responses: {
+                  "201": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModel"
+                        }
+                      }
+                    },
+                    description: "Created"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            }
+          },
+          tags: [
+            {
+              name: "GroupsIntegrationController"
+            }
+          ]
+        });
+      });
+    });
+
+    describe("scenario: 1", () => {
+      it("should returns only props that not decorated by Groups or Groups with negative rule)", async () => {
+        const response = await request.get(`/rest/groups/scenario-1`).expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop1: "prop1",
+          prop2: "prop2",
+          prop3: "prop3"
+        });
+      });
+    });
+    describe("scenario: 2", () => {
+      it("should returns only props that match the groups rules", async () => {
+        const response = await request.get(`/rest/groups/scenario-2`).expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop3: "prop3"
+        });
+      });
+    });
+    describe("scenario: 3", () => {
+      it("should returns only props that match the groups (negative condition)", async () => {
+        const response = await request.get(`/rest/groups/scenario-3`).expect(200);
+
+        expect(response.body).toEqual({
+          prop3: "prop3"
+        });
+      });
+    });
+
+    describe("scenario: 4", () => {
+      it("should post data with all field", async () => {
+        const response = await request
+          .post(`/rest/groups/scenario-4`)
+          .send({
+            id: "id",
+            prop1: "prop1",
+            prop2: "prop2",
+            prop3: "prop3"
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop1: "prop1",
+          prop2: "prop2",
+          prop3: "prop3"
+        });
+      });
+    });
+
+    describe("scenario: 5", () => {
+      it("should post data with defined groups rules", async () => {
+        const response = await request
+          .post(`/rest/groups/scenario-5`)
+          .send({
+            id: "id",
+            prop1: "prop1",
+            prop2: "prop2",
+            prop3: "prop3"
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop1: "prop1",
+          prop3: "prop3"
+        });
+      });
+    });
+
+    describe("scenario: 6", () => {
+      it("should post data with default groups rules", async () => {
+        const response = await request
+          .post(`/rest/groups/scenario-6`)
+          .send({
+            id: "id",
+            prop1: "prop1",
+            prop2: "prop2",
+            prop3: "prop3"
+          })
+          .expect(201);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop1: "prop1",
+          prop2: "prop2",
+          prop3: "prop3"
+        });
+      });
+    });
+  });
+  describe("jsonMapper.strictGroups = true", () => {
+    beforeEach(
+      utils.bootstrap({
+        jsonMapper: {
+          disableUnsecureConstructor: true,
+          strictGroups: true
+        }
+      })
+    );
+    beforeEach(() => {
+      request = SuperTest(PlatformTest.callback());
+    });
+
+    afterEach(utils.reset);
+    afterEach(() => {
+      JsonMapperSettings.strictGroups = false;
+    });
+
+    describe("OS3", () => {
+      it("should return open spec", () => {
+        const response = getSpec(GroupsIntegrationController, {specType: SpecTypes.OPENAPI});
+
+        expect(response).toEqual({
+          components: {
+            schemas: {
+              MyModel: {
+                properties: {
+                  id: {
+                    type: "string"
+                  },
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop3"],
+                type: "object"
+              },
+              MyModelCreation: {
+                properties: {
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop3"],
+                type: "object"
+              },
+              MyModelGroupSummary: {
+                properties: {
+                  id: {
+                    type: "string"
+                  },
+                  prop1: {
+                    minLength: 1,
+                    type: "string"
+                  },
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop1", "prop3"],
+                type: "object"
+              },
+              MyModelSummary: {
+                properties: {
+                  id: {
+                    type: "string"
+                  },
+                  prop3: {
+                    minLength: 1,
+                    type: "string"
+                  }
+                },
+                required: ["prop3"],
+                type: "object"
+              }
+            }
+          },
+          paths: {
+            "/groups/scenario-1": {
+              get: {
+                operationId: "groupsIntegrationControllerScenario1",
+                parameters: [],
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModel"
+                        }
+                      }
+                    },
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-2": {
+              get: {
+                operationId: "groupsIntegrationControllerScenario2",
+                parameters: [],
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModelSummary"
+                        }
+                      }
+                    },
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-3": {
+              get: {
+                operationId: "groupsIntegrationControllerScenario3",
+                parameters: [],
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModelCreation"
+                        }
+                      }
+                    },
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-4": {
+              post: {
+                operationId: "groupsIntegrationControllerScenario4",
+                parameters: [],
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/MyModel"
+                      }
+                    }
+                  },
+                  required: false
+                },
+                responses: {
+                  "200": {
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-5": {
+              post: {
+                operationId: "groupsIntegrationControllerScenario5",
+                parameters: [],
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/MyModelGroupSummary"
+                      }
+                    }
+                  },
+                  required: false
+                },
+                responses: {
+                  "200": {
+                    description: "Success"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            },
+            "/groups/scenario-6": {
+              post: {
+                operationId: "groupsIntegrationControllerScenario6",
+                parameters: [],
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/MyModel"
+                      }
+                    }
+                  },
+                  required: false
+                },
+                responses: {
+                  "201": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/MyModel"
+                        }
+                      }
+                    },
+                    description: "Created"
+                  }
+                },
+                tags: ["GroupsIntegrationController"]
+              }
+            }
+          },
+          tags: [
+            {
+              name: "GroupsIntegrationController"
+            }
+          ]
+        });
+      });
+    });
+
+    describe("scenario: 1", () => {
+      it("should returns only props that not decorated by Groups or Groups with negative rule)", async () => {
+        const response = await request.get(`/rest/groups/scenario-1`).expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop3: "prop3"
+        });
+      });
+    });
+    describe("scenario: 2", () => {
+      it("should returns only props that match the groups rules", async () => {
+        const response = await request.get(`/rest/groups/scenario-2`).expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop3: "prop3"
+        });
+      });
+    });
+    describe("scenario: 3", () => {
+      it("should returns only props that match the groups (negative condition)", async () => {
+        const response = await request.get(`/rest/groups/scenario-3`).expect(200);
+
+        expect(response.body).toEqual({
+          prop3: "prop3"
+        });
+      });
+    });
+
+    describe("scenario: 4", () => {
+      it("should post data with all field", async () => {
+        const response = await request
+          .post(`/rest/groups/scenario-4`)
+          .send({
+            id: "id",
+            prop1: "prop1",
+            prop2: "prop2",
+            prop3: "prop3"
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop3: "prop3"
+        });
+      });
+    });
+
+    describe("scenario: 5", () => {
+      it("should post data with defined groups rules", async () => {
+        const response = await request
+          .post(`/rest/groups/scenario-5`)
+          .send({
+            id: "id",
+            prop1: "prop1",
+            prop2: "prop2",
+            prop3: "prop3"
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop1: "prop1",
+          prop3: "prop3"
+        });
+      });
+    });
+
+    describe("scenario: 6", () => {
+      it("should post data with default groups rules", async () => {
+        const response = await request
+          .post(`/rest/groups/scenario-6`)
+          .send({
+            id: "id",
+            prop1: "prop1",
+            prop2: "prop2",
+            prop3: "prop3"
+          })
+          .expect(201);
+
+        expect(response.body).toEqual({
+          id: "id",
+          prop3: "prop3"
+        });
+      });
+    });
+  });
+});

--- a/packages/specs/json-mapper/src/domain/JsonDeserializer.ts
+++ b/packages/specs/json-mapper/src/domain/JsonDeserializer.ts
@@ -1,4 +1,4 @@
-import {classOf, getValue, isArray, isBoolean, isClass, isEmpty, isNil, nameOf, objectKeys, Type} from "@tsed/core";
+import {classOf, isArray, isBoolean, isClass, isEmpty, isNil, nameOf, objectKeys, Type} from "@tsed/core";
 import {getPropertiesStores, JsonClassStore, JsonEntityStore, JsonParameterStore, JsonPropertyStore} from "@tsed/schema";
 import {alterAfterDeserialize} from "../hooks/alterAfterDeserialize";
 import {alterBeforeDeserialize} from "../hooks/alterBeforeDeserialize";
@@ -274,7 +274,7 @@ export class JsonDeserializer extends JsonMapperCompiler<JsonDeserializerOptions
     return (writer: Writer) => writer.callMapper(nestedMapper.id, varKey(key), formatOpts);
   }
 
-  private mapOptions({groups = false, useAlias = true, types, ...options}: JsonDeserializerOptions<any, any>): JsonDeserializerOptions {
+  private mapOptions({groups, useAlias = true, types, ...options}: JsonDeserializerOptions<any, any>): JsonDeserializerOptions {
     if (options.store instanceof JsonParameterStore) {
       return this.mapOptions(mapParamStoreOptions(options.store, options));
     }
@@ -299,11 +299,13 @@ export class JsonDeserializer extends JsonMapperCompiler<JsonDeserializerOptions
       }
     });
 
+    const strictGroups = options.strictGroups ?? JsonMapperSettings.strictGroups;
+
     return {
       ...options,
-      additionalProperties: getValue(options, "additionalProperties", JsonMapperSettings.additionalProperties),
-      disableUnsecureConstructor: getValue(options, "disableUnsecureConstructor", JsonMapperSettings.disableUnsecureConstructor),
-      groups,
+      additionalProperties: options.additionalProperties ?? JsonMapperSettings.additionalProperties,
+      disableUnsecureConstructor: options.disableUnsecureConstructor ?? JsonMapperSettings.disableUnsecureConstructor,
+      groups: groups === undefined ? (strictGroups ? [] : false) : groups || false,
       useAlias,
       customMappers,
       generics: options.generics || []

--- a/packages/specs/json-mapper/src/domain/JsonDeserializerOptions.ts
+++ b/packages/specs/json-mapper/src/domain/JsonDeserializerOptions.ts
@@ -1,8 +1,9 @@
 import {MetadataTypes, Type} from "@tsed/core";
 import {JsonEntityStore} from "@tsed/schema";
 import {JsonMapperMethods} from "../interfaces/JsonMapperMethods";
+import {JsonMapperGlobalOptions} from "./JsonMapperGlobalOptions";
 
-export interface JsonDeserializerOptions<T = any, C = any> extends MetadataTypes<T, C> {
+export interface JsonDeserializerOptions<T = any, C = any> extends MetadataTypes<T, C>, JsonMapperGlobalOptions {
   /**
    * Types used to map complex types (Symbol, Array, Set, Map)
    */
@@ -11,14 +12,6 @@ export interface JsonDeserializerOptions<T = any, C = any> extends MetadataTypes
    * useAlias mapping
    */
   useAlias?: boolean;
-  /**
-   * Accept additionalProperties or ignore it
-   */
-  additionalProperties?: boolean;
-  /**
-   *
-   */
-  disableUnsecureConstructor?: boolean;
   /**
    * Use the store which have all metadata to deserialize correctly the model. This
    * property is useful when you deal with metadata parameters.

--- a/packages/specs/json-mapper/src/domain/JsonMapperGlobalOptions.ts
+++ b/packages/specs/json-mapper/src/domain/JsonMapperGlobalOptions.ts
@@ -1,0 +1,14 @@
+export interface JsonMapperGlobalOptions {
+  /**
+   * JsonMapper additional property policy. (see [JsonMapper](/docs/json-mapper.md))
+   */
+  additionalProperties?: boolean;
+  /**
+   * Disable the unsecure constructor injection when the deserialize function is used (by default: false)
+   */
+  disableUnsecureConstructor?: boolean;
+  /**
+   * Enable strict Groups configuration when the `options.groups` is undefined. (by default: false)
+   */
+  strictGroups?: boolean;
+}

--- a/packages/specs/json-mapper/src/domain/JsonMapperSettings.ts
+++ b/packages/specs/json-mapper/src/domain/JsonMapperSettings.ts
@@ -1,4 +1,7 @@
-export const JsonMapperSettings = {
+import type {JsonMapperGlobalOptions} from "./JsonMapperGlobalOptions";
+
+export const JsonMapperSettings: JsonMapperGlobalOptions = {
   disableUnsecureConstructor: true,
-  additionalProperties: false
+  additionalProperties: false,
+  strictGroups: false
 };

--- a/packages/specs/json-mapper/src/domain/JsonSerializer.spec.ts
+++ b/packages/specs/json-mapper/src/domain/JsonSerializer.spec.ts
@@ -27,6 +27,7 @@ import "../components/SymbolMapper";
 import {OnDeserialize} from "../decorators/onDeserialize";
 import {OnSerialize} from "../decorators/onSerialize";
 import {deserialize} from "../utils/deserialize";
+import {JsonMapperSettings} from "./JsonMapperSettings";
 import {getJsonMapperTypes} from "./JsonMapperTypesContainer";
 import {JsonSerializer} from "./JsonSerializer";
 
@@ -1329,6 +1330,66 @@ describe("JsonSerializer", () => {
         phone: "",
         website: "website",
         cancellation_hours_limit: null
+      });
+    });
+
+    describe("when jsonMapper.strictGroups = false", () => {
+      it("should serialize props", () => {
+        class Model {
+          @Property()
+          id: string;
+
+          @Groups("summary")
+          ignored: boolean;
+
+          @Name("renamed")
+          name: string;
+        }
+
+        const test = new Model();
+        test.id = "id";
+        test.ignored = true;
+        test.name = "myname";
+
+        const result = serialize(test, {type: Model});
+
+        expect(result).toEqual({
+          id: "id",
+          ignored: true,
+          renamed: "myname"
+        });
+      });
+    });
+    describe("when jsonMapper.strictGroups = true", () => {
+      beforeEach(() => {
+        JsonMapperSettings.strictGroups = true;
+      });
+      afterEach(() => {
+        JsonMapperSettings.strictGroups = false;
+      });
+      it("should serialize props", () => {
+        class Model {
+          @Property()
+          id: string;
+
+          @Groups("summary")
+          ignored: boolean;
+
+          @Name("renamed")
+          name: string;
+        }
+
+        const test = new Model();
+        test.id = "id";
+        test.ignored = true;
+        test.name = "myname";
+
+        const result = serialize(test, {type: Model});
+
+        expect(result).toEqual({
+          id: "id",
+          renamed: "myname"
+        });
       });
     });
   });

--- a/packages/specs/json-mapper/src/domain/JsonSerializer.ts
+++ b/packages/specs/json-mapper/src/domain/JsonSerializer.ts
@@ -18,6 +18,7 @@ import {getPropertiesStores, JsonClassStore, JsonEntityStore, JsonPropertyStore}
 import {alterOnSerialize} from "../hooks/alterOnSerialize";
 import {getObjectProperties} from "../utils/getObjectProperties";
 import {JsonMapperCompiler} from "./JsonMapperCompiler";
+import {JsonMapperSettings} from "./JsonMapperSettings";
 import {getJsonMapperTypes} from "./JsonMapperTypesContainer";
 import {JsonSerializerOptions} from "./JsonSerializerOptions";
 import {Writer} from "./Writer";
@@ -115,7 +116,7 @@ export class JsonSerializer extends JsonMapperCompiler<JsonSerializerOptions> {
     return writer.return("obj").root().toString();
   }
 
-  private mapOptions({groups = false, useAlias = true, types, ...options}: JsonSerializerOptions<any, any>): JsonSerializerOptions {
+  private mapOptions({groups, useAlias = true, types, ...options}: JsonSerializerOptions<any, any>): JsonSerializerOptions {
     const customMappers: Record<string, any> = {};
     types = types || getJsonMapperTypes();
 
@@ -130,9 +131,11 @@ export class JsonSerializer extends JsonMapperCompiler<JsonSerializerOptions> {
       }
     });
 
+    const strictGroups = options.strictGroups ?? JsonMapperSettings.strictGroups;
+
     return {
       ...options,
-      groups,
+      groups: groups === undefined ? (strictGroups ? [] : false) : groups || false,
       useAlias,
       customMappers
     };

--- a/packages/specs/json-mapper/src/domain/JsonSerializerOptions.ts
+++ b/packages/specs/json-mapper/src/domain/JsonSerializerOptions.ts
@@ -1,7 +1,8 @@
 import {MetadataTypes, Type} from "@tsed/core";
 import {JsonMapperMethods} from "../interfaces/JsonMapperMethods";
+import {JsonMapperGlobalOptions} from "./JsonMapperGlobalOptions";
 
-export interface JsonSerializerOptions<T = any, C = any> extends MetadataTypes<T, C> {
+export interface JsonSerializerOptions<T = any, C = any> extends MetadataTypes<T, C>, Pick<JsonMapperGlobalOptions, "strictGroups"> {
   /**
    * Types used to map complex types (Symbol, Number, String, etc...)
    */

--- a/packages/specs/json-mapper/src/index.ts
+++ b/packages/specs/json-mapper/src/index.ts
@@ -13,6 +13,7 @@ export * from "./decorators/onSerialize";
 export * from "./domain/JsonDeserializer";
 export * from "./domain/JsonDeserializerOptions";
 export * from "./domain/JsonMapperCompiler";
+export * from "./domain/JsonMapperGlobalOptions";
 export * from "./domain/JsonMapperSettings";
 export * from "./domain/JsonMapperTypesContainer";
 export * from "./domain/JsonSerializer";

--- a/packages/specs/schema/src/decorators/common/ignore.ts
+++ b/packages/specs/schema/src/decorators/common/ignore.ts
@@ -56,7 +56,7 @@ import {JsonEntityFn} from "./jsonEntityFn";
  * @validation
  * @swagger
  * @schema
- * @deprecated Since v7. Use @Groups decorator instead of.
+ * @deprecated Since v7. Use @Groups decorator instead of and enable `jsonMapper.strictGroups` in your configuration.
  */
 export function Ignore(cb: boolean | IgnoreCallback = true) {
   return JsonEntityFn((store) => {

--- a/packages/specs/schema/src/utils/getSpecType.spec.ts
+++ b/packages/specs/schema/src/utils/getSpecType.spec.ts
@@ -1,17 +1,16 @@
-import {expect} from "chai";
 import {SpecTypes} from "../domain/SpecTypes";
 import {getSpecType, getSpecTypeFromSpec} from "./getSpecType";
 
 describe("getSpecType", () => {
   it("should return spect type from version", () => {
-    expect(getSpecType("2.0")).to.equal(SpecTypes.SWAGGER);
-    expect(getSpecType("3.0.1")).to.equal(SpecTypes.OPENAPI);
+    expect(getSpecType("2.0")).toEqual(SpecTypes.SWAGGER);
+    expect(getSpecType("3.0.1")).toEqual(SpecTypes.OPENAPI);
   });
 });
 
 describe("getSpecTypeFromSpec", () => {
   it("should return spect type from version", () => {
-    expect(getSpecTypeFromSpec({swagger: "2.0"})).to.equal(SpecTypes.SWAGGER);
-    expect(getSpecTypeFromSpec({openapi: "3.0.1"})).to.equal(SpecTypes.OPENAPI);
+    expect(getSpecTypeFromSpec({swagger: "2.0"})).toEqual(SpecTypes.SWAGGER);
+    expect(getSpecTypeFromSpec({openapi: "3.0.1"})).toEqual(SpecTypes.OPENAPI);
   });
 });


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | Yes         |

---

This PR fix the default json-mapper serialization over all endpoints (returned value).
Now by default, Groups rules are applied by default on all endpoints without declaring `@Returns().Groups("somethings")`.

/!\ This change introduce breaking change. We have to add optin to enable this mode and prepare a migration note for the next major version.


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
