### PR TITLE
Remove dirname

### DIFF
--- a/docs/docs/snippets/configuration/bootstrap-with-node-config.ts
+++ b/docs/docs/snippets/configuration/bootstrap-with-node-config.ts
@@ -2,7 +2,7 @@ import {$log} from "@tsed/common";
 import {PlatformExpress} from "@tsed/platform-express";
 import {Server} from "./server";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname;
 
 // /!\ configuration file must be outside of your src directory
 process.env["NODE_CONFIG_DIR"] = `${rootDir}/../config`;

--- a/docs/docs/snippets/controllers/observable-stream-buffer-controller.ts
+++ b/docs/docs/snippets/controllers/observable-stream-buffer-controller.ts
@@ -4,7 +4,7 @@ import {Get} from "@tsed/schema";
 import {createReadStream, ReadStream} from "fs";
 import {Observable, of} from "rxjs";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname;
 
 @Controller("/")
 export class KindOfResponseCtrl {

--- a/packages/core/src/domain/AnyToPromise.spec.ts
+++ b/packages/core/src/domain/AnyToPromise.spec.ts
@@ -5,7 +5,7 @@ import {catchAsyncError} from "../utils/catchError.js";
 import {isStream} from "../utils/objects/isStream.js";
 import {AnyToPromise, AnyToPromiseStatus} from "./AnyToPromise.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe("AnyToPromise", () => {
   it("should handle sync value", async () => {

--- a/packages/engines/src/utils/getEngines.spec.ts
+++ b/packages/engines/src/utils/getEngines.spec.ts
@@ -4,7 +4,7 @@ import {join} from "path";
 
 import {getEngine, getEngines} from "./getEngines.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe("getEngines", () => {
   describe("getEngine()", () => {

--- a/packages/engines/test/getEngineFixture.ts
+++ b/packages/engines/test/getEngineFixture.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import {Engine} from "../src/components/Engine.js";
 import {engines} from "../src/index.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 interface EngineFixtureOptions {
   token: string | typeof Engine;

--- a/packages/engines/test/shared/dust.ts
+++ b/packages/engines/test/shared/dust.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {engines, requires} from "../../src/index.js";
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 export function test(name: string) {
   const user = {name: "Tobi"};

--- a/packages/engines/test/shared/filters.ts
+++ b/packages/engines/test/shared/filters.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {engines} from "../../src/index.js";
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 export function test(name: string) {
   const engine = engines.get(name)!;

--- a/packages/engines/test/shared/helpers.ts
+++ b/packages/engines/test/shared/helpers.ts
@@ -6,7 +6,7 @@ import {engines} from "../../src/index.js";
 
 const Sqrl = require("squirrelly");
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 const readFile = fs.readFile;
 const readFileSync = fs.readFileSync;

--- a/packages/engines/test/shared/includes.ts
+++ b/packages/engines/test/shared/includes.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {engines} from "../../src/index.js";
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 export function test(name: string) {
   const engine = engines.get(name)!;

--- a/packages/engines/test/shared/index.ts
+++ b/packages/engines/test/shared/index.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {engines, requires} from "../../src/index.js";
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 const readFile = fs.readFile;
 const readFileSync = fs.readFileSync;

--- a/packages/engines/test/shared/partials.ts
+++ b/packages/engines/test/shared/partials.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {engines} from "../../src/index.js";
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 const readFile = fs.readFile;
 const readFileSync = fs.readFileSync;
@@ -38,7 +38,7 @@ export function test(name: string) {
       });
       it("should support absolute path partial", async () => {
         const path = `${rootDir}/fixtures/${name}/partials.${name}`;
-        const locals = {user: user, partials: {partial: join(__dirname, "/../../test/fixtures/", name, "/user")}};
+        const locals = {user: user, partials: {partial: join(import.meta.dirname, "/../../test/fixtures/", name, "/user")}};
         const html = await engine.renderFile(path, locals);
         expect(html).toEqual("<p>Tobi</p>");
       });

--- a/packages/engines/test/shared/react.ts
+++ b/packages/engines/test/shared/react.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {engines} from "../../src/index.js";
 
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 
 const readFile = fs.readFile;
 const readFileSync = fs.readFileSync;

--- a/packages/graphql/typegraphql/test/app/Server.ts
+++ b/packages/graphql/typegraphql/test/app/Server.ts
@@ -20,7 +20,7 @@ import {User} from "./graphql/auth/User.js";
 import {AuthResolver} from "./graphql/index.js";
 import {pubSub} from "./graphql/pubsub/pubsub.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 const rootCert = join(rootDir, "../..");
 @Configuration({
   rootDir,

--- a/packages/orm/mikro-orm/test/helpers/Server.ts
+++ b/packages/orm/mikro-orm/test/helpers/Server.ts
@@ -8,7 +8,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/orm/mongoose/test/helpers/Server.ts
+++ b/packages/orm/mongoose/test/helpers/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/orm/objection/test/helpers/Server.ts
+++ b/packages/orm/objection/test/helpers/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/orm/objection/test/integration.spec.ts
+++ b/packages/orm/objection/test/integration.spec.ts
@@ -6,7 +6,7 @@ import {afterAll, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {OBJECTION_CONNECTION} from "..";
 import {User} from "./helpers/models/User.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe.skip("Objection integrations", () => {
   beforeAll(() => {

--- a/packages/orm/prisma/src/__mock__/createProjectFixture.ts
+++ b/packages/orm/prisma/src/__mock__/createProjectFixture.ts
@@ -1,7 +1,7 @@
 import {join} from "path";
 import {ModuleKind, Project, ScriptTarget} from "ts-morph";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 const SNAPSHOT_DIR = `${rootDir}/../../test/snapshots`;
 

--- a/packages/orm/prisma/src/generator.ts
+++ b/packages/orm/prisma/src/generator.ts
@@ -4,7 +4,7 @@ import {join} from "path";
 
 import {generate} from "./cli/prismaGenerator.js";
 
-const rootDir = __dirname; // automatically replaced by tsed tools on build
+const rootDir = import.meta.dirname; // automatically replaced by tsed tools on build
 export const defaultOutput = join(rootDir, "..", ".schema");
 export const packageDir = join(rootDir, "..", "..");
 

--- a/packages/platform/common/src/services/PlatformResponse.spec.ts
+++ b/packages/platform/common/src/services/PlatformResponse.spec.ts
@@ -4,7 +4,7 @@ import {createReadStream} from "fs";
 import {PlatformResponse} from "./PlatformResponse.js";
 import {PlatformTest} from "./PlatformTest.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 vi.mock("on-finished");
 

--- a/packages/platform/common/test/integration/groups.spec.ts
+++ b/packages/platform/common/test/integration/groups.spec.ts
@@ -12,7 +12,7 @@ import SuperTest from "supertest";
 
 import {BodyParams, Configuration, Controller, Get, PlatformTest} from "../../src/index.ts";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 class MyModel {
   @Groups("!creation")

--- a/packages/platform/common/test/integration/platform.spec.ts
+++ b/packages/platform/common/test/integration/platform.spec.ts
@@ -10,7 +10,7 @@ import SuperTest from "supertest";
 
 import {Configuration, Controller, Get, PlatformTest} from "../../src/index.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Controller("/hello")
 class TestHelloWorld {

--- a/packages/platform/platform-exceptions/src/domain/ExceptionSchema.spec.ts
+++ b/packages/platform/platform-exceptions/src/domain/ExceptionSchema.spec.ts
@@ -6,7 +6,7 @@ import {getJsonSchema, getSpec, OperationPath, Path, Returns, SpecTypes} from "@
 import {Ajv} from "ajv";
 import fs from "fs-extra";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 function getAjv() {
   return new Ajv({

--- a/packages/platform/platform-express/test/app/Server.ts
+++ b/packages/platform/platform-express/test/app/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import {Application} from "express";
 import session from "express-session";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/platform/platform-express/test/fullpayload.spec.ts
+++ b/packages/platform/platform-express/test/fullpayload.spec.ts
@@ -8,7 +8,7 @@ import SuperTest from "supertest";
 import {PlatformExpress} from "../src/index.js";
 import {rootDir, Server} from "./app/Server.js";
 
-const root = __dirname;
+const root = import.meta.dirname;
 
 const utils = PlatformTestSdk.create({
   rootDir,

--- a/packages/platform/platform-koa/test/app/Server.ts
+++ b/packages/platform/platform-koa/test/app/Server.ts
@@ -5,7 +5,7 @@ import {Configuration, Inject} from "@tsed/di";
 import Application from "koa";
 import session from "koa-session";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/platform/platform-test-sdk/src/tests/testMulter.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testMulter.ts
@@ -8,7 +8,7 @@ import {afterAll, beforeAll, describe, expect, it, vi} from "vitest";
 
 import {PlatformTestingSdkOpts} from "../interfaces/index.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 export class Task {
   @Property()
@@ -80,7 +80,7 @@ export function testMulter(options: PlatformTestingSdkOpts) {
   const buffer = Buffer.from("test content");
 
   const pkg = readPkgUp.sync({
-    cwd: __dirname
+    cwd: import.meta.dirname
   });
   const rootDir = join(dirname(pkg?.path || ""), "src");
 

--- a/packages/platform/platform-test-sdk/src/tests/testStream.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testStream.ts
@@ -7,7 +7,7 @@ import {afterAll, beforeAll, describe, expect, it} from "vitest";
 
 import {PlatformTestingSdkOpts} from "../interfaces/index.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Controller("/stream")
 class TestStreamCtrl {

--- a/packages/security/jwks/src/getJwks.spec.ts
+++ b/packages/security/jwks/src/getJwks.spec.ts
@@ -3,7 +3,7 @@ import {join} from "path";
 
 import {generateJwks, getJwks} from "./getJwks.js";
 
-const rootDir = join(__dirname, "__mocks__");
+const rootDir = join(import.meta.dirname, "__mocks__");
 
 describe("GetJwks", () => {
   beforeEach(() => {

--- a/packages/security/oidc-provider/test/app/Server.ts
+++ b/packages/security/oidc-provider/test/app/Server.ts
@@ -14,7 +14,7 @@ import {join} from "path";
 
 import {Accounts} from "./services/Accounts.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/security/oidc-provider/test/oidc.integration.spec.ts
+++ b/packages/security/oidc-provider/test/oidc.integration.spec.ts
@@ -10,7 +10,7 @@ import {InteractionsCtrl} from "./app/controllers/oidc/InteractionsCtrl.js";
 import {Server} from "./app/Server.js";
 import {Accounts} from "./app/services/Accounts.js";
 
-const testDir = __dirname;
+const testDir = import.meta.dirname;
 
 const utils = PlatformTestSdk.create({
   rootDir,

--- a/packages/security/passport/test/app/Server.ts
+++ b/packages/security/passport/test/app/Server.ts
@@ -14,7 +14,7 @@ import methodOverride from "method-override";
 import {AuthCtrl} from "./controllers/rest/auth/AuthCtrl.js";
 import {Account} from "./models/Account.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/specs/schema/src/utils/generateSpec.spec.ts
+++ b/packages/specs/schema/src/utils/generateSpec.spec.ts
@@ -18,7 +18,7 @@ import {Post} from "../decorators/operations/route.js";
 import {SpecTypes} from "../domain/SpecTypes.js";
 import {generateSpec} from "./generateSpec.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe("generateSpec()", () => {
   describe("OS 3.0.1", () => {

--- a/packages/specs/schema/test/helpers/validateSpec.ts
+++ b/packages/specs/schema/test/helpers/validateSpec.ts
@@ -4,7 +4,7 @@ import {v4} from "uuid";
 
 import {SpecTypes} from "../../src/index.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 export const validateSpec = async (spec: any, version = SpecTypes.SWAGGER) => {
   const file = `${rootDir}/spec-${v4()}.json`;

--- a/packages/specs/swagger/src/constants.ts
+++ b/packages/specs/swagger/src/constants.ts
@@ -1,4 +1,4 @@
 import getAbsoluteFSPath from "swagger-ui-dist/absolute-path.js";
 
 export const SWAGGER_UI_DIST = getAbsoluteFSPath();
-export const ROOT_DIR = __dirname;
+export const ROOT_DIR = import.meta.dirname;

--- a/packages/specs/swagger/test/app/Server.ts
+++ b/packages/specs/swagger/test/app/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/third-parties/agenda/test/helpers/Server.ts
+++ b/packages/third-parties/agenda/test/helpers/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/third-parties/components-scan/src/importFiles.spec.ts
+++ b/packages/third-parties/components-scan/src/importFiles.spec.ts
@@ -4,7 +4,7 @@ import {Test1} from "./__mock__/Test1.js";
 import {Test2} from "./__mock__/Test2.js";
 import {importFiles} from "./importFiles.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe("importFiles", () => {
   it("should import symbols", async () => {

--- a/packages/third-parties/components-scan/src/importProviders.spec.ts
+++ b/packages/third-parties/components-scan/src/importProviders.spec.ts
@@ -3,7 +3,7 @@ import {resolveControllers} from "@tsed/di";
 
 import {importProviders} from "./importProviders.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe("importProviders", () => {
   it("should load providers and merge configuration", async () => {

--- a/packages/third-parties/event-emitter/test/helpers/Server.ts
+++ b/packages/third-parties/event-emitter/test/helpers/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/third-parties/formio/test/app/Server.ts
+++ b/packages/third-parties/formio/test/app/Server.ts
@@ -14,7 +14,7 @@ import methodOverride from "method-override";
 
 import template from "../template/project.json";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/third-parties/pulse/test/helpers/Server.ts
+++ b/packages/third-parties/pulse/test/helpers/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/third-parties/socketio/test/app/Server.ts
+++ b/packages/third-parties/socketio/test/app/Server.ts
@@ -10,7 +10,7 @@ import methodOverride from "method-override";
 
 import {SocketPageCtrl} from "./controllers/pages/SocketPageCtrl.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 export {rootDir};
 

--- a/packages/third-parties/stripe/test/app/Server.ts
+++ b/packages/third-parties/stripe/test/app/Server.ts
@@ -5,7 +5,7 @@ import "@tsed/swagger";
 import {FileSyncAdapter} from "@tsed/adapters";
 import {Configuration} from "@tsed/di";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/third-parties/temporal/test/helpers/Server.ts
+++ b/packages/third-parties/temporal/test/helpers/Server.ts
@@ -7,7 +7,7 @@ import compress from "compression";
 import cookieParser from "cookie-parser";
 import methodOverride from "method-override";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 @Configuration({
   rootDir,

--- a/packages/third-parties/temporal/test/worker.integration.spec.ts
+++ b/packages/third-parties/temporal/test/worker.integration.spec.ts
@@ -27,7 +27,7 @@ describe("Temporal Worker", () => {
   it("should start a worker and execute decorated activities", async () => {
     const worker = await bootstrapWorker(Server, {
       worker: {
-        workflowsPath: join(__dirname, "workflows"),
+        workflowsPath: join(import.meta.dirname, "workflows"),
         taskQueue: "test"
       },
       connection: testEnv.nativeConnection

--- a/packages/third-parties/terminus/test/app/Server.ts
+++ b/packages/third-parties/terminus/test/app/Server.ts
@@ -9,7 +9,7 @@ import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import {Application} from "express";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 export {rootDir};
 
 @Configuration({

--- a/packages/third-parties/vike/src/middlewares/ViteRendererMiddleware.spec.ts
+++ b/packages/third-parties/vike/src/middlewares/ViteRendererMiddleware.spec.ts
@@ -3,7 +3,7 @@ import {PlatformTest} from "@tsed/common";
 import {ViteService} from "../services/ViteService.js";
 import {ViteRendererMiddleware} from "./ViteRendererMiddleware.js";
 
-const rootDir = __dirname; // automatically replaced by import.meta.dirname on build
+const rootDir = import.meta.dirname; // automatically replaced by import.meta.dirname on build
 
 describe("ViteRenderMiddleware", () => {
   describe("use()", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the method of determining the `rootDir` constant to use `import.meta.dirname`, aligning with ES module syntax across various files.
  
- **Bug Fixes**
	- No specific bug fixes were introduced; however, the changes enhance compatibility with modern JavaScript module standards.

- **Documentation**
	- Updated comments to reflect changes in the `rootDir` declaration and its implications for path resolution.

- **Chores**
	- Refactored multiple test files to ensure consistent use of `import.meta.dirname` instead of `__dirname`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->