### PR TITLE
feat(schema): store groups metadata as customKey

### DIFF
--- a/packages/orm/prisma/scripts/backup-index.esm.js
+++ b/packages/orm/prisma/scripts/backup-index.esm.js
@@ -1,1 +1,1 @@
-export * from "./.schema.js";
+export * from "./.schema/index.js";

--- a/packages/specs/schema/src/decorators/common/groups.spec.ts
+++ b/packages/specs/schema/src/decorators/common/groups.spec.ts
@@ -1,4 +1,5 @@
 import {QueryParams} from "@tsed/platform-params";
+import {type} from "node:os";
 import {SpecTypes} from "../../domain/SpecTypes.js";
 import {getJsonSchema} from "../../utils/getJsonSchema.js";
 import {getSpec} from "../../utils/getSpec.js";
@@ -73,6 +74,59 @@ describe("@Groups", () => {
             type: "string"
           },
           prop2: {
+            minLength: 1,
+            type: "string"
+          },
+          prop3: {
+            minLength: 1,
+            type: "string"
+          },
+          prop4: {
+            items: {
+              $ref: "#/definitions/ChildModel"
+            },
+            type: "array"
+          }
+        },
+        required: ["prop1", "prop2", "prop3"],
+        type: "object"
+      });
+    });
+    it("should show fields with group annotation (with x-groups custom key)", () => {
+      const spec = getJsonSchema(MyModel, {
+        groups: false,
+        customKeys: true
+      });
+
+      expect(spec).toEqual({
+        definitions: {
+          ChildModel: {
+            properties: {
+              id: {
+                "x-groups": ["!creation"],
+                type: "string"
+              },
+              prop1: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["prop1"],
+            type: "object"
+          }
+        },
+        properties: {
+          id: {
+            "x-groups": ["!creation"],
+            type: "string"
+          },
+          prop1: {
+            "x-groups": ["group.summary"],
+            minLength: 1,
+            type: "string"
+          },
+          prop2: {
+            "x-groups": ["group.extended"],
             minLength: 1,
             type: "string"
           },

--- a/packages/specs/schema/src/decorators/common/groups.ts
+++ b/packages/specs/schema/src/decorators/common/groups.ts
@@ -2,6 +2,7 @@ import {DecoratorTypes, isArray} from "@tsed/core";
 import type {JsonClassStore} from "../../domain/JsonClassStore.js";
 import type {JsonParameterStore} from "../../domain/JsonParameterStore.js";
 import {matchGroups} from "../../utils/matchGroups.js";
+import {CustomKey} from "./customKey.js";
 import {JsonEntityFn} from "./jsonEntityFn.js";
 
 /**
@@ -37,6 +38,7 @@ export function Groups(...groups: any): any {
         groupsClass(groups, entity as JsonClassStore);
         break;
       case DecoratorTypes.PROP:
+        CustomKey("x-groups", groups)(entity.target, entity.propertyKey);
         entity.schema.$hooks.on("groups", (prev: boolean, givenGroups: string[]) => {
           if (!prev) {
             if (matchGroups(groups, givenGroups)) {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
