### PR TITLE
fix(prisma): resolve several issues with prisma generate for ESM

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 97.52,
-      branches: 92.65,
+      branches: 92.45,
       functions: 95.41,
       lines: 97.52
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * from "./interfaces/AnyDecorator.js";
 export * from "./interfaces/DecoratorParameters.js";
 export * from "./interfaces/MetadataTypes.js";
 export * from "./interfaces/ValueOf.js";
+export * from "./interfaces/Relation.js";
 export * from "./utils/catchError.js";
 export * from "./utils/decorators/decorateMethodsOf.js";
 export * from "./utils/decorators/decoratorArgs.js";

--- a/packages/core/src/interfaces/Relation.ts
+++ b/packages/core/src/interfaces/Relation.ts
@@ -1,0 +1,1 @@
+export type Relation<T> = T;

--- a/packages/orm/prisma/scripts/backup-index.esm.js
+++ b/packages/orm/prisma/scripts/backup-index.esm.js
@@ -1,1 +1,1 @@
-export * from "./.schema/index.js";
+export * from "../.schema/index.js";

--- a/packages/orm/prisma/src/generator/domain/DmmfField.spec.ts
+++ b/packages/orm/prisma/src/generator/domain/DmmfField.spec.ts
@@ -1,0 +1,40 @@
+import {DmmfField} from "./DmmfField.js";
+import {DmmfModel} from "./DmmfModel.js";
+
+describe("DmmfField", () => {
+  it("should create a new instance of DmmfField", () => {
+    const dmmfField = new DmmfField({
+      field: {
+        name: "name",
+        isRequired: true,
+        type: "string",
+        isList: false,
+        kind: "scalar"
+      },
+      schemaArg: {
+        isNullable: false
+      },
+      model: new DmmfModel({
+        model: {
+          name: "model",
+          fields: []
+        },
+        modelType: {
+          fields: []
+        },
+        isInputType: true
+      })
+    });
+
+    expect(dmmfField).toBeInstanceOf(DmmfField);
+    expect(dmmfField.name).toBe("name");
+    expect(dmmfField.isRequired).toBe(true);
+    expect(dmmfField.type).toBe("string");
+    expect(dmmfField.isList).toBe(false);
+    expect(dmmfField.kind).toBe("scalar");
+    expect(dmmfField.isNullable).toBe(false);
+    expect(dmmfField.location).toBe("scalar");
+    expect(dmmfField.getAdditionalDecorators()).toEqual([]);
+    expect(dmmfField.toString()).toBe("name");
+  });
+});

--- a/packages/orm/prisma/src/generator/domain/DmmfModel.ts
+++ b/packages/orm/prisma/src/generator/domain/DmmfModel.ts
@@ -65,26 +65,23 @@ export class DmmfModel {
     return pascalCase(`${name}Model`);
   }
 
-  addImportDeclaration(moduleSpecifier: string, name: string, isDefault = false) {
+  addImportDeclaration(moduleSpecifier: string, name: string, isTypeOnly = false) {
     if (!this.#imports.has(moduleSpecifier)) {
       moduleSpecifier = resolveExtension(moduleSpecifier);
 
       this.#imports.set(moduleSpecifier, {
         kind: StructureKind.ImportDeclaration,
         moduleSpecifier: moduleSpecifier,
-        namedImports: []
+        namedImports: [],
+        isTypeOnly
       });
     }
 
     const moduleDeclaration = this.#imports.get(moduleSpecifier)!;
+    const nameImports = moduleDeclaration.namedImports as any[];
 
