### PR TITLE
docs: restore some page to avoid seo error and add canonical url

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,7 +11,7 @@ export default defineConfig({
   lastUpdated: true,
   description: "Ts.ED offers a flexible and easy-to-learn structure designed to enhance the developer experience. It provides decorators, guidelines, and supports Node.js, Bun.js, Express, Koa, CLI, and serverless architectures (e.g., AWS).",
   sitemap: {
-    hostname: "https://tsed.io"
+    hostname: "https://tsed.dev"
   },
 
   head: [
@@ -33,7 +33,7 @@ export default defineConfig({
       {async: "", src: "https://www.googletagmanager.com/gtag/js?id=G-3M3Q4QME6H&cx=c&_slc=1"}
     ],
     [
-      'script',
+      "script",
       {},
       `window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
@@ -594,5 +594,16 @@ export default defineConfig({
     config: (md) => {
       md.use(apiAnchor);
     }
+  },
+  transformPageData(pageData) {
+    const canonicalUrl = `https://tsed.dev/${pageData.relativePath}`
+      .replace(/index\.md$/, "")
+      .replace(/\.md$/, ".html");
+
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push([
+      "link",
+      {rel: "canonical", href: canonicalUrl}
+    ]);
   }
 });

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,187 @@
+---
+contributors:
+  classes: bg-gray-lighter
+  title: Our awesome <b>contributors</b>
+  cta:
+    label: Become contributor
+    url: /contributing.html
+  badge:
+    width: 45
+    bgColor: white
+backers:
+  type: cols
+  title: Our <b>Backers</b>
+  description: Thank you to all our backers who contributes to our project! 🙏
+  cta:
+    label: Become Backers
+    url: https://opencollective.com/tsed#backers
+sponsors:
+  type: cols
+  classes:
+  title: Our <b>Sponsors / Partners</b>
+  description: Support this project by becoming a sponsor. Your logo will show up here with a link to your website.
+  image:
+    src: /sponsors.svg
+    href: http://www.freepik.com
+    title: Designed by pch.vector / Freepik
+  cta:
+    label: Become a sponsor
+    url: /support.html
+---
+
+# Contributing
+
+## Introduction
+
+First, thank you for considering contributing to Ts.ED! It is people like you that make the open source community such a great community! 😊
+
+We welcome any type of contribution, not just code. You can help with:
+
+- QA: file bug reports, the more details you can give the better (e.g. screenshots with the console open).
+- Marketing: writing blog posts, how to's, printing stickers....
+- Community: presenting the project at meetups, organizing a dedicated meetup for the local community....
+- Code: take a look at the [open issues](https://github.com/tsedio/tsed/issues). Even if you can't write code, commenting on them and showing that you care about a given issue matters. It helps us triage them.
+- Money: we welcome financial contributions in full transparency on our [open collective](https://opencollective.com/tsed).
+
+## Your First Contribution
+
+Working on your first Pull Request? You can learn how from this free series: [How to Contribute to an Open Source Project on GitHub](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
+
+## Submitting code
+
+Any code change should be submitted as a pull request. The description should explain what the code does and give steps to execute it. The pull request should also contain tests.
+
+The bigger the pull request, the longer it will take to review and merge. Try to break down large pull requests in smaller chunks that are easier to review and merge. It is also always helpful to have some context for your pull request. What was the purpose? Why does it matter to you?
+
+::: warning
+Ts.ED project uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) as format commit message.
+
+Release note and tagging version are based on the message commits.
+If you don't follow the format, our CI won't be able to increment the version correctly and your feature won't be released on NPM.
+
+To write your commit message, see [convention page here](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
+:::
+
+## Financial contributions
+
+We also welcome financial contributions in full transparency on our open collective. Anyone can file an expense. If the expense makes sense for the development of the community, it will be "merged" in the ledger of our [open collective](https://opencollective.com/tsed) by the core contributors, and the person who filed the expense will be reimbursed.
+
+## Questions
+
+If you have any questions, create an [issue](https://github.com/tsedio/tsed/issues) (protip: do a quick search first to see if someone else didn't ask the same question before!). You can also reach us at hello@tsed.opencollective.com.
+
+## How to work on Ts.ED
+
+### Setup
+
+Clone your fork of the repository:
+
+```bash
+$ git clone https://github.com/YOUR_USERNAME/tsed.git
+```
+
+Install npm dependencies with yarn (not with NPM!):
+
+```bash
+yarn
+```
+
+> After installing dependencies, yarn/npm run the `postinstall` hook and mount all packages with `npm link` (e.g. `yarn run repo:bootstrap`).
+
+Compile TypeScript:
+
+```bash
+tsc
+# or
+yarn tsc
+# or
+npm run tsc
+```
+
+### Test
+
+```bash
+yarn test
+# or
+npm run test
+```
+
+### Gflow (optional)
+
+[Gflow](https://www.npmjs.com/package/gflow) is a command line tool to help developers with the Git process used in Ts.ED.
+
+Gflow helps you create a branch from production, rebase and run the tests before pushing your branch on your remote repository.
+
+```bash
+npm install -g gflow
+```
+
+### Start a feature branch
+
+```bash
+git fetch
+git branch --no-track -b feat-branch-name origin/production  # !IMPORTANT
+yarn
+
+## OR
+gflow new feat name_of_feat
+```
+
+### Commit & Push a feature
+
+This command rebases your branch feature from the production branch, runs the test, and pushes your branch.
+
+```bash
+git commit -m "feat(domain): Your message"
+```
+
+> To write your commit message see [convention page](https://www.conventionalcommits.org/en/v1.0.0-beta.4/).
+
+Then:
+
+```bash
+npm run test
+git fetch
+git rebase origin/production
+git push -f
+
+# OR using gflow (run fetch, rebase and push for you)
+gflow push
+```
+
+When your feature is ready to review, you can open a PR on Ts.ED github.
+
+### Finish a feature (repo owner and maintainers)
+
+After the PR has been accepted, the feature will be automatically merged on the master branch, but
+your feature isn't merged with the production branch.
+
+To publish your feature on the production branch you need to run this command:
+
+```bash
+gflow finish
+```
+
+::: tip NOTE
+This action works only on the Ts.ED repository (not on your fork).
+:::
+
+### Write documentation
+
+Ts.ED uses docsify to convert markdown to HTML. In addition, all documentation in your code will be used to generate
+the API documentation. To preview your comments on a class you can run this command:
+
+```
+npm run doc:serve
+```
+
+### Guidelines
+
+- Ts.ED follows the git flow to generate a release note. To write your commit message see [convention page](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit).
+- Please try to combine multiple commits before pushing.
+- Please use TDD when fixing bugs. This means that you should write a unit test that fails because it reproduces the issue, fixes the issue, and then finally runs the test to ensure that the issue has been resolved. This helps us prevent fixed bugs from happening again in the future.
+- Please keep the test coverage at 100%. Write additional unit tests if necessary.
+- Please create an issue before sending a PR if it is going to change the public interface of Ts.ED or include significant architecture changes.
+- Feel free to ask for help from other members of the Ts.ED team.
+
+<!-- This `CONTRIBUTING.md` is based on @nayafia's template https://github.com/nayafia/contributing-template -->

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,0 +1,463 @@
+---
+head:
+  - - meta
+    - name: description
+      content: Documentation over the server configuration. Ts.ED is built on top of Express/Koa and use TypeScript language.
+  - - meta
+    - name: keywords
+      content: configuration ts.ed express typescript node.js javascript decorators mvc class models
+---
+
+This page is a legacy version of the documentation.
+
+Go to the latest [configuration page version](/docs/configuration/index.md).
+
+# Configuration
+
+@@Configuration@@ lets you quickly configure your server via decorator. This decorator takes your configuration and
+merges it with the default server configuration.
+
+The default configuration is as follows:
+
+```json
+{
+  "env": "development",
+  "port": 8080,
+  "debug": false,
+  "httpsPort": 8000,
+  "uploadDir": "./uploads"
+}
+```
+
+You can customize your configuration as follows on `Server.ts`level:
+
+<<< @/docs/configuration/snippets/server.ts
+
+or when you bootstrap your Server (e.g. `index.ts`):
+
+<<< @/docs/configuration/snippets/bootstrap.ts
+
+::: tip Note
+Ts.ED supports [ts-node](https://github.com/TypeStrong/ts-node). Ts extension will be replaced by a Js extension if
+ts-node isn't the runtime.
+:::
+
+## Options
+
+### rootDir
+
+- type: `string`
+
+The root directory where you build run project. By default, it is equal to `process.cwd()`.
+
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  rootDir: process.cwd()
+})
+export class Server {}
+```
+
+### env
+
+- type: @@Env@@
+
+The environment profiles. By default the environment profile is equal to `NODE_ENV`.
+
+```typescript
+import {Env} from "@tsed/core";
+import {Configuration, Constant} from "@tsed/di";
+
+@Configuration({
+  env: Env.PROD
+})
+export class Server {
+  @Constant("env")
+  env: Env;
+
+  $beforeRoutesInit() {
+    if (this.env === Env.PROD) {
+      // do something
+    }
+  }
+}
+```
+
+### httpPort
+
+- type: `string` | `number` | `false`
+
+Port number for the [HTTP.Server](https://nodejs.org/api/http.html#http_class_http_server).
+Set `false` to disable the http port.
+
+### httpsPort
+
+- type: `string` | `number` | `false`
+
+Port number for the [HTTPs.Server](https://nodejs.org/api/https.html#https_class_https_server).
+
+### httpsOptions
+
+- type: [Https.ServerOptions](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener)
+  - `key` &lt;string&gt; | &lt;string[]&gt; | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer)
+    | &lt;Object[]&gt;: The private key of the server in PEM format. To support multiple keys using different
+    algorithms, an array can be provided either as a plain array of key strings or an array of objects in the
+    format `{pem: key, passphrase: passphrase}`. This option is required for ciphers making use of private keys.
+  - `passphrase` &lt;string&gt; A string containing the passphrase for the private key or pfx.
+  - `cert` &lt;string&gt; | &lt;string[]&gt;
+    | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer)
+    | [&lt;Buffer[]&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer): A string, Buffer, array of strings,
+    or array of Buffers containing the certificate key of the server in PEM format. (Required)
+  - `ca` &lt;string&gt; | &lt;string[]&gt; | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer)
+    | [&lt;Buffer[]&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer): A string, Buffer, array of strings,
+    or array of Buffers of trusted certificates in PEM format. If this is omitted, several well known "root" CAs (like
+    VeriSign) will be used. These are used to authorize connections.
+
+See the [HTTPs project example](https://github.com/tsedio/example-ts-express-decorator/tree/2.0.0/example-https)
+
+### mount
+
+- type: @@EndpointDirectoriesSettings@@
+
+Mount all given controllers and map controllers to the corresponding endpoints.
+
+Ts.ED provides the possibility to mount multiple Rest paths instead of the default path `/rest`.
+This option will allow you to define a version for an endpoint and select which controllers you want to associate with
+the given path.
+
+<<< @/docs/configuration/snippets/server-endpoint-versionning.ts
+
+It is also possible to split the configuration by using the @@Module@@:
+
+<Tabs class="-code">
+  <Tab label="Server.ts">
+
+<<< @/docs/configuration/snippets/server-endpoint-versionning-with-module.ts
+
+  </Tab>
+  <Tab label="ModuleV1.ts">
+
+<<< @/docs/configuration/snippets/modulev1-endpoint-versionning.ts
+
+  </Tab>  
+  <Tab label="ModuleV0.ts">
+
+<<< @/docs/configuration/snippets/modulev0-endpoint-versionning.ts
+
+  </Tab>    
+</Tabs>
+
+### ~~componentsScan~~ (deprecated)
+
+- type: `string[]`
+
+List of glob pattern to scan directories which contains [Services](/docs/services)
+or [Middlewares](/docs/middlewares).
+
+### middlewares
+
+- type: `PlatformMiddlewareSettings[]`
+
+A middleware list (Express.js, Ts.ED, Koa, etc...) must be loaded on the `$beforeRoutesInit` hook or on the specified
+hook.
+In addition, it's also possible to configure the environment for which the middleware should be loaded.
+
+Since v7.4, the middlewares options accepts multiple format to register a native middleware (Express, Koa) and/or a
+Ts.ED middleware:
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+
+@Configuration({
+  middlewares: [
+    {use: "helmet", hook: "$afterInit", options: {contentSecurityPolicy: false}},
+    {use: EnsureHttpsMiddleware, env: Env.PROD},
+    "cors",
+    cookieParser(),
+    "json-parser", // you can add also the text-parser
+    {use: "encodedurl-parser", options: {extended: true}},
+    "compression",
+    "method-override",
+    AuthTokenMiddleware
+  ]
+})
+export class Server {}
+```
+
+::: warning Order priority
+The middlewares added through `middlewares` options will always be registered after the middlewares registered through
+the hook methods!
+:::
+
+Here is an equivalent example to load middlewares with the hooks:
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+import {Env} from "@tsed/core";
+import bodyParser from "body-parser";
+
+@Configuration({})
+export class Server {
+  $afterInit() {
+    this.app.use(helmet({contentSecurityPolicy: false}));
+  }
+
+  $beforeRoutesInit() {
+    if (this.env === Env.PROD) {
+      this.app.use(EnsureHttpsMiddleware);
+    }
+
+    this.app
+      .use(cors())
+      .use(cookieParser())
+      .use(bodyParser.json())
+      .use(bodyParser.urlencoded({extended: true}))
+      .use(compress({}))
+      .use(methodOverride())
+      .use(AuthTokenMiddleware);
+
+    return null;
+  }
+}
+```
+
+::: tip
+
+Prefer the 1st example if you use @@RawBodyParams@@ in your application. Ts.ED will automatically configure the json-parser and urlencoded parser with the rawBody parser.
+
+:::
+
+### rawBody <Badge text="v7.4.0+" />
+
+This option force the rawBody parser if Ts.ED doesn't detect the @@RawBodyParams@@ usage in your code.
+
+```diff
+@Configuration({
++  rawBody: true,
++  middlewares: [
++     {use: 'json-parser'},
++     {use: 'urlencoded-parser', options: {extended: true})
++  ]
+})
+export class Server {
+  @Inject()
+  protected app: PlatformApplication;
+
+  $beforeRoutesInit() {
+-    this.app
+-      .use(bodyParser.json())
+-      .use(bodyParser.urlencoded({extended: true}));
+  }
+}
+```
+
+### imports
+
+- type: `Type<any>[]`
+
+Add providers or modules here. These modules or provider will be built before the server itself.
+
+<Tabs class="-code">
+  <Tab label="Server.ts">
+
+<<< @/docs/configuration/snippets/server-options-imports.ts
+
+  </Tab>
+  <Tab label="MyModule.ts">
+
+<<< @/docs/configuration/snippets/module-options-imports.ts
+
+  </Tab>
+</Tabs>
+
+### logger
+
+- type: @@PlatformLoggerSettings@@
+
+Logger configuration. See [logger section for more detail](/docs/logger).
+
+### views
+
+Object to configure Views engines with Ts.ED engines or Consolidate (deprecated). See more
+on [View engine](/docs/templating).
+
+### acceptMimes
+
+Configure the mimes accepted by default for each request by the server.
+
+### responseFilters
+
+A list of response filters must be called before returning a response to the consumer. See more
+on [Response filters](/docs/response-filter).
+
+### multer
+
+Object configure Multer. See more on [Upload file](/docs/upload-files).
+
+## router
+
+```typescript
+@Configuration({
+  router: {
+    appendChildrenRoutesFirst: true
+  }
+})
+```
+
+### router.appendChildrenRoutesFirst
+
+- type: `boolean`
+
+Append children routes before the controller routes itself. Defaults to `false`, but will be deprecated and set to `true` in next major version.
+
+## jsonMapper
+
+```typescript
+@Configuration({
+  jsonMapper: {
+    additionalProperties: false,
+    disableUnsecureConstructor: true,
+    strictGroups: false
+  }
+})
+```
+
+### jsonMapper.additionalProperties
+
+Enable additional properties on model. By default, `false`. Enable this option is dangerous and may be a potential
+security issue.
+
+### jsonMapper.disableUnsecureConstructor
+
+Pass the plain object to the model constructor. By default, `true`.
+
+It may be a potential security issue if you have as constructor with this followings code:
+
+```typescript
+class MyModel {
+  constructor(obj: any = {}) {
+    Object.assign(this, obj); // potential prototype pollution
+  }
+}
+```
+
+### jsonMapper.strictGroups
+
+Enable strict mode for `@Groups` decorator. By default, `false`. See [Groups](/docs/model.md#groups-strict-mode) for more information.
+
+::: warning
+The `strictGroups` option is enabled by default in the next major version of Ts.ED.
+:::
+
+## Platform Options
+
+See specific platform options for:
+
+- [Express.js](/docs/configuration/express)
+- [Koa.js](/docs/configuration/koa)
+
+## HTTP & HTTPs server
+
+### Change address
+
+It's possible to change the HTTP and HTTPS server address as follows:
+
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  httpPort: "127.0.0.1:8081",
+  httpsPort: "127.0.0.2:8082"
+})
+export class Server {}
+```
+
+### Random port
+
+Random port assignment can be enabled with the value `0`. The port assignment will be delegated to the OS.
+
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  httpPort: "127.0.0.1:0",
+  httpsPort: "127.0.0.2:0"
+})
+export class Server {}
+```
+
+Or:
+
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  httpPort: 0,
+  httpsPort: 0
+})
+export class Server {}
+```
+
+### Disable HTTP
+
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  httpPort: false
+})
+export class Server {}
+```
+
+### Disable HTTPS
+
+```typescript
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  httpsPort: false
+})
+export class Server {}
+```
+
+## Get configuration
+
+The configuration can be reused throughout your application in different ways.
+
+- With dependency injection in [Controller](/docs/controllers), [Middleware](/docs/middlewares)
+  , [Pipe](/docs/pipes) or any [Injectable](/docs/services) services.
+- With the decorators @@Constant@@ and @@Value@@.
+
+### From service (DI)
+
+```typescript
+import {Configuration, Injectable} from "@tsed/di";
+
+@Injectable() // or Controller or Middleware
+export class MyService {
+  constructor(@Configuration() configuration: Configuration) {}
+}
+```
+
+### From decorators
+
+Decorators @@Constant@@ and @@Value@@ can be used in all classes including:
+
+- [Provider](/docs/providers),
+- [Interceptor](/docs/interceptors),
+- [Service](/docs/services),
+- [Controller](/docs/controllers),
+- [Middleware](/docs/middlewares).
+
+@@Constant@@ and @@Value@@ accepts an expression as parameters to inspect the configuration object and return the value.
+
+<<< @/docs/configuration/snippets/binding-configuration.ts
+
+::: warning
+@@Constant@@ returns an Object.freeze() value.
+:::
+
+::: tip NOTE
+The values for the decorated properties aren't available on constructor. Use \$onInit() hook to use the value.
+:::

--- a/docs/warehouse/index.md
+++ b/docs/warehouse/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+head:
+  - - meta
+    - name: description
+      content: Discover our list of plugins to extends your Ts.ED project. Created by the Ts.ED team and community.
+  - - meta
+    - name: keywords
+      content: Ts.ED nodejs express typescript javascript es6 decorators mvc model ioc service model middleware socket.io swagger typeorm mongoose ajv
+---
+
+<Warehouse />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Updated the sitemap hostname to "https://tsed.dev".
  - Introduced a new method for transforming page data to include canonical URLs.
  - Added a new documentation section for contributors, backers, and sponsors to enhance community engagement.
  - Launched a new documentation page listing plugins for Ts.ED projects.

- **Documentation**
  - Enhanced server configuration documentation with detailed instructions and examples.
  - Added SEO meta tags to improve visibility and context for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->