### PR TITLE
fix(prisma): fix circular reference when column is optional

### DIFF
--- a/packages/orm/prisma/package.json
+++ b/packages/orm/prisma/package.json
@@ -25,6 +25,7 @@
     "test": "vitest run",
     "generate:postgres:esm": "yarn build && cd test/postgres-esm && prisma -v && prisma generate",
     "generate:mongo:esm": "yarn build && cd test/mongo-esm && prisma -v && prisma generate",
+    "generate:circular:esm": "yarn build && cd test/circular-ref && prisma -v && prisma generate",
     "test:ci": "vitest run --coverage.thresholds.autoUpdate=true"
   },
   "dependencies": {

--- a/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
+++ b/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
@@ -107,11 +107,11 @@ describe("transformScalarToType()", () => {
     });
     // @ts-ignore
     field.model.name = "User";
-    expect(transformScalarToType(field, ctx)).toEqual("UserModel | null");
-    expect(field.model.addImportDeclaration).not.toHaveBeenCalled();
+    expect(transformScalarToType(field, ctx)).toEqual("Relation<UserModel> | null");
+    expect(field.model.addImportDeclaration).toHaveBeenCalledWith("@tsed/core", "Relation", true);
   });
 
-  it("should transform User to User", () => {
+  it("should transform Role to User", () => {
     const ctx = createContextFixture();
     const field = createDmmfFieldFixture({
       kind: "object",
@@ -119,7 +119,7 @@ describe("transformScalarToType()", () => {
     });
     // @ts-ignore
     field.model.name = "User";
-    expect(transformScalarToType(field, ctx)).toEqual("RoleModel | null");
+    expect(transformScalarToType(field, ctx)).toEqual("Relation<RoleModel> | null");
     expect(field.model.addImportDeclaration).toHaveBeenCalledWith("./RoleModel", "RoleModel");
   });
 });

--- a/packages/orm/prisma/src/generator/transform/transformScalarToType.ts
+++ b/packages/orm/prisma/src/generator/transform/transformScalarToType.ts
@@ -31,6 +31,11 @@ export function transformScalarToType(field: DmmfField, ctx: TransformContext): 
     TSType += "[]";
   }
 
+  if (!isList && hasCircularRef && ["inputObjectTypes", "enumTypes"].includes(location)) {
+    hasCircularRef && !isList && field.model.addImportDeclaration("@tsed/core", "Relation", true);
+    TSType = `Relation<${TSType}>`;
+  }
+
   if (!isRequired) {
     if (model.isInputType) {
       TSType += " | undefined";
@@ -39,11 +44,6 @@ export function transformScalarToType(field: DmmfField, ctx: TransformContext): 
     }
   } else if (isNullable && !isList) {
     TSType += " | null";
-  }
-
-  if (isRequired && !isList && !isNullable && hasCircularRef && ["inputObjectTypes", "enumTypes"].includes(location)) {
-    hasCircularRef && !isList && field.model.addImportDeclaration("@tsed/core", "Relation", true);
-    TSType = `Relation<${TSType}>`;
   }
 
   return TSType;

--- a/packages/orm/prisma/src/generator/utils/__snapshots__/generateModels.spec.ts.snap
+++ b/packages/orm/prisma/src/generator/utils/__snapshots__/generateModels.spec.ts.snap
@@ -21,6 +21,7 @@ exports[`generateModels > should generate models (post) 1`] = `
 "import { Post } from "../client/index.js";
 import { Integer, Required, Property, Allow } from "@tsed/schema";
 import { UserModel } from "./UserModel.js";
+import type { Relation } from "@tsed/core";
 
 export class PostModel implements Post {
   @Property(Number)
@@ -30,7 +31,7 @@ export class PostModel implements Post {
 
   @Property(() => UserModel)
   @Allow(null)
-  user: UserModel | null;
+  user: Relation<UserModel> | null;
 
   @Property(Number)
   @Integer()
@@ -44,6 +45,7 @@ export class PostModel implements Post {
 exports[`generateModels > should generate models (user) 1`] = `
 "import { User } from "../client/index.js";
 import { Integer, Required, Property, Groups, Format, Email, Description, Allow, Enum, CollectionOf } from "@tsed/schema";
+import type { Relation } from "@tsed/core";
 import { Role } from "../enums/index.js";
 import { PostModel } from "./PostModel.js";
 
@@ -84,11 +86,11 @@ export class UserModel implements User {
 
   @Property(() => UserModel)
   @Allow(null)
-  successor: UserModel | null;
+  successor: Relation<UserModel> | null;
 
   @Property(() => UserModel)
   @Allow(null)
-  predecessor: UserModel | null;
+  predecessor: Relation<UserModel> | null;
 
   @Required()
   @Enum(Role)

--- a/packages/orm/prisma/test/circular-ref/package.json
+++ b/packages/orm/prisma/test/circular-ref/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@tsed/prisma-test",
+  "type": "commonjs",
+  "devDependencies": {
+    "prisma": "^4.0.0"
+  },
+  "dependencies": {
+    "@prisma/client": "^4.0.0"
+  }
+}

--- a/packages/orm/prisma/test/circular-ref/prisma/schema.prisma
+++ b/packages/orm/prisma/test/circular-ref/prisma/schema.prisma
@@ -1,0 +1,32 @@
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  binaryTargets   = ["native", "windows", "debian-openssl-1.1.x"]
+  output          = "../prisma/generated/client"
+}
+
+generator tsed {
+  provider                 = "node ../../lib/cjs/generator.js"
+  output                   = "../prisma/generated/tsed"
+  emitDMMF                 = true
+}
+
+model Conversation {
+  id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  assignmentId String?     @map("assignment_id") @db.Uuid
+  assignment   Assignment? @relation(fields: [assignmentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@map("conversation")
+}
+
+model Assignment {
+  id                String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  conversations     Conversation[]
+
+  @@map("assignment")
+}

--- a/packages/orm/prisma/test/snapshots/generate_code/models/PostModel.ts
+++ b/packages/orm/prisma/test/snapshots/generate_code/models/PostModel.ts
@@ -1,6 +1,7 @@
 import { Post } from "../client/index.js";
 import { Integer, Required, Property, Allow } from "@tsed/schema";
 import { UserModel } from "./UserModel.js";
+import type { Relation } from "@tsed/core";
 
 export class PostModel implements Post {
   @Property(Number)
@@ -10,7 +11,7 @@ export class PostModel implements Post {
 
   @Property(() => UserModel)
   @Allow(null)
-  user: UserModel | null;
+  user: Relation<UserModel> | null;
 
   @Property(Number)
   @Integer()

--- a/packages/orm/prisma/test/snapshots/generate_code/models/UserModel.ts
+++ b/packages/orm/prisma/test/snapshots/generate_code/models/UserModel.ts
@@ -1,5 +1,6 @@
 import { User } from "../client/index.js";
 import { Integer, Required, Property, Groups, Format, Email, Description, Allow, Enum, CollectionOf } from "@tsed/schema";
+import type { Relation } from "@tsed/core";
 import { Role } from "../enums/index.js";
 import { PostModel } from "./PostModel.js";
 
@@ -40,11 +41,11 @@ export class UserModel implements User {
 
   @Property(() => UserModel)
   @Allow(null)
-  successor: UserModel | null;
+  successor: Relation<UserModel> | null;
 
   @Property(() => UserModel)
   @Allow(null)
-  predecessor: UserModel | null;
+  predecessor: Relation<UserModel> | null;
 
   @Required()
   @Enum(Role)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new script for generating Prisma models specifically for circular references.
  - Added a new Prisma schema configuration for managing relationships between `Conversation` and `Assignment` models.

- **Bug Fixes**
  - Enhanced handling of relationships in the transformation logic for circular references in Prisma models.

- **Documentation**
  - Updated the `PostModel` and `UserModel` classes to reflect new relation-based property types.

- **Chores**
  - Created a new package for testing circular references in Prisma.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->