### PR TITLE
Fixed generateSpec util

### DIFF
--- a/packages/specs/schema/src/utils/mergeSpec.ts
+++ b/packages/specs/schema/src/utils/mergeSpec.ts
@@ -5,7 +5,13 @@ import {OpenSpec2, OpenSpec3} from "@tsed/openspec";
  * @ignore
  */
 export const schemesReducer = mergeReducerBuilder(
-  (current, value) => (current.type && current.type === value.type) || (current.$ref && current.$ref === value.$ref)
+  (current, value) => {
+    if (current.type && current.type && current.type === value.type && value.type === 'array') {
+      return JSON.stringify(current.items) === JSON.stringify(value.items);
+    }
+
+    return (current.type && current.type === value.type) || (current.$ref && current.$ref === value.$ref)
+  }
 );
 
 /**

--- a/packages/specs/schema/src/utils/mergeSpec.ts
+++ b/packages/specs/schema/src/utils/mergeSpec.ts
@@ -1,4 +1,4 @@
-import {cleanObject, deepMerge, mergeReducerBuilder} from "@tsed/core";
+import {deepMerge, mergeReducerBuilder} from "@tsed/core";
 import {OpenSpec2, OpenSpec3} from "@tsed/openspec";
 
 /**


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |
| Chore | No          |

---

Incorrect schema merging for cases with multiple items with type 'array'.

## Example
Let's say we have the next model:
```typescript
class Filter {
  @AnyOf(
    Number,
    String,
    { type: 'array', items: { type: 'number' } },
    { type: 'array', items: { type: 'string' } },
  )
  value: number | string | number[] | string[];
}
```

and controller:
```typescript
@Controller('/controller')
class Controller {
  @Post('/post')
  post(@BodyParams() body: Filter) {}
}
```

This is fine and valid. The generated schema is correct too. But if we have more controllers that using the same model we will get an incorrect schema for this model:
```json
"Model": {
    "type": "object",
    "properties": {
        "test": {
            "anyOf": [
                {
                    "type": "number"
                },
                {
                    "type": "boolean"
                },
                {
                    "type": "string"
                },
                {
                    "type": "array",
                    "items": {
                        "type": "string"
                    }
                },
                {
                    "type": "array",
                    "items": {
                        "type": "string"
                    }
                },
            ]
        }
    }
}
```
instead of:
```json
"Model": {
    "type": "object",
    "properties": {
        "test": {
            "anyOf": [
                {
                    "type": "number"
                },
                {
                    "type": "boolean"
                },
                {
                    "type": "string"
                },
                {
                    "type": "array",
                    "items": {
                        "type": "number"
                    }
                },
                {
                    "type": "array",
                    "items": {
                        "type": "string"
                    }
                },
            ]
        }
    }
}
```

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [x] Tests
- [ ] Coverage
- [x] Example
- [ ] Documentation
