### PR TITLE
Fix schema collection of map of string

### DIFF
--- a/packages/specs/json-mapper/src/domain/JsonMapperCompiler.ts
+++ b/packages/specs/json-mapper/src/domain/JsonMapperCompiler.ts
@@ -184,7 +184,7 @@ export abstract class JsonMapperCompiler<Options extends Record<string, any> = a
       return value.toString();
     }
 
-    return this.mappers[id](value, options);
+    return this.mappers[id || nameOf(classOf(value))](value, options);
   }
 
   protected abstract map(input: any, options: Options): any;

--- a/packages/specs/json-mapper/test/integration/collection-of-map.integration.spec.ts
+++ b/packages/specs/json-mapper/test/integration/collection-of-map.integration.spec.ts
@@ -1,0 +1,31 @@
+import {CollectionOf, Schema, array, map, string} from "@tsed/schema";
+import {deserialize} from "@tsed/json-mapper";
+
+describe("Collection of Map", () => {
+  it("should declare an array of map of string", () => {
+    const schema = array().items(map().additionalProperties(string()));
+
+    class Test {
+      @Schema(schema)
+      @CollectionOf(Map)
+      fields: Map<string, string>[] = [];
+    }
+
+    const result = deserialize(
+      {
+        fields: [
+          {
+            test: "test"
+          }
+        ]
+      },
+      {
+        type: Test
+      }
+    );
+
+    expect(result).toEqual({
+      fields: [new Map([["test", "test"]])]
+    });
+  });
+});

--- a/packages/specs/schema/src/decorators/collections/collectionOf.spec.ts
+++ b/packages/specs/schema/src/decorators/collections/collectionOf.spec.ts
@@ -8,6 +8,8 @@ import {CollectionContains} from "./collectionContains.js";
 import {ArrayOf, CollectionOf, MapOf} from "./collectionOf.js";
 import {MaxItems} from "./maxItems.js";
 import {MinItems} from "./minItems.js";
+import {Schema} from "../common/schema.js";
+import {map, array, string} from "../../utils/from.js";
 
 describe("@CollectionOf", () => {
   it("should declare a collection (Array of)", () => {
@@ -22,6 +24,30 @@ describe("@CollectionOf", () => {
     expect(error?.message).toEqual(
       "A type is required on `@CollectionOf(type)` decorator. Please give a type or wrap it inside an arrow function if you have a circular reference."
     );
+  });
+  it("should declare an array of map of string", () => {
+    const schema = array().items(map().additionalProperties(string()));
+
+    class Test {
+      @Schema(schema)
+      @CollectionOf(Map)
+      fields: Map<string, string>[] = [];
+    }
+
+    expect(getJsonSchema(Test)).toEqual({
+      properties: {
+        fields: {
+          items: {
+            additionalProperties: {
+              type: "string"
+            },
+            type: "object"
+          },
+          type: "array"
+        }
+      },
+      type: "object"
+    });
   });
   it("should declare a collection (Array of)", () => {
     // WHEN

--- a/packages/specs/schema/src/decorators/common/schema.ts
+++ b/packages/specs/schema/src/decorators/common/schema.ts
@@ -42,9 +42,7 @@ import {JsonEntityFn} from "./jsonEntityFn.js";
  */
 export function Schema(partialSchema: Partial<JsonSchemaObject> | JsonSchema) {
   return JsonEntityFn((entity) => {
-    Object.entries(partialSchema).forEach(([key, value]) => {
-      entity.schema.set(key, value);
-    });
+    entity.schema.assign(partialSchema);
   });
 }
 

--- a/packages/specs/schema/src/decorators/operations/returns.ts
+++ b/packages/specs/schema/src/decorators/operations/returns.ts
@@ -311,7 +311,7 @@ class ReturnDecoratorContext extends DecoratorContext<ReturnsChainedDecorators> 
     return this.manyOf("anyOf", types);
   }
 
-  schema(partial: Partial<JsonSchemaObject>) {
+  schema(partial: Partial<JsonSchemaObject> | JsonSchema) {
     this.addAction(() => {
       const schema = this.get("schema") as JsonSchema;
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

## Usage example

Fix issue with json-mapper when a schema is declared as follows:

```typescript
import {CollectionOf, Required} from "@tsed/schema";

class Test {
  @Required()
  @CollectionOf(Map)
  fields: Array<Map<string, string>> = [];
}

```


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [ ] Documentation
