### PR TITLE
feat(schema): support multiple security schemes

### DIFF
--- a/packages/specs/schema/src/decorators/operations/security.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/security.spec.ts
@@ -54,6 +54,44 @@ describe("Security", () => {
       }
     });
   });
+  it("should store multiple security schemes (method)", () => {
+    class MyController {
+      @OperationPath("POST", "/")
+      @Security([{ "A": ["scope-1"] }, { "B": [], "C": ["scope-2", "scope-3"]}])
+      post() {}
+    }
+
+    expect(getSpec(MyController)).toEqual({
+      tags: [
+        {
+          name: "MyController"
+        }
+      ],
+      paths: {
+        "/": {
+          post: {
+            operationId: "myControllerPost",
+            parameters: [],
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            },
+            security: [
+              {
+                A: ["scope-1"]
+              },
+              {
+                B: [],
+                C: ["scope-2", "scope-3"]
+              }
+            ],
+            tags: ["MyController"]
+          }
+        }
+      }
+    })
+  });
   it("should store metadata (class)", () => {
     @Security("oauth", "user")
     class MyController {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

## Usage example

Support multiple authentication types as documented [here](https://swagger.io/docs/specification/authentication/#multiple):
```typescript
@Controller("/")
class ModelCtrl {
   @Security([{ "A": ["scope-1"] }, { "B": [], "C": ["scope-2", "scope-3"]}])
   async method() {}
}
```

## Todos

- [x] Tests
- [ ] Coverage
- [x] Example
- [ ] Documentation
