### PR TITLE
fix(platform-http): doesn't call inject.get when provider is instance…

### DIFF
--- a/packages/platform/platform-http/src/common/utils/createInjector.ts
+++ b/packages/platform/platform-http/src/common/utils/createInjector.ts
@@ -49,7 +49,9 @@ export function createInjector(settings: Partial<TsED.Configuration>) {
     inj.addProvider(token, provider);
   });
 
-  DEFAULT_PROVIDERS.map((provider) => inj.get(provider.token));
+  DEFAULT_PROVIDERS.filter((provider) => ![PlatformResponse, PlatformRequest].includes(provider.token as never)).map((provider) => {
+    return inj.get(provider.token);
+  });
 
   return inj;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Refined provider management within the injector by excluding specific providers from processing.

- **Bug Fixes**
	- Improved control flow for retrieving providers, ensuring more accurate instance management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->