-    if (isDefault) {
-      moduleDeclaration.defaultImport = name;
-    } else {
-      const nameImports = moduleDeclaration.namedImports as any[];
-      if (!nameImports.includes(name)) {
-        nameImports.push(name);
-      }
+    if (!nameImports.includes(name)) {
+      nameImports.push(name);
     }
 
     return this;

--- a/packages/orm/prisma/src/generator/transform/transformFieldToDecorators.ts
+++ b/packages/orm/prisma/src/generator/transform/transformFieldToDecorators.ts
@@ -4,6 +4,7 @@ import {DmmfModel} from "../domain/DmmfModel.js";
 import {ScalarDecorators, ScalarJsClasses} from "../domain/ScalarTsTypes.js";
 import {TransformContext} from "../domain/TransformContext.js";
 import {isCircularRef} from "../utils/isCircularRef.js";
+import {isEsm} from "../utils/sourceType.js";
 
 function createDecorator(name: string, args: string[]): DecoratorStructure {
   return {
@@ -15,7 +16,9 @@ function createDecorator(name: string, args: string[]): DecoratorStructure {
 
 export function transformFieldToDecorators(field: DmmfField, ctx: TransformContext): DecoratorStructure[] {
   const hasCircularRef = isCircularRef(field.model.name, field.type, ctx);
-
+  if (isEsm() && hasCircularRef) {
+    return [];
+  }
   const decorators: DecoratorStructure[] = [...(ScalarDecorators[field.type] || [])].map((obj) => {
     field.model.addImportDeclaration("@tsed/schema", obj.name);
 

--- a/packages/orm/prisma/src/generator/transform/transformFieldToDecorators.ts
+++ b/packages/orm/prisma/src/generator/transform/transformFieldToDecorators.ts
@@ -16,9 +16,7 @@ function createDecorator(name: string, args: string[]): DecoratorStructure {
 
 export function transformFieldToDecorators(field: DmmfField, ctx: TransformContext): DecoratorStructure[] {
   const hasCircularRef = isCircularRef(field.model.name, field.type, ctx);
-  if (isEsm() && hasCircularRef) {
-    return [];
-  }
+
   const decorators: DecoratorStructure[] = [...(ScalarDecorators[field.type] || [])].map((obj) => {
     field.model.addImportDeclaration("@tsed/schema", obj.name);
 

--- a/packages/orm/prisma/src/generator/transform/transformFieldToProperty.ts
+++ b/packages/orm/prisma/src/generator/transform/transformFieldToProperty.ts
@@ -9,7 +9,7 @@ export function transformFieldToProperty(field: DmmfField, ctx: TransformContext
     kind: StructureKind.Property,
     name: field.name,
     trailingTrivia: "\n",
-    type: transformScalarToType(field),
+    type: transformScalarToType(field, ctx),
     decorators: transformFieldToDecorators(field, ctx)
   };
 }

--- a/packages/orm/prisma/src/generator/transform/transformModelToClass.spec.ts
+++ b/packages/orm/prisma/src/generator/transform/transformModelToClass.spec.ts
@@ -407,7 +407,7 @@ describe("transformModelToClass()", () => {
           kind: 30,
           name: "role",
           trailingTrivia: "\n",
-          type: "Role"
+          type: "Relation<Role>"
         }
       ],
       trailingTrivia: "\n"

--- a/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
+++ b/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
@@ -1,46 +1,66 @@
+import {createContextFixture} from "../../__mock__/createContextFixture.js";
 import {transformScalarToType} from "./transformScalarToType.js";
 import {createDmmfFieldFixture} from "../../__mock__/createDmmfFieldFixture.js";
 import {PrismaScalars} from "../domain/ScalarTsTypes.js";
 
 describe("transformScalarToType()", () => {
+  it("should transform User to User (not null + circular ref)", () => {
+    const ctx = createContextFixture();
+    const field = createDmmfFieldFixture({
+      kind: "object",
+      type: "Role",
+      isRequired: true,
+      isNullable: false
+    });
+    // @ts-ignore
+    field.model.name = "User";
+    expect(transformScalarToType(field, ctx)).toEqual("Relation<RoleModel>");
+    expect(field.model.addImportDeclaration).toHaveBeenCalledWith("./RoleModel", "RoleModel");
+    expect(field.model.addImportDeclaration).toHaveBeenCalledWith("@tsed/core", "Relation", true);
+  });
   it("should transform String to string", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.String
     });
-    expect(transformScalarToType(field)).toEqual("string | null");
+    expect(transformScalarToType(field, ctx)).toEqual("string | null");
   });
 
   it("should transform String to string (isInputType)", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.String,
       isInputType: true
     });
 
-    expect(transformScalarToType(field)).toEqual("string | undefined");
+    expect(transformScalarToType(field, ctx)).toEqual("string | undefined");
   });
 
   it("should transform String to string (Required)", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.String,
       isRequired: true
     });
-    expect(transformScalarToType(field)).toEqual("string");
+    expect(transformScalarToType(field, ctx)).toEqual("string");
   });
 
   it("should transform String to string (Required + null)", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.String,
       isRequired: true,
       isNullable: true
     });
-    expect(transformScalarToType(field)).toEqual("string | null");
+    expect(transformScalarToType(field, ctx)).toEqual("string | null");
   });
 
   it("should transform String to string (Required + null + List)", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.String,
@@ -48,53 +68,58 @@ describe("transformScalarToType()", () => {
       isNullable: true,
       isList: true
     });
-    expect(transformScalarToType(field)).toEqual("string[]");
+    expect(transformScalarToType(field, ctx)).toEqual("string[]");
   });
 
   it("should transform Int to number", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.Int
     });
