### PR TITLE
fix: fix peerDependencies flag

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -14,9 +14,7 @@
   "version": "8.4.0",
   "command": {
     "bootstrap": {
-      "npmClientArgs": [
-        "--no-package-lock"
-      ]
+      "npmClientArgs": ["--no-package-lock"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@swc-node/register": "1.10.9",
     "@swc/core": "1.7.28",
     "@swc/helpers": "0.5.13",
-    "@tsed/monorepo-utils": "2.3.9",
+    "@tsed/monorepo-utils": "2.3.11",
     "@tsed/ts-doc": "5.0.0",
     "@types/axios": "0.14.0",
     "@types/globby": "9.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
   "browser": "./lib/browser/core.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/core.umd.min.js",
       "import": "./lib/esm/index.js",

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -10,7 +10,7 @@
   "browser": "./lib/browser/di.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/di.umd.min.js",
       "import": "./lib/esm/index.js",
@@ -43,10 +43,10 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/hooks": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/hooks": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/schema": "8.4.0"
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/graphql/apollo/package.json
+++ b/packages/graphql/apollo/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -44,10 +44,10 @@
   },
   "peerDependencies": {
     "@apollo/server": ">=4.10.4",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/platform-http": ">=8.0.0",
     "graphql": ">16.0.0"
   }
 }

--- a/packages/graphql/graphql-ws/package.json
+++ b/packages/graphql/graphql-ws/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -35,10 +35,10 @@
     "typescript": "5.4.5"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/platform-http": ">=8.0.0",
     "graphql-ws": ">=5.14.2"
   }
 }

--- a/packages/graphql/typegraphql/package.json
+++ b/packages/graphql/typegraphql/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -10,7 +10,7 @@
   "browser": "./lib/browser/core.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/hooks.umd.min.js",
       "import": "./lib/esm/index.js",

--- a/packages/orm/adapters-redis/package.json
+++ b/packages/orm/adapters-redis/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -37,11 +37,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/adapters": "8.4.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/hooks": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/adapters": ">=8.0.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/hooks": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
     "ioredis": ">=5.2.3",
     "ioredis-mock": ">=8.2.2",
     "uuid": "^10.0.0"

--- a/packages/orm/adapters/package.json
+++ b/packages/orm/adapters/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -47,12 +47,12 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/ajv": "8.4.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/ajv": ">=8.0.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/ajv": {

--- a/packages/orm/ioredis/package.json
+++ b/packages/orm/ioredis/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -38,8 +38,8 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
     "ioredis": ">=5.2.3",
     "ioredis-mock": ">=8.2.2"
   }

--- a/packages/orm/mikro-orm/package.json
+++ b/packages/orm/mikro-orm/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -45,9 +45,9 @@
   },
   "peerDependencies": {
     "@mikro-orm/core": ">=4.5.9",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/platform-http": "8.4.0"
+    "@tsed/platform-http": ">=8.0.0"
   }
 }

--- a/packages/orm/mongoose/package.json
+++ b/packages/orm/mongoose/package.json
@@ -16,7 +16,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -49,12 +49,12 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/ajv": "8.4.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/ajv": ">=8.0.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/schema": "8.4.0",
+    "@tsed/schema": ">=8.0.0",
     "mongoose": ">=6.0.0"
   }
 }

--- a/packages/orm/objection/package.json
+++ b/packages/orm/objection/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -41,11 +41,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/ajv": "8.4.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/ajv": ">=8.0.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "knex": ">=0.94.0",
     "objection": ">=2.0.0"
   },

