### PR TITLE
fix(swagger): use getAbsolutePath from swagger-ui-dist/get-absolute-path.js

### DIFF
--- a/packages/specs/swagger/.npmignore
+++ b/packages/specs/swagger/.npmignore
@@ -1,5 +1,8 @@
 src
 test
-tsconfig.compile.json
+tsconfig.esm.json
 tsconfig.json
 *.tsbuildinfo
+scripts
+jest.config.js
+*.spec.js

--- a/packages/specs/swagger/scripts/constants.js
+++ b/packages/specs/swagger/scripts/constants.js
@@ -1,7 +1,8 @@
 import {dirname} from "node:path";
 import {fileURLToPath} from "node:url";
+import * as SwaggerUIDist from "swagger-ui-dist/absolute-path.js";
 
 // @ts-ignore
-export const SWAGGER_UI_DIST = dirname(fileURLToPath(import.meta.resolve("swagger-ui-dist")));
+export const SWAGGER_UI_DIST = await (SwaggerUIDist.default || SwaggerUIDist)();
 // @ts-expect-error
 export const ROOT_DIR = dirname(fileURLToPath(import.meta.url));

--- a/packages/specs/swagger/src/constants.ts
+++ b/packages/specs/swagger/src/constants.ts
@@ -1,4 +1,4 @@
-import {dirname} from "path";
+import getAbsoluteFSPath from "swagger-ui-dist/absolute-path";
 
-export const SWAGGER_UI_DIST = dirname(require.resolve("swagger-ui-dist"));
+export const SWAGGER_UI_DIST = getAbsoluteFSPath();
 export const ROOT_DIR = __dirname;


### PR DESCRIPTION
Closes: #2695

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |


## Todos

- [x] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
