### PR TITLE
fix(swagger): add missing explicit extension swagger-ui-dist/absolute-path import

### DIFF
--- a/packages/specs/swagger/src/constants.ts
+++ b/packages/specs/swagger/src/constants.ts
@@ -1,4 +1,4 @@
-import getAbsoluteFSPath from "swagger-ui-dist/absolute-path";
+import getAbsoluteFSPath from "swagger-ui-dist/absolute-path.js";
 
 export const SWAGGER_UI_DIST = getAbsoluteFSPath();
 export const ROOT_DIR = __dirname;


### PR DESCRIPTION
## Information

The migration to full ESM for the Ts.ED repository is in progress. Latest release has switched the code builder to replace automatically __dirname to import.meta.dirname. But I missed to add explicit extension for external library. This PR fix that.

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---