--- a/packages/orm/prisma/package.json
+++ b/packages/orm/prisma/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -57,10 +57,10 @@
   },
   "peerDependencies": {
     "@prisma/client": ">=6.0.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "keywords": [
     "TypeScript",

--- a/packages/orm/testcontainers-mongo/package.json
+++ b/packages/orm/testcontainers-mongo/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -42,9 +42,9 @@
   },
   "peerDependencies": {
     "@testcontainers/mongodb": ">=10.11.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
     "mongodb": ">=6",
     "testcontainers": ">=10.11.0"
   }

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -10,7 +10,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/platform/common/package.json
+++ b/packages/platform/common/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/platform/platform-cache/package.json
+++ b/packages/platform/platform-cache/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -40,10 +40,10 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/platform/platform-exceptions/package.json
+++ b/packages/platform/platform-exceptions/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -37,10 +37,10 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/platform/platform-express/package.json
+++ b/packages/platform/platform-express/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -90,14 +90,14 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/openspec": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/platform-views": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/openspec": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/platform-views": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "@types/multer": "^1.4.5",
     "body-parser": "^1.19.0",
     "cross-env": "7.0.3",

--- a/packages/platform/platform-http/package.json
+++ b/packages/platform/platform-http/package.json
@@ -9,13 +9,13 @@
   "typings": "./lib/types/common/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/common/index.d.ts",
       "import": "./lib/esm/common/index.js",
       "default": "./lib/esm/common/index.js"
     },
     "./testing": {
-      "@tsed/source": "./src/testing/index.ts",
+      "tsed-source": "./src/testing/index.ts",
       "types": "./lib/types/testing/index.d.ts",
       "import": "./lib/esm/testing/index.js",
       "default": "./lib/esm/testing/index.js"

--- a/packages/platform/platform-koa/package.json
+++ b/packages/platform/platform-koa/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -92,13 +92,13 @@
     "tslib": "2.7.0"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/openspec": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/openspec": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "cross-env": "7.0.3",
     "koa": ">=2.13.0",
     "koa-bodyparser": ">=4.3.0",

--- a/packages/platform/platform-log-middleware/package.json
+++ b/packages/platform/platform-log-middleware/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -36,9 +36,9 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/di": "8.4.0",
-    "@tsed/platform-middlewares": "8.4.0",
-    "@tsed/platform-params": "8.4.0"
+    "@tsed/di": ">=8.0.0",
+    "@tsed/platform-middlewares": ">=8.0.0",
+    "@tsed/platform-params": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/di": {

--- a/packages/platform/platform-log-request/package.json
+++ b/packages/platform/platform-log-request/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -36,9 +36,9 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/di": "8.4.0",
-    "@tsed/platform-middlewares": "8.4.0",
-    "@tsed/platform-params": "8.4.0"
+    "@tsed/di": ">=8.0.0",
+    "@tsed/platform-middlewares": ">=8.0.0",
+    "@tsed/platform-params": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/di": {

--- a/packages/platform/platform-middlewares/package.json
+++ b/packages/platform/platform-middlewares/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -36,9 +36,9 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/platform/platform-params/package.json
+++ b/packages/platform/platform-params/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -38,11 +38,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/platform/platform-response-filter/package.json
+++ b/packages/platform/platform-response-filter/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -38,11 +38,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/platform/platform-router/package.json
+++ b/packages/platform/platform-router/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -39,12 +39,12 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/platform-params": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/platform-params": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/platform/platform-router/test/__snapshots__/routers.integration.spec.ts.snap
+++ b/packages/platform/platform-router/test/__snapshots__/routers.integration.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:get",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -32,7 +32,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:post",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -50,7 +50,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:put",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -68,7 +68,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:delete",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -86,7 +86,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:head",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -104,7 +104,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:option",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -122,7 +122,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:patch",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -140,7 +140,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:get",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -158,7 +158,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:post",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -176,7 +176,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:put",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -194,7 +194,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:delete",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -212,7 +212,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:head",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -230,7 +230,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:option",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -248,7 +248,7 @@ exports[`routers integration > getLayers() > should declare router - appRouter 1
     "opts": {
       "basePath": "/nested",
       "endpoint": "NestedController:patch",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "NestedController",
     },
@@ -271,7 +271,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:get",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -289,7 +289,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:post",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -307,7 +307,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:put",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -325,7 +325,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:delete",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -343,7 +343,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:head",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -361,7 +361,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:option",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },
@@ -379,7 +379,7 @@ exports[`routers integration > getLayers() > should declare router 1`] = `
     "opts": {
       "basePath": "/controller",
       "endpoint": "MyController:patch",
-      "operationPath": "[object Object]",
+      "operationPath": "[object Map]",
       "paramsTypes": "[object Object]",
       "token": "MyController",
     },

--- a/packages/platform/platform-serverless-http/package.json
+++ b/packages/platform/platform-serverless-http/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -76,13 +76,13 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/openspec": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/openspec": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "serverless-http": ">=2.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/platform/platform-serverless-testing/package.json
+++ b/packages/platform/platform-serverless-testing/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -71,12 +71,12 @@
     "tslib": "2.7.0"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/openspec": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/openspec": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   }
 }

--- a/packages/platform/platform-serverless/package.json
+++ b/packages/platform/platform-serverless/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -49,7 +49,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/di": "8.4.0",
+    "@tsed/di": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
     "find-my-way": ">=7.0.0"
   },

--- a/packages/platform/platform-test-sdk/package.json
+++ b/packages/platform/platform-test-sdk/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/platform/platform-views/package.json
+++ b/packages/platform/platform-views/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -40,11 +40,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/engines": "8.4.0",
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/engines": ">=8.0.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/security/jwks/package.json
+++ b/packages/security/jwks/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/security/oidc-provider-plugin-wildcard-redirect-uri/package.json
+++ b/packages/security/oidc-provider-plugin-wildcard-redirect-uri/package.json
@@ -14,7 +14,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -45,10 +45,10 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/oidc-provider": "8.4.0",
+    "@tsed/oidc-provider": ">=8.0.0",
     "oidc-provider": ">=8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/security/oidc-provider/package.json
+++ b/packages/security/oidc-provider/package.json
@@ -20,7 +20,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -63,12 +63,12 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/ajv": "8.4.0",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/ajv": ">=8.0.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "oidc-provider": ">=8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/security/passport/package.json
+++ b/packages/security/passport/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -47,7 +47,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/platform-http": ">=8.0.0",
     "passport": ">=0.4.1"
   },
   "peerDependenciesMeta": {

--- a/packages/specs/ajv/package.json
+++ b/packages/specs/ajv/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -40,10 +40,10 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "ajv": ">=8.9.0",
     "ajv-errors": ">=3.0.0"
   },

--- a/packages/specs/exceptions/package.json
+++ b/packages/specs/exceptions/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -36,6 +36,6 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0"
+    "@tsed/core": ">=8.0.0"
   }
 }

--- a/packages/specs/json-mapper/package.json
+++ b/packages/specs/json-mapper/package.json
@@ -10,7 +10,7 @@
   "browser": "./lib/browser/json-mapper.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/json-mapper.umd.min.js",
       "import": "./lib/esm/index.js",
@@ -52,8 +52,8 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/specs/openapi-utils/package.json
+++ b/packages/specs/openapi-utils/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -42,7 +42,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/platform-http": "8.4.0"
+    "@tsed/platform-http": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/platform-http": {

--- a/packages/specs/openspec/package.json
+++ b/packages/specs/openspec/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/specs/scalar/package.json
+++ b/packages/specs/scalar/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -47,7 +47,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/platform-http": "8.4.0"
+    "@tsed/platform-http": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/platform-http": {

--- a/packages/specs/schema/package.json
+++ b/packages/specs/schema/package.json
@@ -10,7 +10,7 @@
   "browser": "./lib/browser/schema.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/schema.umd.min.js",
       "import": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/hooks": "8.4.0",
-    "@tsed/openspec": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/hooks": ">=8.0.0",
+    "@tsed/openspec": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/specs/swagger/package.json
+++ b/packages/specs/swagger/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -48,7 +48,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/platform-http": "8.4.0"
+    "@tsed/platform-http": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/platform-http": {

--- a/packages/third-parties/agenda/package.json
+++ b/packages/third-parties/agenda/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/third-parties/bullmq/package.json
+++ b/packages/third-parties/bullmq/package.json
@@ -13,7 +13,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/third-parties/components-scan/package.json
+++ b/packages/third-parties/components-scan/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -37,7 +37,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0"
+    "@tsed/core": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/core": {

--- a/packages/third-parties/event-emitter/package.json
+++ b/packages/third-parties/event-emitter/package.json
@@ -15,7 +15,7 @@
   "browser": "./lib/browser/event-emitter.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/event-emitter.umd.min.js",
       "import": "./lib/esm/index.js",

--- a/packages/third-parties/formio-types/package.json
+++ b/packages/third-parties/formio-types/package.json
@@ -17,7 +17,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/third-parties/formio/package.json
+++ b/packages/third-parties/formio/package.json
@@ -17,7 +17,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -53,7 +53,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/platform-http": ">=8.0.0",
     "express": "^4.17.1",
     "formio": ">=2.0.0",
     "lodash": "^4.17.21",

--- a/packages/third-parties/normalize-path/package.json
+++ b/packages/third-parties/normalize-path/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/third-parties/pulse/package.json
+++ b/packages/third-parties/pulse/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/third-parties/schema-formio/package.json
+++ b/packages/third-parties/schema-formio/package.json
@@ -10,7 +10,7 @@
   "browser": "./lib/browser/schema-formio.umd.min.js",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "browser": "./lib/browser/schema-formio.umd.min.js",
       "import": "./lib/esm/index.js",
@@ -54,9 +54,9 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/openspec": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/openspec": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "formiojs": ">=4.0.0",
     "lodash": ">=4.0.0",
     "moment": ">=2.0.0"

--- a/packages/third-parties/socketio-testing/package.json
+++ b/packages/third-parties/socketio-testing/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -33,9 +33,9 @@
     "typescript": "5.4.5"
   },
   "peerDependencies": {
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
     "socket.io-client": "^4.0.1"
   }
 }

--- a/packages/third-parties/socketio/package.json
+++ b/packages/third-parties/socketio/package.json
@@ -16,7 +16,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -52,11 +52,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/platform-middlewares": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/platform-middlewares": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "socket.io": ">=4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/third-parties/sse/package.json
+++ b/packages/third-parties/sse/package.json
@@ -16,7 +16,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -50,11 +50,11 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/di": "8.4.0",
-    "@tsed/json-mapper": "8.4.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/json-mapper": ">=8.0.0",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/platform-middlewares": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/platform-middlewares": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@tsed/di": {

--- a/packages/third-parties/stripe/package.json
+++ b/packages/third-parties/stripe/package.json
@@ -18,7 +18,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -50,10 +50,10 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/exceptions": "8.4.0",
-    "@tsed/platform-middlewares": "8.4.0",
-    "@tsed/platform-params": "8.4.0",
-    "@tsed/schema": "8.4.0",
+    "@tsed/exceptions": ">=8.0.0",
+    "@tsed/platform-middlewares": ">=8.0.0",
+    "@tsed/platform-params": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0",
     "@types/body-parser": "^1.19.0",
     "body-parser": "^1.19.0",
     "stripe": "^9.16.0"

--- a/packages/third-parties/temporal/package.json
+++ b/packages/third-parties/temporal/package.json
@@ -9,7 +9,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"

--- a/packages/third-parties/terminus/package.json
+++ b/packages/third-parties/terminus/package.json
@@ -10,7 +10,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -41,10 +41,10 @@
   },
   "peerDependencies": {
     "@godaddy/terminus": "^4.7.1",
-    "@tsed/core": "8.4.0",
-    "@tsed/di": "8.4.0",
-    "@tsed/platform-http": "8.4.0",
-    "@tsed/schema": "8.4.0"
+    "@tsed/core": ">=8.0.0",
+    "@tsed/di": ">=8.0.0",
+    "@tsed/platform-http": ">=8.0.0",
+    "@tsed/schema": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "@godaddy/terminus": {

--- a/packages/third-parties/vike/package.json
+++ b/packages/third-parties/vike/package.json
@@ -14,7 +14,7 @@
   "typings": "./lib/types/index.d.ts",
   "exports": {
     ".": {
-      "@tsed/source": "./src/index.ts",
+      "tsed-source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
@@ -44,7 +44,7 @@
     "vitest": "2.1.2"
   },
   "peerDependencies": {
-    "@tsed/platform-http": "8.4.0",
+    "@tsed/platform-http": ">=8.0.0",
     "vike": ">=0.4.160",
     "vite": ">=4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6533,11 +6533,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/adapters": 8.4.0
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/hooks": 8.4.0
-    "@tsed/platform-http": 8.4.0
+    "@tsed/adapters": ">=8.0.0"
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/hooks": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
     ioredis: ">=5.2.3"
     ioredis-mock: ">=8.2.2"
     uuid: ^10.0.0
@@ -6569,12 +6569,12 @@ __metadata:
     uuid: "npm:^10.0.0"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/ajv": 8.4.0
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/ajv": ">=8.0.0"
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/ajv":
       optional: false
@@ -6628,10 +6628,10 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/exceptions": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     ajv: ">=8.9.0"
     ajv-errors: ">=3.0.0"
   peerDependenciesMeta:
@@ -6668,10 +6668,10 @@ __metadata:
     vitest: "npm:2.1.2"
   peerDependencies:
     "@apollo/server": ">=4.10.4"
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
     graphql: ">16.0.0"
   languageName: unknown
   linkType: soft
@@ -6746,7 +6746,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
+    "@tsed/core": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -6789,10 +6789,10 @@ __metadata:
     vitest: "npm:2.1.2"
     webpack: "npm:^5.75.0"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/hooks": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/hooks": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/schema": 8.4.0
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -6905,7 +6905,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
+    "@tsed/core": ">=8.0.0"
   languageName: unknown
   linkType: soft
 
@@ -6945,7 +6945,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
     express: ^4.17.1
     formio: ">=2.0.0"
     lodash: ^4.17.21
@@ -6980,10 +6980,10 @@ __metadata:
     tslib: "npm:2.7.0"
     typescript: "npm:5.4.5"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
     graphql-ws: ">=5.14.2"
   languageName: unknown
   linkType: soft
@@ -7039,8 +7039,8 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
     ioredis: ">=5.2.3"
     ioredis-mock: ">=8.2.2"
   languageName: unknown
@@ -7060,8 +7060,8 @@ __metadata:
     vitest: "npm:2.1.2"
     webpack: "npm:^5.75.0"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -7132,10 +7132,10 @@ __metadata:
     vitest: "npm:2.1.2"
   peerDependencies:
     "@mikro-orm/core": ">=4.5.9"
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7159,15 +7159,48 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/ajv": 8.4.0
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/ajv": ">=8.0.0"
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/schema": 8.4.0
+    "@tsed/schema": ">=8.0.0"
     mongoose: ">=6.0.0"
   languageName: unknown
   linkType: soft
+
+"@tsed/monorepo-utils@npm:2.3.11":
+  version: 2.3.11
+  resolution: "@tsed/monorepo-utils@npm:2.3.11"
+  dependencies:
+    "@samverschueren/stream-to-observable": "npm:>=0.3.1"
+    "@typescript-eslint/typescript-estree": "npm:>=6.20.0"
+    any-observable: "npm:>=0.5.1"
+    axios: "npm:>=1.6.7"
+    chalk: "npm:>=5.3.0"
+    commander: "npm:>=12.0.0"
+    execa: "npm:>=8.0.1"
+    fancy-log: "npm:>=1.3.3"
+    figures: "npm:>=3.2.0"
+    fs-extra: "npm:>=11.2.0"
+    globby: "npm:>=14.0.0"
+    has-yarn: "npm:>=3.0.0"
+    inquirer: "npm:>=9.2.13"
+    jsonfile: "npm:>=6.1.0"
+    listr2: "npm:>=8.0.2"
+    lodash: "npm:>=4.17.21"
+    normalize-path: "npm:>=3.0.0"
+    rxjs: "npm:>=7.8.1"
+    semver: "npm:>=7.5.4"
+    split: "npm:>=1.0.1"
+    typescript: "npm:>=5.3.3"
+  peerDependencies:
+    semantic-release: ">=19"
+  bin:
+    monorepo: bin/monorepo.js
+  checksum: 10/4a368111c540684957addd8802d79a615d4975de70cb9b2de39444dc0441cf2f3032a033a3f0402714f552ce5821bdfa6d3b64c58b728847e4f19fd83d69102e
+  languageName: node
+  linkType: hard
 
 "@tsed/monorepo-utils@npm:2.3.9":
   version: 2.3.9
@@ -7236,11 +7269,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/ajv": 8.4.0
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/ajv": ">=8.0.0"
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     knex: ">=0.94.0"
     objection: ">=2.0.0"
   peerDependenciesMeta:
@@ -7278,10 +7311,10 @@ __metadata:
     vitest: "npm:2.1.2"
     wildcard: "npm:2.0.1"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/oidc-provider": 8.4.0
+    "@tsed/oidc-provider": ">=8.0.0"
     oidc-provider: ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
@@ -7322,12 +7355,12 @@ __metadata:
     uuid: "npm:^10.0.0"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/ajv": 8.4.0
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/ajv": ">=8.0.0"
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     oidc-provider: ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/ajv":
@@ -7363,7 +7396,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/platform-http":
       optional: false
@@ -7404,7 +7437,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
     passport: ">=0.4.1"
   peerDependenciesMeta:
     "@tsed/platform-http":
@@ -7443,10 +7476,10 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -7475,10 +7508,10 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/exceptions": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -7523,14 +7556,14 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/openspec": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/platform-views": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/openspec": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/platform-views": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     "@types/multer": ^1.4.5
     body-parser: ^1.19.0
     cross-env: 7.0.3
@@ -7626,13 +7659,13 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/openspec": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/openspec": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     cross-env: 7.0.3
     koa: ">=2.13.0"
     koa-bodyparser: ">=4.3.0"
@@ -7675,9 +7708,9 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/di": 8.4.0
-    "@tsed/platform-middlewares": 8.4.0
-    "@tsed/platform-params": 8.4.0
+    "@tsed/di": ">=8.0.0"
+    "@tsed/platform-middlewares": ">=8.0.0"
+    "@tsed/platform-params": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/di":
       optional: false
@@ -7702,9 +7735,9 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/di": 8.4.0
-    "@tsed/platform-middlewares": 8.4.0
-    "@tsed/platform-params": 8.4.0
+    "@tsed/di": ">=8.0.0"
+    "@tsed/platform-middlewares": ">=8.0.0"
+    "@tsed/platform-params": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/di":
       optional: false
@@ -7729,9 +7762,9 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: true
@@ -7758,11 +7791,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/exceptions": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -7793,11 +7826,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/exceptions": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -7829,12 +7862,12 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/exceptions": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/platform-params": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/platform-params": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -7868,13 +7901,13 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/openspec": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/openspec": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     serverless-http: ">=2.0.0"
   peerDependenciesMeta:
     "@tsed/core":
@@ -7909,13 +7942,13 @@ __metadata:
     tslib: "npm:2.7.0"
     typescript: "npm:5.4.5"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/openspec": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/openspec": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7946,7 +7979,7 @@ __metadata:
     uuid: "npm:^10.0.0"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/di": 8.4.0
+    "@tsed/di": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
     find-my-way: ">=7.0.0"
   peerDependenciesMeta:
@@ -8003,11 +8036,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/engines": 8.4.0
-    "@tsed/exceptions": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/engines": ">=8.0.0"
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -8047,10 +8080,10 @@ __metadata:
     vitest: "npm:2.1.2"
   peerDependencies:
     "@prisma/client": ">=6.0.0"
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   bin:
     tsed-prisma: lib/esm/generator.js
     tsed-prisma-esm: lib/esm/generator.js
@@ -8087,7 +8120,7 @@ __metadata:
     "@swc/core": "npm:1.7.28"
     "@swc/helpers": "npm:0.5.13"
     "@tsed/logger": "npm:^7.0.1"
-    "@tsed/monorepo-utils": "npm:2.3.9"
+    "@tsed/monorepo-utils": "npm:2.3.11"
     "@tsed/ts-doc": "npm:5.0.0"
     "@types/axios": "npm:0.14.0"
     "@types/globby": "npm:9.1.0"
@@ -8160,7 +8193,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/platform-http":
       optional: false
@@ -8183,9 +8216,9 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/openspec": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/openspec": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     formiojs: ">=4.0.0"
     lodash: ">=4.0.0"
     moment: ">=2.0.0"
@@ -8231,9 +8264,9 @@ __metadata:
     vitest: "npm:2.1.2"
     webpack: "npm:^5.75.0"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/hooks": 8.4.0
-    "@tsed/openspec": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/hooks": ">=8.0.0"
+    "@tsed/openspec": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/core":
       optional: false
@@ -8255,9 +8288,9 @@ __metadata:
     tslib: "npm:2.7.0"
     typescript: "npm:5.4.5"
   peerDependencies:
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/platform-http": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
     socket.io-client: ^4.0.1
   languageName: unknown
   linkType: soft
@@ -8284,11 +8317,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/platform-middlewares": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/platform-middlewares": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     socket.io: ">=4.0.0"
   peerDependenciesMeta:
     "@tsed/di":
@@ -8322,11 +8355,11 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/di": 8.4.0
-    "@tsed/json-mapper": 8.4.0
+    "@tsed/di": ">=8.0.0"
+    "@tsed/json-mapper": ">=8.0.0"
     "@tsed/logger": ">=7.0.1"
-    "@tsed/platform-middlewares": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/platform-middlewares": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/di":
       optional: false
@@ -8358,10 +8391,10 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/exceptions": 8.4.0
-    "@tsed/platform-middlewares": 8.4.0
-    "@tsed/platform-params": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/exceptions": ">=8.0.0"
+    "@tsed/platform-middlewares": ">=8.0.0"
+    "@tsed/platform-params": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
     "@types/body-parser": ^1.19.0
     body-parser: ^1.19.0
     stripe: ^9.16.0
@@ -8400,7 +8433,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
   peerDependenciesMeta:
     "@tsed/platform-http":
       optional: false
@@ -8447,10 +8480,10 @@ __metadata:
     vitest: "npm:2.1.2"
   peerDependencies:
     "@godaddy/terminus": ^4.7.1
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/platform-http": 8.4.0
-    "@tsed/schema": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
+    "@tsed/schema": ">=8.0.0"
   peerDependenciesMeta:
     "@godaddy/terminus":
       optional: false
@@ -8481,9 +8514,9 @@ __metadata:
     typescript: "npm:5.4.5"
   peerDependencies:
     "@testcontainers/mongodb": ">=10.11.0"
-    "@tsed/core": 8.4.0
-    "@tsed/di": 8.4.0
-    "@tsed/platform-http": 8.4.0
+    "@tsed/core": ">=8.0.0"
+    "@tsed/di": ">=8.0.0"
+    "@tsed/platform-http": ">=8.0.0"
     mongodb: ">=6"
     testcontainers: ">=10.11.0"
   languageName: unknown
@@ -8564,7 +8597,7 @@ __metadata:
     vite: "npm:5.4.8"
     vitest: "npm:2.1.2"
   peerDependencies:
-    "@tsed/platform-http": 8.4.0
+    "@tsed/platform-http": ">=8.0.0"
     vike: ">=0.4.160"
     vite: ">=4"
   peerDependenciesMeta:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Export Naming**
  - Renamed module source export keys from `@tsed/source` to `tsed-source` across all packages.

- **Dependency Management**
  - Updated peer dependency version constraints from fixed versions to more flexible ranges.
  - Most dependencies now use `>=8.0.0` version constraint.
  - Allows greater compatibility with newer package versions.

- **Key Packages Updated**
  - Core packages like `@tsed/core`, `@tsed/di`, `@tsed/schema`.
  - Platform packages such as `@tsed/platform-http`.
  - Various third-party integration packages.

- **Compatibility**
  - Broader version support for dependencies.
  - Simplified version management.
  - Reduced potential version conflicts.

This release focuses on improving package flexibility and dependency management across the Ts.ED ecosystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->