### PR TITLE
Fix autoinjectable with many args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,9 +307,7 @@ jobs:
       - name: Download Core vitest config files
         uses: actions/download-artifact@v4
         with:
-          path: .
           pattern: vitest-config-*
-          merge-multiple: true
       - name: "Git status"
         run: git status
       - name: Release packages

--- a/packages/di/src/common/decorators/autoInjectable.spec.ts
+++ b/packages/di/src/common/decorators/autoInjectable.spec.ts
@@ -115,6 +115,22 @@ describe("AutoInjectable", () => {
 
       new Test("test");
     });
+    it("should return a class that extends the original class (with 3 arguments)", () => {
+      @AutoInjectable()
+      class Test {
+        constructor(
+          public items: string[],
+          public group: string,
+          @Inject() logger?: Logger
+        ) {
+          expect(items).toEqual(["item1", "item2", "item3"]);
+          expect(group).toBe("group");
+          expect(logger).toBeInstanceOf(Logger);
+        }
+      }
+
+      new Test(["item1", "item2", "item3"], "group");
+    });
   });
   describe("when the instance is created outside of an injection context", () => {
     it("should throw an error", () => {

--- a/packages/di/src/common/services/InjectorService.ts
+++ b/packages/di/src/common/services/InjectorService.ts
@@ -94,7 +94,7 @@ export class InjectorService extends Container {
 
     for (let i = 0; i < length; i++) {
       if (args[i] !== undefined) {
-        list.push(args);
+        list.push(args[i]);
       } else {
         const value = deps[i];
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---


## Usage example


```typescript
@AutoInjectable()
      class Test {
        constructor(
          public items: string[],
          public group: string,
          @Inject() logger?: Logger
        ) {
          expect(items).toEqual(["item1", "item2", "item3"]);
          expect(group).toBe("group");
          expect(logger).toBeInstanceOf(Logger);
        }
      }

      new Test(["item1", "item2", "item3"], "group");

```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
