### PR TITLE
feat(di): add support chain interceptor on the same method

### DIFF
--- a/packages/di/src/common/decorators/intercept.ts
+++ b/packages/di/src/common/decorators/intercept.ts
@@ -1,4 +1,4 @@
-import {classOf, decorateMethodsOf, DecoratorParameters, decoratorTypeOf, DecoratorTypes, Store, Type} from "@tsed/core";
+import {classOf, decorateMethodsOf, DecoratorParameters, decoratorTypeOf, DecoratorTypes, nameOf, Store, Type} from "@tsed/core";
 
 import {DI_INTERCEPTOR_OPTIONS, DI_INVOKE_OPTIONS} from "../constants/constants.js";
 import {inject} from "../fn/inject.js";
@@ -19,7 +19,7 @@ export function bindIntercept(target: any, propertyKey: string | symbol, token: 
 
   Store.fromMethod(klass, propertyKey).set(DI_INTERCEPTOR_OPTIONS, options);
 
-  descriptor!.value = function (...args: any[]) {
+  function newMethod(...args: any[]) {
     const next = (err?: Error) => {
       if (!err) {
         return originalMethod.apply(this, args);
@@ -50,7 +50,12 @@ export function bindIntercept(target: any, propertyKey: string | symbol, token: 
       },
       next
     );
-  };
+  }
+
+  descriptor!.value = newMethod;
+
+  Reflect.deleteProperty(klass.prototype, propertyKey);
+  Reflect.defineProperty(klass.prototype, propertyKey, descriptor!);
 
   return descriptor;
 }


### PR DESCRIPTION
Closes: #2914

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

Add chained interceptor support

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `MyInterceptor2` class for enhanced interception capabilities.
	- Added a new `chained` method in `ServiceTest` to apply multiple interceptors in sequence.
	- Added a `reverseChained` method in `ServiceTest` to apply interceptors in reverse order.

- **Bug Fixes**
	- Updated return values for interceptors to reflect new behavior in tests.

- **Refactor**
	- Improved method binding process in the `bindIntercept` function for better error handling and token management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->