### PR TITLE
fix(platform-serverless): add support of REQUEST type lambda authorizer

### DIFF
--- a/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.ts
+++ b/packages/platform/platform-serverless/src/builder/PlatformServerlessHandler.ts
@@ -49,7 +49,7 @@ export class PlatformServerlessHandler {
   }
 
   private async flush($ctx: ServerlessContext<ServerlessEvent>) {
-    const body: unknown = $ctx.isHttpEvent() ? await this.makeHttpResponse($ctx) : $ctx.response.getBody();
+    const body: unknown = $ctx.isHttpEvent() && !$ctx.isAuthorizerEvent() ? await this.makeHttpResponse($ctx) : $ctx.response.getBody();
 
     await this.injector.emit("$onResponse", $ctx);
 

--- a/packages/platform/platform-serverless/src/domain/ServerlessContext.spec.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessContext.spec.ts
@@ -40,6 +40,8 @@ describe("ServerlessContext", () => {
       expect(ctx.request.event).toEqual(ctx.response.event);
       expect(ctx.request.response).toEqual(ctx.response);
       expect(ctx.response.request).toEqual(ctx.request);
+      expect(ctx.isHttpEvent()).toBeTruthy();
+      expect(ctx.isAuthorizerEvent()).toBeFalsy();
     });
     it("should push callback with event headers", () => {
       const ctx = createServerlessContext({
@@ -78,6 +80,26 @@ describe("ServerlessContext", () => {
       expect(ctx.request.event).toEqual(ctx.response.event);
       expect(ctx.request.response).toEqual(ctx.response);
       expect(ctx.response.request).toEqual(ctx.request);
+    });
+    it("should accept auth event (request)", () => {
+      const ctx = createServerlessContext({
+        event: {
+          type: "REQUEST",
+          httpMethod: "GET"
+        } as never,
+        endpoint: {} as any
+      });
+      expect(ctx.isHttpEvent()).toBeTruthy();
+      expect(ctx.isAuthorizerEvent()).toBeTruthy();
+    });
+    it("should accept auth event (token)", () => {
+      const ctx = createServerlessContext({
+        event: {
+          type: "TOKEN"
+        } as never,
+        endpoint: {} as any
+      });
+      expect(ctx.isAuthorizerEvent()).toBeTruthy();
     });
   });
 });

--- a/packages/platform/platform-serverless/src/domain/ServerlessContext.ts
+++ b/packages/platform/platform-serverless/src/domain/ServerlessContext.ts
@@ -1,6 +1,6 @@
 import {DIContext, DIContextOptions} from "@tsed/di";
 import {JsonEntityStore} from "@tsed/schema";
-import {type APIGatewayProxyEvent, Context} from "aws-lambda";
+import {type APIGatewayProxyEvent, APIGatewayTokenAuthorizerEvent, Context} from "aws-lambda";
 import {ServerlessRequest} from "./ServerlessRequest.js";
 import {ServerlessResponse} from "./ServerlessResponse.js";
 import type {ServerlessResponseStream} from "./ServerlessResponseStream";
@@ -42,6 +42,10 @@ export class ServerlessContext<Event extends object = APIGatewayProxyEvent> exte
 
   isHttpEvent() {
     return "httpMethod" in this.event;
+  }
+
+  isAuthorizerEvent() {
+    return "type" in this.event && ["TOKEN", "REQUEST"].includes(this.event.type as string);
   }
 
   async destroy() {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| fix | No          |

---
## Information

This PR improve support of lambda authorizer for the REQUEST type event

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
