### PR TITLE
fix(platform-cache): add $ctx to key resolver

### DIFF
--- a/packages/platform/platform-cache/src/interceptors/PlatformCacheInterceptor.ts
+++ b/packages/platform/platform-cache/src/interceptors/PlatformCacheInterceptor.ts
@@ -76,7 +76,7 @@ export class PlatformCacheInterceptor implements InterceptorMethods {
   }
 
   async cacheMethod(context: InterceptorContext<any, PlatformCacheOptions>, next: InterceptorNext) {
-    const {key, type, ttl, collectionType, refreshThreshold, keyArgs, args, canCache} = this.getOptions(context);
+    const {key, type, ttl, collectionType, refreshThreshold, args, canCache} = this.getOptions(context);
 
     const set = (result: any) => {
       if (!canCache || (canCache && canCache(result))) {
@@ -176,7 +176,7 @@ export class PlatformCacheInterceptor implements InterceptorMethods {
     let {canCache} = context.options || {};
 
     const args = this.getArgs(context);
-    const keyArgs = isString(k) ? k : k(args);
+    const keyArgs = isString(k) ? k : k(args, $ctx);
 
     if (canCache && canCache === "no-nullish") {
       canCache = (item: any) => ![null, undefined].includes(item);


### PR DESCRIPTION
Fix issue when you trying to resolve a cache key from $ctx:

```ts
import {Configuration} from "@tsed/di";
import {PlatformContext} from "@tsed/common";

@Configuration({
  cache: {
    keyResolver(args: any[], $ctx?: PlatformContext): string {
      // NOTE $ctx is only available for endpoints
      return "key"
    }
  }
})

```