### PR TITLE
feat: add `appendChildrenRoutesFirst` configuration option

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -172,6 +172,15 @@ It is also possible to split the configuration by using the @@Module@@:
 
 Append children routes before the controller routes itself. Defaults to `false`, but will be deprecated and set to `true` in next major version.
 
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  appendChildrenRoutesFirst: true
+})
+export class Server {}
+```
+
 ### ~~componentsScan~~ (deprecated)
 
 - type: `string[]`

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -166,6 +166,12 @@ It is also possible to split the configuration by using the @@Module@@:
   </Tab>    
 </Tabs>
 
+### appendChildrenRoutesFirst
+
+- type: `boolean`
+
+Append children routes before the controller routes itself. Defaults to `false`, but will be deprecated and set to `true` in next major version.
+
 ### ~~componentsScan~~ (deprecated)
 
 - type: `string[]`

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -166,21 +166,6 @@ It is also possible to split the configuration by using the @@Module@@:
   </Tab>    
 </Tabs>
 
-### appendChildrenRoutesFirst
-
-- type: `boolean`
-
-Append children routes before the controller routes itself. Defaults to `false`, but will be deprecated and set to `true` in next major version.
-
-```typescript
-import {Configuration} from "@tsed/di";
-
-@Configuration({
-  appendChildrenRoutesFirst: true
-})
-export class Server {}
-```
-
 ### ~~componentsScan~~ (deprecated)
 
 - type: `string[]`
@@ -367,6 +352,22 @@ on [Response filters](/docs/response-filter.md).
 ### multer
 
 Object configure Multer. See more on [Upload file](/tutorials/serve-static-files.md).
+
+## router
+
+```typescript
+@Configuration({
+  router: {
+    appendChildrenRoutesFirst: true
+  }
+})
+```
+
+### router.appendChildrenRoutesFirst
+
+- type: `boolean`
+
+Append children routes before the controller routes itself. Defaults to `false`, but will be deprecated and set to `true` in next major version.
 
 ## jsonMapper
 

--- a/packages/di/src/common/interfaces/DIConfigurationOptions.ts
+++ b/packages/di/src/common/interfaces/DIConfigurationOptions.ts
@@ -22,6 +22,12 @@ declare global {
        * Mount controllers
        */
       mount: Record<string, TokenProvider[]>;
+      /**
+       * Append children routes before the controller routes itself
+       *
+       * Will default to true in next major version
+       */
+      appendChildrenRoutesFirst: boolean;
     }
   }
 }

--- a/packages/di/src/common/interfaces/DIConfigurationOptions.ts
+++ b/packages/di/src/common/interfaces/DIConfigurationOptions.ts
@@ -22,12 +22,6 @@ declare global {
        * Mount controllers
        */
       mount: Record<string, TokenProvider[]>;
-      /**
-       * Append children routes before the controller routes itself
-       *
-       * Will default to true in next major version
-       */
-      appendChildrenRoutesFirst: boolean;
     }
   }
 }

--- a/packages/platform/common/src/config/interfaces/PlatformRouterSettings.ts
+++ b/packages/platform/common/src/config/interfaces/PlatformRouterSettings.ts
@@ -1,13 +1,11 @@
-import {JsonMapperGlobalOptions} from "@tsed/json-mapper";
-
-export interface PlatformJsonMapperSettings extends JsonMapperGlobalOptions {}
+export interface PlatformRouterSettings {
+  appendChildrenRoutesFirst?: boolean;
+}
 
 declare global {
   namespace TsED {
     interface Configuration extends Record<string, any> {
-      router?: {
-        appendChildrenRoutesFirst?: boolean;
-      }
+      router?: PlatformRouterSettings;
     }
   }
 }

--- a/packages/platform/common/src/config/interfaces/PlatformRouterSettings.ts
+++ b/packages/platform/common/src/config/interfaces/PlatformRouterSettings.ts
@@ -1,0 +1,13 @@
+import {JsonMapperGlobalOptions} from "@tsed/json-mapper";
+
+export interface PlatformJsonMapperSettings extends JsonMapperGlobalOptions {}
+
+declare global {
+  namespace TsED {
+    interface Configuration extends Record<string, any> {
+      router?: {
+        appendChildrenRoutesFirst?: boolean;
+      }
+    }
+  }
+}

--- a/packages/platform/platform-router/src/domain/PlatformRouters.ts
+++ b/packages/platform/platform-router/src/domain/PlatformRouters.ts
@@ -79,7 +79,7 @@ export class PlatformRouters {
     const {children} = provider;
 
     // Set default to true in next major version
-    const appendChildrenRoutesFirst = this.injector.settings.get<boolean>('appendChildrenRoutesFirst', false)
+    const appendChildrenRoutesFirst = this.injector.settings.get<boolean>('router.appendChildrenRoutesFirst', false)
 
     if (appendChildrenRoutesFirst) {
       children.forEach((token: Type<any>) => {

--- a/packages/platform/platform-router/test/routers-nested.integration.spec.ts
+++ b/packages/platform/platform-router/test/routers-nested.integration.spec.ts
@@ -103,7 +103,7 @@ describe("routers integration", () => {
 
     it('should declare correctly with appendChildrenRoutesFirst', () => {
       const {injector, platformRouters, appRouter} = createAppRouterFixture();
-      injector.settings.set('appendChildrenRoutesFirst', true);
+      injector.settings.set('router.appendChildrenRoutesFirst', true);
 
       platformRouters.prebuild();
 

--- a/packages/platform/platform-router/test/routers-nested.integration.spec.ts
+++ b/packages/platform/platform-router/test/routers-nested.integration.spec.ts
@@ -58,6 +58,7 @@ function createAppRouterFixture() {
 describe("routers integration", () => {
   beforeEach(() => PlatformTest.create());
   afterEach(() => PlatformTest.reset());
+
   describe("getLayers()", () => {
     it("should declare router", () => {
       const {platformRouters, appRouter} = createAppRouterFixture();
@@ -97,6 +98,48 @@ describe("routers integration", () => {
         "/rest/platform/:platform",
         "/rest/platform/:platform/comments",
         "/rest/platform/:platform/comments"
+      ]);
+    });
+
+    it('should declare correctly with appendChildrenRoutesFirst', () => {
+      const {injector, platformRouters, appRouter} = createAppRouterFixture();
+      injector.settings.set('appendChildrenRoutesFirst', true);
+
+      platformRouters.prebuild();
+
+      appRouter.use("/rest", platformRouters.from(DomainController));
+      appRouter.use("/rest", platformRouters.from(PlatformController));
+
+      const layers = platformRouters.getLayers(appRouter);
+
+      expect(
+        layers.map((layer) => {
+          return layer.inspect().path;
+        })
+      ).toEqual([
+        "/rest/domain/:contextID/comments/flag",
+        "/rest/domain/:contextID/comments/:commentID/flag",
+        "/rest/domain/:contextID/comments",
+        "/rest/domain/:contextID",
+        "/rest/platform/:platform/comments/flag",
+        "/rest/platform/:platform/comments/:commentID/flag",
+        "/rest/platform/:platform/comments",
+        "/rest/platform/:platform"
+      ]);
+
+      expect(
+        layers.map((layer) => {
+          return layer.getBasePath();
+        })
+      ).toEqual([
+        "/rest/domain/:contextID/comments",
+        "/rest/domain/:contextID/comments",
+        "/rest/domain/:contextID",
+        "/rest",
+        "/rest/platform/:platform/comments",
+        "/rest/platform/:platform/comments",
+        "/rest/platform/:platform",
+        "/rest"
       ]);
     });
   });


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature |No          |

closes #2706

---

## Description

As described in the original issue the children routes should be appended before the controller routes itself. This PR adds a opt-in solution via a configuration setting. As discussed we should follow the following:

- In next major release (`8.0.0`): Set the default of this value to `true` & deprecate the option
- In the next major version after that (`9.0.0`): Remove the option

## Usage example

```typescript
import {Configuration} from "@tsed/di";

@Configuration({
  appendChildrenRoutesFirst: true
})
export class Server {}
```

## Todos

- [X] Tests
- [X] Coverage
- [X] Example
- [X] Documentation
