### PR TITLE
feat(di): add support to configure providers from settings.imports options

### DIFF
--- a/packages/di/src/common/domain/Provider.ts
+++ b/packages/di/src/common/domain/Provider.ts
@@ -1,10 +1,10 @@
-import {classOf, getClassOrSymbol, isClass, Metadata, methodsOf, nameOf, Store, Type} from "@tsed/core";
-import {ProviderOpts} from "../interfaces/ProviderOpts.js";
-import {TokenProvider} from "../interfaces/TokenProvider.js";
+import {classOf, getClassOrSymbol, isClass, methodsOf, nameOf, Store, Type} from "@tsed/core";
+import type {ProviderOpts} from "../interfaces/ProviderOpts.js";
+import type {TokenProvider} from "../interfaces/TokenProvider.js";
 import {ProviderScope} from "./ProviderScope.js";
 import {ProviderType} from "./ProviderType.js";
 
-export type ProviderHookCallback<T = any> = (instance: T, ...args: any[]) => Promise<void> | void;
+export type ProviderHookCallback<T = any> = (instance: T, ...args: unknown[]) => Promise<void> | void;
 
 export class Provider<T = any> implements ProviderOpts<T> {
   /**
@@ -12,11 +12,11 @@ export class Provider<T = any> implements ProviderOpts<T> {
    */
   public type: TokenProvider | ProviderType = ProviderType.PROVIDER;
   public deps: TokenProvider[];
-  public imports: any[];
+  public imports: (TokenProvider | [TokenProvider])[];
   public alias?: string;
-  public useFactory: Function;
-  public useAsyncFactory: Function;
-  public useValue: any;
+  public useFactory?: Function;
+  public useAsyncFactory?: Function;
+  public useValue?: unknown;
   public hooks?: Record<string, ProviderHookCallback<T>>;
   private _useClass: Type<T>;
   private _provide: TokenProvider;

--- a/packages/di/src/common/index.ts
+++ b/packages/di/src/common/index.ts
@@ -31,6 +31,7 @@ export * from "./interfaces/DIConfigurationOptions.js";
 export * from "./interfaces/DILogger.js";
 export * from "./interfaces/DILoggerOptions.js";
 export * from "./interfaces/DIResolver.js";
+export * from "./interfaces/ImportTokenProviderOpts.js";
 export * from "./interfaces/InjectableProperties.js";
 export * from "./interfaces/InterceptorContext.js";
 export * from "./interfaces/InterceptorMethods.js";

--- a/packages/di/src/common/interfaces/DIConfigurationOptions.ts
+++ b/packages/di/src/common/interfaces/DIConfigurationOptions.ts
@@ -1,7 +1,7 @@
 import type {ProviderScope} from "../domain/ProviderScope.js";
 import type {DIResolver} from "./DIResolver.js";
+import type {ImportTokenProviderOpts} from "./ImportTokenProviderOpts.js";
 import type {TokenProvider} from "./TokenProvider.js";
-import {TokenProviderOpts} from "./TokenProvider.js";
 
 declare global {
   namespace TsED {
@@ -17,7 +17,7 @@ declare global {
       /**
        * Define dependencies to build the provider
        */
-      imports: (TokenProvider | TokenProviderOpts)[];
+      imports: (TokenProvider | ImportTokenProviderOpts)[];
       /**
        * Mount controllers
        */

--- a/packages/di/src/common/interfaces/ImportTokenProviderOpts.ts
+++ b/packages/di/src/common/interfaces/ImportTokenProviderOpts.ts
@@ -1,0 +1,28 @@
+import type {Type} from "@tsed/core";
+import type {TokenProvider} from "./TokenProvider.js";
+
+export type UseImportTokenProviderOpts = {
+  token: TokenProvider;
+  use: unknown;
+};
+
+export type UseClassImportTokenProviderOpts = {
+  token: TokenProvider;
+  useClass: Type | Function;
+};
+
+export type UseFactoryImportTokenProviderOpts = {
+  token: TokenProvider;
+  useFactory: (...args: unknown[]) => unknown;
+};
+
+export type UseAsyncFactoryImportTokenProviderOpts = {
+  token: TokenProvider;
+  useAsyncFactory: (...args: unknown[]) => Promise<unknown>;
+};
+
+export type ImportTokenProviderOpts =
+  | UseImportTokenProviderOpts
+  | UseClassImportTokenProviderOpts
+  | UseFactoryImportTokenProviderOpts
+  | UseAsyncFactoryImportTokenProviderOpts;

--- a/packages/di/src/common/services/DIConfiguration.ts
+++ b/packages/di/src/common/services/DIConfiguration.ts
@@ -2,7 +2,8 @@ import {Env, getValue, proxyDelegation, setValue} from "@tsed/core";
 import type {ProviderScope} from "../domain/ProviderScope.js";
 import type {DILoggerOptions} from "../interfaces/DILoggerOptions.js";
 import type {DIResolver} from "../interfaces/DIResolver.js";
-import type {TokenProvider, TokenProviderOpts} from "../interfaces/TokenProvider.js";
+import type {ImportTokenProviderOpts} from "../interfaces/ImportTokenProviderOpts.js";
+import type {TokenProvider} from "../interfaces/TokenProvider.js";
 import type {TokenRoute} from "../interfaces/TokenRoute.js";
 
 export class DIConfiguration {
@@ -68,11 +69,11 @@ export class DIConfiguration {
     this.map.set("resolvers", resolvers);
   }
 
-  get imports(): (TokenProvider | TokenProviderOpts)[] {
+  get imports(): (TokenProvider | ImportTokenProviderOpts)[] {
     return this.get("imports");
   }
 
-  set imports(imports: (TokenProvider | TokenProviderOpts)[]) {
+  set imports(imports: (TokenProvider | ImportTokenProviderOpts)[]) {
     this.map.set("imports", imports);
   }
 

--- a/packages/di/src/common/services/InjectorService.spec.ts
+++ b/packages/di/src/common/services/InjectorService.spec.ts
@@ -571,7 +571,7 @@ describe("InjectorService", () => {
     });
   });
   describe("loadModule()", () => {
-    it("should load DI with a rootModule", async () => {
+    it("should load DI with a rootModule (SINGLETON + deps)", async () => {
       // GIVEN
       @Injectable()
       class RootModule {}
@@ -588,8 +588,7 @@ describe("InjectorService", () => {
 
       expect(injector.get(RootModule)).toBeInstanceOf(RootModule);
     });
-  });
-  describe("loadModule()", () => {
+
     it("should load DI with a rootModule", async () => {
       // GIVEN
       @Injectable()
@@ -951,6 +950,114 @@ describe("InjectorService", () => {
 
       expect(service.$alterValue).toBeCalledWith("value");
       expect(value).toEqual("alteredValue");
+    });
+  });
+
+  describe("imports", () => {
+    it("should load all provider and override by configuration a provider (use)", async () => {
+      const injector = new InjectorService();
+      @Injectable()
+      class TestService {
+        get() {
+          return "hello";
+        }
+      }
+
+      injector.settings.set("imports", [
+        {
+          token: TestService,
+          use: {
+            get: jest.fn().mockReturnValue("world")
+          }
+        }
+      ]);
+
+      await injector.load();
+
+      const result = injector.get<TestService>(TestService).get();
+      expect(result).toEqual("world");
+    });
+    it("should load all provider and override by configuration a provider (useClass)", async () => {
+      const injector = new InjectorService();
+      @Injectable()
+      class TestService {
+        get() {
+          return "hello";
+        }
+      }
+
+      @Injectable()
+      class FsTestService {
+        get() {
+          return "fs";
+        }
+      }
+
+      injector.settings.set("imports", [
+        {
+          token: TestService,
+          useClass: FsTestService
+        }
+      ]);
+
+      await injector.load();
+
+      const result = injector.get<TestService>(TestService).get();
+      expect(result).toEqual("fs");
+    });
+    it("should load all provider and override by configuration a provider (useFactory)", async () => {
+      const injector = new InjectorService();
+      @Injectable()
+      class TestService {
+        get() {
+          return "hello";
+        }
+      }
+
+      injector.settings.set("imports", [
+        {
+          token: TestService,
+          useFactory: () => {
+            return {
+              get() {
+                return "world";
+              }
+            };
+          }
+        }
+      ]);
+
+      await injector.load();
+
+      const result = injector.get<TestService>(TestService).get();
+      expect(result).toEqual("world");
+    });
+    it("should load all provider and override by configuration a provider (useAsyncFactory)", async () => {
+      const injector = new InjectorService();
+      @Injectable()
+      class TestService {
+        get() {
+          return "hello";
+        }
+      }
+
+      injector.settings.set("imports", [
+        {
+          token: TestService,
+          useAsyncFactory: () => {
+            return Promise.resolve({
+              get() {
+                return "world";
+              }
+            });
+          }
+        }
+      ]);
+
+      await injector.load();
+
+      const result = injector.get<TestService>(TestService).get();
+      expect(result).toEqual("world");
     });
   });
 });

--- a/packages/di/src/node/services/DITest.ts
+++ b/packages/di/src/node/services/DITest.ts
@@ -1,6 +1,14 @@
 import {Env, getValue, isClass, isPromise, setValue} from "@tsed/core";
 import {$log} from "@tsed/logger";
-import {createContainer, InjectorService, LocalsContainer, OnInit, Provider, TokenProvider, TokenProviderOpts} from "../../common/index.js";
+import {
+  createContainer,
+  type ImportTokenProviderOpts,
+  InjectorService,
+  LocalsContainer,
+  OnInit,
+  TokenProvider,
+  type UseImportTokenProviderOpts
+} from "../../common/index.js";
 import {DIContext} from "../domain/DIContext.js";
 import {setLoggerConfiguration} from "../utils/setLoggerConfiguration.js";
 
@@ -84,7 +92,7 @@ export class DITest {
    * @param target
    * @param providers
    */
-  static async invoke<T = any>(target: TokenProvider, providers: TokenProviderOpts[] = []): Promise<T> {
+  static async invoke<T = any>(target: TokenProvider, providers: UseImportTokenProviderOpts[] = []): Promise<T> {
     const locals = new LocalsContainer();
     providers.forEach((p) => {
       locals.set(p.token, p.use);


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---


## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {@Configuration} from "@tsed/common";

const TokenService =  Symbol.for('TOKEN_SERVICE')

class ProdTokenService {
  
}

class DevTokenService {
  
}


@Configuration({
   imports: [
       token: TokenService,
       useClass: process.env.NODE_ENV === "production" ? ProdTokenService : DevTokenService
   ]
})
class Server {

}
```


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [ ] Documentation
