### PR TITLE
fix: Fix documentation url in the ReadMe

### DIFF
--- a/packages/specs/openspec/readme.md
+++ b/packages/specs/openspec/readme.md
@@ -33,7 +33,7 @@ OpenSpec2 and OpenSpec3 interfaces declarations for TypeScript application.
 
 ## Documentation
 
-Documentation is available on [https://tsed.dev](https://tsed.devtutorials/swagger.html)
+Documentation is available on [https://tsed.dev](https://tsed.dev/tutorials/swagger.html)
 
 ## Installation
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

## Documentation

Fixed the documentation link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation links for Swagger tutorials.
	- Improved phrasing for contributing guidelines link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->