### PR TITLE
feat(vite): use statusCode from Context response if superior to httpResponse.statusCode

### DIFF
--- a/packages/third-parties/vike/src/services/ViteService.spec.ts
+++ b/packages/third-parties/vike/src/services/ViteService.spec.ts
@@ -205,6 +205,49 @@ describe("ViteService", () => {
         expect($ctx.response.status).toHaveBeenCalledWith(200);
         expect($ctx.response.setHeader).toHaveBeenCalledWith("content-type", "text/html");
       });
+
+      it("should render the page with statusCode from context.response if superior to httpResponse.statusCode", async () => {
+        const {$ctx, service, renderPage} = await getServiceFixture({
+          statusCode: 200,
+          headers: [["content-type", "text/html"]],
+          body: "html"
+        });
+
+        $ctx.response.status(404);
+        jest.spyOn($ctx.response, "status").mockReturnThis();
+        jest.spyOn($ctx.response, "setHeader").mockReturnThis();
+        const result = await service.render("*", {$ctx});
+
+        expect(result).toEqual({
+          body: "html",
+          headers: [["content-type", "text/html"]],
+          statusCode: 200
+        });
+        expect(renderPage).toHaveBeenCalledWith({
+          view: "*",
+          pageProps: {
+            view: "*"
+          },
+          contextProps: {
+            headers: {
+              host: "host",
+              "x-header": "x-header",
+              "user-agent": "ua"
+            },
+            host: "host",
+            method: "GET",
+            protocol: "https",
+            secure: true,
+            session: {},
+            stateSnapshot: {state: "state"},
+            url: "/"
+          },
+          urlOriginal: "/",
+          userAgent: "ua"
+        });
+        expect($ctx.response.status).toHaveBeenCalledWith(404);
+        expect($ctx.response.setHeader).toHaveBeenCalledWith("content-type", "text/html");
+      });
     });
   });
 });

--- a/packages/third-parties/vike/src/services/ViteService.ts
+++ b/packages/third-parties/vike/src/services/ViteService.ts
@@ -61,7 +61,7 @@ export class ViteService {
     if (pageContext.httpResponse) {
       const {httpResponse} = pageContext;
       httpResponse.headers?.forEach(([name, value]: [string, string]) => $ctx.response.setHeader(name, value));
-      $ctx.response.status(httpResponse.statusCode);
+      $ctx.response.status(Math.max(httpResponse.statusCode, $ctx.response.statusCode));
 
       if (this.enableStream) {
         return httpResponse;


### PR DESCRIPTION
Allow to specify a status code with $ctx.response.status() instead of using httpResponse.statusCode