-    expect(transformScalarToType(field)).toEqual("number | null");
+    expect(transformScalarToType(field, ctx)).toEqual("number | null");
   });
 
   it("should transform DateTime to Date", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "scalar",
       type: PrismaScalars.DateTime
     });
-    expect(transformScalarToType(field)).toEqual("Date | null");
+    expect(transformScalarToType(field, ctx)).toEqual("Date | null");
   });
 
   it("should transform enumTypes to Date", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "enum",
       type: "Role"
     });
-    expect(transformScalarToType(field)).toEqual("Role | null");
+    expect(transformScalarToType(field, ctx)).toEqual("Role | null");
     expect(field.model.addImportDeclaration).toHaveBeenCalledWith("../enums/index", "Role");
   });
 
   it("should transform User to User (self-ref)", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "object",
       type: "User"
     });
     // @ts-ignore
     field.model.name = "User";
-    expect(transformScalarToType(field)).toEqual("UserModel | null");
+    expect(transformScalarToType(field, ctx)).toEqual("UserModel | null");
     expect(field.model.addImportDeclaration).not.toHaveBeenCalled();
   });
 
   it("should transform User to User", () => {
+    const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "object",
       type: "Role"
     });
     // @ts-ignore
     field.model.name = "User";
-    expect(transformScalarToType(field)).toEqual("RoleModel | null");
+    expect(transformScalarToType(field, ctx)).toEqual("RoleModel | null");
     expect(field.model.addImportDeclaration).toHaveBeenCalledWith("./RoleModel", "RoleModel");
   });
 });

--- a/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.spec.ts
+++ b/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.spec.ts
@@ -1,6 +1,9 @@
 import {parseDocumentationAttributes} from "./parseDocumentationAttributes.js";
 
 describe("parseDocumentationAttributes", () => {
+  it("should ignore undefined comment", () => {
+    expect(parseDocumentationAttributes(undefined)).toEqual([]);
+  });
   it("should parse @TsED.Email()", () => {
     expect(parseDocumentationAttributes("/// @TsED.Email()")).toEqual([
       {
@@ -10,7 +13,6 @@ describe("parseDocumentationAttributes", () => {
       }
     ]);
   });
-
   it("should parse @TsED.Ignore(endpoint = true)", () => {
     expect(parseDocumentationAttributes("/// @TsED.Ignore(ctx.endpoint === true)")).toEqual([
       {
@@ -20,7 +22,6 @@ describe("parseDocumentationAttributes", () => {
       }
     ]);
   });
-
   it("should parse @TsED.Ignore()", () => {
     expect(parseDocumentationAttributes("/// @TsED.Ignore()")).toEqual([
       {
@@ -30,7 +31,6 @@ describe("parseDocumentationAttributes", () => {
       }
     ]);
   });
-
   it('should parse @TsED.Groups("!creation")', () => {
     expect(parseDocumentationAttributes('/// @TsED.Groups("!creation")')).toEqual([
       {
@@ -55,9 +55,5 @@ describe("parseDocumentationAttributes", () => {
   });
   it("should ignore other comments", () => {
     expect(parseDocumentationAttributes("/// comments")).toEqual([]);
-  });
-
-  it("should ignore undefined comment", () => {
-    expect(parseDocumentationAttributes(undefined)).toEqual([]);
   });
 });

--- a/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.spec.ts
+++ b/packages/orm/prisma/src/generator/utils/parseDocumentationAttributes.spec.ts
@@ -1,6 +1,20 @@
 import {parseDocumentationAttributes} from "./parseDocumentationAttributes.js";
 
 describe("parseDocumentationAttributes", () => {
+  it('should parse @TsED.Groups(type: "test", fix: "other")', () => {
+    expect(parseDocumentationAttributes('/// @TsED.Groups(type: "test", fix: "other")')).toEqual([
+      {
+        arguments: [
+          {
+            type: "test",
+            fix: "other"
+          }
+        ],
+        content: '@TsED.Groups(type: "test", fix: "other")',
+        name: "Groups"
+      }
+    ]);
+  });
   it("should ignore undefined comment", () => {
     expect(parseDocumentationAttributes(undefined)).toEqual([]);
   });


### PR DESCRIPTION
1. Correct the generated 'lib/esm/index.js' file's path.
2. Workaround for 'ReferenceError: Cannot access 'xxx' before initialization' caused by esm circular ref.

```
../tsed/packages/orm/prisma/lib/esm/.schema/models/MessageModel.js:129
    __metadata("design:type", ConversationModel)
                              ^

ReferenceError: Cannot access 'ConversationModel' before initialization
    at ../tsed/packages/orm/prisma/lib/esm/.schema/models/MessageModel.js:129:31
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)

Node.js v20.11.1
```

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature/Fix/Doc/Chore | Yes/No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
