### PR TITLE
feat(platform-serverless): detect lambda event type to map http respo…

### DIFF
--- a/packages/platform/platform-serverless/src/builder/PlatformServerless.ts
+++ b/packages/platform/platform-serverless/src/builder/PlatformServerless.ts
@@ -5,6 +5,7 @@ import {getOperationsRoutes, JsonEntityStore} from "@tsed/schema";
 import type {APIGatewayProxyResult, Handler} from "aws-lambda";
 import type {HTTPMethod, Instance} from "find-my-way";
 import {ServerlessContext} from "../domain/ServerlessContext.js";
+import type {ServerlessEvent} from "../domain/ServerlessEvent";
 import {getRequestId} from "../utils/getRequestId.js";
 import {PlatformServerlessHandler} from "./PlatformServerlessHandler.js";
 
@@ -124,11 +125,11 @@ export class PlatformServerless {
     return this._promise;
   }
 
-  protected callback(token: Type<any>, propertyKey: string): Handler {
+  protected callback(token: Type<any>, propertyKey: string): Handler<ServerlessEvent> {
     const entity = JsonEntityStore.fromMethod(token, propertyKey);
     let handler: ($ctx: ServerlessContext) => Promise<APIGatewayProxyResult>;
 
-    return async (event, context) => {
+    return async (event: ServerlessEvent, context) => {
       await this.init();
 
       if (!handler) {

--- a/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.spec.ts
+++ b/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.spec.ts
@@ -1,6 +1,9 @@
+import {catchAsyncError} from "@tsed/core";
 import {DITest, Inject, Injectable} from "@tsed/di";
+import {Unauthorized} from "@tsed/exceptions";
 import {QueryParams} from "@tsed/platform-params";
 import {JsonEntityStore} from "@tsed/schema";
+import type {APIGatewayTokenAuthorizerEvent} from "aws-lambda";
 import {ServerlessContext} from "../domain/ServerlessContext.js";
 import {PlatformServerlessHandler} from "./PlatformServerlessHandler.js";
 
@@ -30,18 +33,23 @@ export class TimeslotsLambdaController {
       endDate
     };
   }
+
+  throwError(@QueryParams("start_date") startDate: Date, @QueryParams("end_date") endDate: Date) {
+    throw new Unauthorized("Unauthorized");
+  }
 }
 
 describe("PlatformServerlessHandler", () => {
-  beforeEach(() => DITest.create());
+  beforeEach(() => DITest.create({}));
   afterEach(() => DITest.reset());
 
-  it("should call lambda provider", async () => {
+  it("should call lambda provider and return http response", async () => {
     const {service} = await getPlatformServerlessHandlerFixture();
 
     const endpoint = JsonEntityStore.fromMethod(TimeslotsLambdaController, "get");
     const $ctx = new ServerlessContext({
       event: {
+        httpMethod: "GET",
         headers: {
           "Content-Type": "application/json"
         }
@@ -50,7 +58,7 @@ describe("PlatformServerlessHandler", () => {
       endpoint
     } as any);
 
-    const handler = await service.createHandler(TimeslotsLambdaController, "get");
+    const handler = service.createHandler(TimeslotsLambdaController, "get");
     const result = await handler($ctx);
 
     expect(result).toEqual({
@@ -61,5 +69,76 @@ describe("PlatformServerlessHandler", () => {
       isBase64Encoded: false,
       statusCode: 200
     });
+  });
+  it("shouldn't throw error and return http response", async () => {
+    const {service} = await getPlatformServerlessHandlerFixture();
+
+    const endpoint = JsonEntityStore.fromMethod(TimeslotsLambdaController, "throwError");
+    const $ctx = new ServerlessContext({
+      event: {
+        httpMethod: "GET",
+        headers: {
+          "Content-Type": "application/json"
+        }
+      } as any,
+      context: {} as any,
+      endpoint,
+      injector: DITest.injector
+    } as any);
+
+    const handler = service.createHandler(TimeslotsLambdaController, "throwError");
+
+    const result = await handler($ctx);
+
+    expect(result).toEqual({
+      body: '{"name":"UNAUTHORIZED","message":"Unauthorized","status":401,"errors":[]}',
+      headers: {
+        "content-type": "application/json"
+      },
+      isBase64Encoded: false,
+      statusCode: 401
+    });
+  });
+  it("should call lambda provider and return raw response when isn't a http event", async () => {
+    const {service} = await getPlatformServerlessHandlerFixture();
+
+    const endpoint = JsonEntityStore.fromMethod(TimeslotsLambdaController, "get");
+    const $ctx = new ServerlessContext({
+      event: {
+        type: "TOKEN",
+        methodArn: "",
+        authorizationToken: ""
+      } as APIGatewayTokenAuthorizerEvent,
+      context: {} as any,
+      endpoint
+    } as any);
+
+    const handler = service.createHandler(TimeslotsLambdaController, "get");
+    const result = await handler($ctx);
+
+    expect(result).toEqual({
+      value: "test"
+    });
+  });
+  it("should throw error when isn't a http event", async () => {
+    const {service} = await getPlatformServerlessHandlerFixture();
+
+    const endpoint = JsonEntityStore.fromMethod(TimeslotsLambdaController, "throwError");
+    const $ctx = new ServerlessContext({
+      event: {
+        type: "TOKEN",
+        methodArn: "",
+        authorizationToken: ""
+      } as APIGatewayTokenAuthorizerEvent,
+      context: {} as any,
+      endpoint,
+      injector: DITest.injector
+    } as any);
+
+    const handler = service.createHandler(TimeslotsLambdaController, "throwError");
+
+    const result = await catchAsyncError<Error>(() => handler($ctx));
+
+    expect(result?.message).toEqual("Unauthorized");
   });
 });

--- a/packages/platform/platform-serverless/src/domain/ServerlessEvent.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessEvent.ts
@@ -1,0 +1,22 @@
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayTokenAuthorizerEvent,
+  CloudWatchLogsEvent,
+  DynamoDBStreamEvent,
+  KinesisStreamEvent,
+  S3Event,
+  ScheduledEvent,
+  SNSEvent,
+  SQSEvent
+} from "aws-lambda";
+
+export type ServerlessEvent =
+  | APIGatewayProxyEvent
+  | S3Event
+  | SQSEvent
+  | SNSEvent
+  | DynamoDBStreamEvent
+  | KinesisStreamEvent
+  | CloudWatchLogsEvent
+  | ScheduledEvent
+  | APIGatewayTokenAuthorizerEvent;

--- a/packages/platform/platform-serverless/src/domain/ServerlessRequest.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessRequest.ts
@@ -1,14 +1,15 @@
 import {getValue} from "@tsed/core";
+import type {APIGatewayProxyEvent} from "aws-lambda";
 import {ServerlessContext} from "./ServerlessContext.js";
 
 /**
  * @platform
  */
-export class ServerlessRequest {
-  constructor(protected $ctx: ServerlessContext) {}
+export class ServerlessRequest<Event = APIGatewayProxyEvent> {
+  constructor(protected $ctx: ServerlessContext<Event>) {}
 
   get event() {
-    return this.$ctx.event;
+    return this.getEvent();
   }
 
   get raw() {
@@ -37,15 +38,15 @@ export class ServerlessRequest {
    * Is equivalent of `express.response.originalUrl || express.response.url`.
    */
   get url(): string {
-    return this.event.path;
+    return this.getEvent<APIGatewayProxyEvent>().path;
   }
 
   get headers() {
-    return this.event.headers;
+    return this.getEvent<APIGatewayProxyEvent>().headers;
   }
 
   get method(): string {
-    return this.event.httpMethod;
+    return this.getEvent<APIGatewayProxyEvent>().httpMethod;
   }
 
   /**
@@ -54,14 +55,14 @@ export class ServerlessRequest {
    */
   get body(): any {
     try {
-      return this.event.body ? JSON.parse(this.event.body) : {};
+      return this.getEvent<APIGatewayProxyEvent>().body ? JSON.parse(this.getEvent<APIGatewayProxyEvent>().body!) : {};
     } catch (er) {
-      return this.event.body;
+      return this.getEvent<APIGatewayProxyEvent>().body;
     }
   }
 
   get rawBody(): any {
-    return this.event.body;
+    return this.getEvent<APIGatewayProxyEvent>().body;
   }
 
   /**
@@ -70,7 +71,7 @@ export class ServerlessRequest {
    * This object defaults to `{}`.
    */
   get params(): {[key: string]: any} {
-    return this.event.pathParameters || {};
+    return this.getEvent<APIGatewayProxyEvent>().pathParameters || {};
   }
 
   /**
@@ -78,7 +79,11 @@ export class ServerlessRequest {
    * When query parser is set to disabled, it is an empty object `{}`, otherwise it is the result of the configured query parser.
    */
   get query(): {[key: string]: any} {
-    return this.event.queryStringParameters || {};
+    return this.getEvent<APIGatewayProxyEvent>().queryStringParameters || {};
+  }
+
+  getEvent<E = Event>(): E {
+    return this.$ctx.event as unknown as E;
   }
 
   /**
@@ -91,6 +96,6 @@ export class ServerlessRequest {
    * @param name
    */
   get(name: string) {
-    return getValue(this.event.headers, name);
+    return getValue(this.getEvent<APIGatewayProxyEvent>().headers, name);
   }
 }

--- a/packages/platform/platform-serverless/src/domain/ServerlessResponse.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessResponse.ts
@@ -1,5 +1,6 @@
 import {getValue} from "@tsed/core";
 import {getStatusMessage} from "@tsed/schema";
+import type {APIGatewayProxyEvent} from "aws-lambda";
 import encodeUrl from "encodeurl";
 import mime from "mime";
 import {ServerlessContext} from "./ServerlessContext.js";
@@ -9,14 +10,14 @@ export type HeaderValue = boolean | number | string;
 /**
  * @platform
  */
-export class ServerlessResponse {
+export class ServerlessResponse<Event = APIGatewayProxyEvent> {
   #status: number = 200;
   #body: any = undefined;
   #headers: Record<string, HeaderValue> = {};
   #locals: Record<string, any> = {};
   #isHeadersSent = false;
 
-  constructor(protected $ctx: ServerlessContext) {}
+  constructor(protected $ctx: ServerlessContext<Event>) {}
 
   get event() {
     return this.$ctx.event;

--- a/packages/platform/platform-serverless/src/utils/getRequestId.ts
+++ b/packages/platform/platform-serverless/src/utils/getRequestId.ts
@@ -1,10 +1,15 @@
-import {APIGatewayEventDefaultAuthorizerContext, APIGatewayProxyEventBase, Context} from "aws-lambda";
+import {Context} from "aws-lambda";
 import {v4} from "uuid";
+import type {ServerlessEvent} from "../domain/ServerlessEvent";
 
-export function getRequestId(event: APIGatewayProxyEventBase<APIGatewayEventDefaultAuthorizerContext>, context: Context) {
-  if (event?.headers && event.headers["x-request-id"]) {
+export function getRequestId(event: ServerlessEvent, context: Context) {
+  if ("headers" in event && event.headers["x-request-id"]) {
     return event.headers["x-request-id"];
   }
 
-  return event?.requestContext?.requestId || context?.awsRequestId || v4().replace(/-/gi, "");
+  if ("requestContext" in event) {
+    return event?.requestContext?.requestId;
+  }
+
+  return context?.awsRequestId || v4().replace(/-/gi, "");
 }


### PR DESCRIPTION
…nse when it's only necessary

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---
Improve support on `platform-serverless` package. Now Ts.ED detect if the lambda is an APIGatewayEvent (or http event like) and map ServerlessResponse to a valid AWS response. Otherwise, Ts.ED return the raw response from the endpoint.

Solve issue with Lambda Authorizer and other kind of AWS event.

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
