### PR TITLE
fix(platform-serverless): fix .headers undefined error when event is a SQS event

### DIFF
--- a/packages/platform/platform-serverless/src/domain/ServerlessContext.spec.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessContext.spec.ts
@@ -41,5 +41,43 @@ describe("ServerlessContext", () => {
       expect(ctx.request.response).toEqual(ctx.response);
       expect(ctx.response.request).toEqual(ctx.request);
     });
+    it("should push callback with event headers", () => {
+      const ctx = createServerlessContext({
+        endpoint: {} as any,
+        event: {
+          headers: undefined
+        }
+      });
+      expect(ctx.event).toEqual({
+        body: "",
+        headers: {},
+        httpMethod: "",
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        path: "/",
+        pathParameters: {},
+        queryStringParameters: {},
+        requestContext: {
+          accountId: "",
+          apiId: "",
+          httpMethod: "",
+          identity: {},
+          path: "/",
+          protocol: "https",
+          requestId: "requestId",
+          requestTimeEpoch: 0,
+          resourceId: 1,
+          resourcePath: "/",
+          stage: ""
+        },
+        resource: "",
+        stageVariables: {}
+      });
+      expect(ctx.response.raw).toEqual(ctx.request.raw);
+      expect(ctx.request.event).toEqual(ctx.response.event);
+      expect(ctx.request.response).toEqual(ctx.response);
+      expect(ctx.response.request).toEqual(ctx.request);
+    });
   });
 });

--- a/packages/platform/platform-serverless/src/domain/ServerlessContext.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessContext.ts
@@ -26,7 +26,7 @@ export class ServerlessContext extends DIContext {
     this.context = context;
     this.event = {
       ...event,
-      headers: Object.fromEntries(Object.entries(event.headers).map(([key, value]) => [key.toLowerCase(), value]))
+      headers: Object.fromEntries(Object.entries(event.headers || {}).map(([key, value]) => [key.toLowerCase(), value]))
     };
     this.request = new ServerlessRequest(this);
     this.response = new ServerlessResponse(this);

--- a/packages/platform/platform-serverless/test/utils/createServerlessContext.ts
+++ b/packages/platform/platform-serverless/test/utils/createServerlessContext.ts
@@ -1,11 +1,19 @@
 import {JsonEntityStore} from "@tsed/schema";
-import {createFakeContext, createFakeEvent, PlatformServerlessTest} from "@tsed/platform-serverless-testing";
+import {createFakeEvent, createFakeContext, PlatformServerlessTest} from "@tsed/platform-serverless-testing";
 import {Logger} from "@tsed/logger";
 import {ServerlessContext} from "../../src/domain/ServerlessContext.js";
 
-export function createServerlessContext({endpoint}: {endpoint: JsonEntityStore}) {
-  const context: any = createFakeContext();
-  const event: any = createFakeEvent();
+export function createServerlessContext({
+  endpoint,
+  event: initialEvent,
+  context: initialContext
+}: {
+  endpoint: JsonEntityStore;
+  event?: Parameters<typeof createFakeEvent>[0];
+  context?: Parameters<typeof createFakeContext>[0];
+}) {
+  const context: any = createFakeContext(initialContext);
+  const event: any = createFakeEvent(initialEvent);
 
   return new ServerlessContext({
     event,


### PR DESCRIPTION


Closes: #2746

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | Yes          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
