### PR TITLE
fix(prisma): add useDefineForClassFields option to default ts compilation option

### DIFF
--- a/packages/orm/prisma/src/generator/generateCode.ts
+++ b/packages/orm/prisma/src/generator/generateCode.ts
@@ -15,7 +15,8 @@ const baseCompilerOptions: CompilerOptions = {
   module: ModuleKind.ESNext,
   emitDecoratorMetadata: true,
   experimentalDecorators: true,
-  esModuleInterop: true
+  esModuleInterop: true,
+  useDefineForClassFields: false
 };
 
 export interface GenerateCodeOptions {
@@ -31,7 +32,9 @@ export async function generateCode(dmmf: DMMF.Document, options: GenerateCodeOpt
   const project = new Project({
     compilerOptions: {
       ...baseCompilerOptions,
-      ...(emitTranspiledCode && {declaration: true})
+      ...(emitTranspiledCode && {
+        declaration: true
+      })
     }
   });
 

--- a/packages/orm/prisma/vitest.config.mts
+++ b/packages/orm/prisma/vitest.config.mts
@@ -10,10 +10,10 @@ export default defineConfig(
       coverage: {
         ...presets.test.coverage,
         thresholds: {
-          statements: 91.11,
+          statements: 91.02,
           branches: 92.2,
           functions: 92.59,
-          lines: 91.11
+          lines: 91.02
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated configuration options for TypeScript class field definitions.
	- Reformatted code for improved clarity in the project instantiation section.
	- Adjusted test coverage thresholds for Vitest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->