### PR TITLE
fix(schema): set the correct content type when OneOf/AnyOf/AllOf is used on Returns decorator

### DIFF
--- a/packages/platform/platform-express/test/__snapshots__/discriminator.spec.ts.snap
+++ b/packages/platform/platform-express/test/__snapshots__/discriminator.spec.ts.snap
@@ -161,7 +161,7 @@ Object {
         "responses": Object {
           "200": Object {
             "content": Object {
-              "*/*": Object {
+              "application/json": Object {
                 "schema": Object {
                   "discriminator": Object {
                     "propertyName": "type",
@@ -294,7 +294,7 @@ Object {
         "responses": Object {
           "200": Object {
             "content": Object {
-              "*/*": Object {
+              "application/json": Object {
                 "schema": Object {
                   "discriminator": Object {
                     "propertyName": "type",

--- a/packages/specs/schema/src/decorators/operations/returns.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.spec.ts
@@ -1053,6 +1053,83 @@ describe("@Returns", () => {
         ]
       });
     });
+    it("should apply application/json content type if OneOf/AnyOf/AllOf is used without base model", () => {
+      class Model {
+        @Property()
+        id: string;
+      }
+
+      class Model2 {
+        @Property()
+        id: string;
+      }
+
+      class Controller {
+        @OperationPath("POST", "/")
+        @Returns(200).OneOf(Model, Model2).Description("description")
+        method() {
+          return {};
+        }
+      }
+
+      const result = getSpec(Controller, {specType: SpecTypes.OPENAPI});
+
+      expect(result).toEqual({
+        components: {
+          schemas: {
+            Model: {
+              properties: {
+                id: {
+                  type: "string"
+                }
+              },
+              type: "object"
+            },
+            Model2: {
+              properties: {
+                id: {
+                  type: "string"
+                }
+              },
+              type: "object"
+            }
+          }
+        },
+        paths: {
+          "/": {
+            post: {
+              operationId: "controllerMethod",
+              parameters: [],
+              responses: {
+                "200": {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        oneOf: [
+                          {
+                            $ref: "#/components/schemas/Model"
+                          },
+                          {
+                            $ref: "#/components/schemas/Model2"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  description: "description"
+                }
+              },
+              tags: ["Controller"]
+            }
+          }
+        },
+        tags: [
+          {
+            name: "Controller"
+          }
+        ]
+      });
+    });
   });
   describe("Multiple contentType", () => {
     it("should manage multiple content and model", () => {

--- a/packages/specs/schema/src/decorators/operations/returns.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.ts
@@ -188,6 +188,8 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
     "location"
   ];
 
+  private hasOfTypes: boolean;
+
   constructor({status, model}: any) {
     super();
 
@@ -344,7 +346,7 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
     const model = this.get("model");
     let contentType = this.get("contentType");
 
-    if (model && !isPlainObject(model) && !isPrimitiveOrPrimitiveClass(model)) {
+    if ((model && !isPlainObject(model) && !isPrimitiveOrPrimitiveClass(model)) || this.hasOfTypes) {
       contentType = contentType || "application/json";
     }
 
@@ -461,6 +463,7 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
 
   private manyOf(kind: string, types: any[]) {
     const model = this.get("model");
+    this.hasOfTypes = true;
 
     this.addAction(() => {
       const schema = this.get("schema") as JsonSchema;

--- a/packages/specs/schema/test/integrations/discriminator.integration.spec.ts
+++ b/packages/specs/schema/test/integrations/discriminator.integration.spec.ts
@@ -843,7 +843,7 @@ describe("Discriminator", () => {
               responses: {
                 "200": {
                   content: {
-                    "*/*": {
+                    "application/json": {
                       schema: {
                         discriminator: {
                           propertyName: "type"
@@ -1049,7 +1049,7 @@ describe("Discriminator", () => {
               responses: {
                 "200": {
                   content: {
-                    "*/*": {
+                    "application/json": {
                       schema: {
                         discriminator: {
                           propertyName: "type"
@@ -1176,7 +1176,7 @@ describe("Discriminator", () => {
               responses: {
                 "200": {
                   content: {
-                    "*/*": {
+                    "application/json": {
                       schema: {
                         discriminator: {
                           propertyName: "type"
@@ -1261,7 +1261,7 @@ describe("Discriminator", () => {
               responses: {
                 "200": {
                   content: {
-                    "*/*": {
+                    "application/json": {
                       schema: {
                         $ref: "#/components/schemas/Base"
                       }


### PR DESCRIPTION


## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---
