### PR TITLE
fix(mongoose): fix prehook when insertMany is used to hook method

### DIFF
--- a/packages/orm/mongoose/src/decorators/postHook.spec.ts
+++ b/packages/orm/mongoose/src/decorators/postHook.spec.ts
@@ -8,7 +8,7 @@ describe("@PostHook()", () => {
       const fn = vi.fn();
 
       // WHEN
-      @PostHook("method", fn)
+      @PostHook("save", fn)
       class Test {}
 
       // THEN
@@ -17,7 +17,7 @@ describe("@PostHook()", () => {
       expect(options).toEqual({
         post: [
           {
-            method: "method",
+            method: "save",
             fn,
             options: undefined
           }

--- a/packages/orm/mongoose/src/decorators/postHook.ts
+++ b/packages/orm/mongoose/src/decorators/postHook.ts
@@ -1,6 +1,6 @@
 import {decoratorTypeOf, DecoratorTypes, StaticMethodDecorator} from "@tsed/core";
 
-import {MongooseHookOptions, MongoosePostHookCB} from "../interfaces/MongooseSchemaOptions.js";
+import {MongooseHookOptions, MongooseMethods, MongoosePostHookCB} from "../interfaces/MongooseSchemaOptions.js";
 import {schemaOptions} from "../utils/schemaOptions.js";
 
 /**
@@ -46,10 +46,10 @@ import {schemaOptions} from "../utils/schemaOptions.js";
  * @mongoose
  * @class
  */
-export function PostHook<T = any>(method: string, fn: MongoosePostHookCB<T>): ClassDecorator;
-export function PostHook<T = any>(method: string, fn: MongoosePostHookCB<T>, options: MongooseHookOptions): ClassDecorator;
-export function PostHook<T = any>(method: string, options: MongooseHookOptions): StaticMethodDecorator;
-export function PostHook<T = any>(method: string, ...params: any[]): Function {
+export function PostHook<T = any>(method: MongooseMethods, fn: MongoosePostHookCB<T>): ClassDecorator;
+export function PostHook<T = any>(method: MongooseMethods, fn: MongoosePostHookCB<T>, options: MongooseHookOptions): ClassDecorator;
+export function PostHook<T = any>(method: MongooseMethods, options: MongooseHookOptions): StaticMethodDecorator;
+export function PostHook<T = any>(method: MongooseMethods, ...params: any[]): ClassDecorator | StaticMethodDecorator {
   return ((...args: any[]) => {
     let options: MongooseHookOptions = params[1];
     let fn: MongoosePostHookCB<T> = params[0];

--- a/packages/orm/mongoose/src/decorators/preHook.spec.ts
+++ b/packages/orm/mongoose/src/decorators/preHook.spec.ts
@@ -7,7 +7,7 @@ describe("@PreHook()", () => {
       const fn = vi.fn();
 
       // WHEN
-      @PreHook("method", fn, {query: true})
+      @PreHook("save", fn as any, {query: true})
       class Test {}
 
       // THEN
@@ -16,7 +16,7 @@ describe("@PreHook()", () => {
       expect(options).toEqual({
         pre: [
           {
-            method: "method",
+            method: "save",
             fn,
             options: {
               query: true
@@ -32,7 +32,7 @@ describe("@PreHook()", () => {
       });
 
       // WHEN
-      @PreHook("method", fn, {query: true})
+      @PreHook("save", fn, {query: true})
       class Test {}
 
       // THEN
@@ -41,7 +41,7 @@ describe("@PreHook()", () => {
       expect(options).toEqual({
         pre: [
           {
-            method: "method",
+            method: "save",
             fn,
             options: {
               query: true

--- a/packages/orm/mongoose/src/interfaces/MongooseSchemaOptions.ts
+++ b/packages/orm/mongoose/src/interfaces/MongooseSchemaOptions.ts
@@ -2,32 +2,42 @@ import {type IndexOptions, Schema, SchemaOptions} from "mongoose";
 
 import {MongooseDocument} from "./MongooseDocument.js";
 
+export type MongooseMethod =
+  | "aggregate"
+  | "bulkWrite"
+  | "createCollection"
+  | "save"
+  | "insertMany"
+  | "estimatedDocumentCount"
+  | "countDocuments"
+  | "deleteMany"
+  | "distinct"
+  | "find"
+  | "findOne"
+  | "findOneAndDelete"
+  | "findOneAndReplace"
+  | "findOneAndUpdate"
+  | "replaceOne"
+  | "updateMany"
+  | "init"
+  | "validate";
+
+export type MongooseMethods = MongooseMethod | RegExp | MongooseMethod[];
+
 export type MongooseNextCB = (err?: Error) => void;
-
-export interface MongooseHookOptions {
-  document?: boolean;
-  query?: boolean;
-  parallel?: boolean;
-}
-
-export type MongooseHookPromised<T = any> = (doc: T | MongooseDocument<T>) => Promise<void> | void;
-
-export type MongoosePreHookCB<T = any> = ((doc: T | MongooseDocument<T>, next: MongooseNextCB) => void) | MongooseHookPromised;
-
-export type MongoosePostHookCB<T = any> =
-  | ((doc: T | MongooseDocument<T>, error: Error, next: MongooseNextCB) => void)
-  | ((doc: T | MongooseDocument<T>, error: Error) => Promise<void> | void)
-  | ((doc: T | MongooseDocument<T>, next: MongooseNextCB) => void)
-  | MongooseHookPromised;
+export type MongooseHookOptions = Record<string, unknown>;
+export type MongooseHookPromised<T = any> = (doc: T | MongooseDocument<T>) => Promise<void>;
+export type MongoosePreHookCB<T = any> = (doc: T | MongooseDocument<T>, ...args: unknown[]) => Promise<void> | void;
+export type MongoosePostHookCB<T = any> = (doc: T | MongooseDocument<T>, ...args: unknown[]) => Promise<void> | void;
 
 export interface MongoosePreHook<T = any> {
-  method: string | RegExp;
+  method: MongooseMethods;
   fn: MongoosePreHookCB<T>;
   options?: MongooseHookOptions;
 }
 
 export interface MongoosePostHook<T = any> {
-  method: string | RegExp;
+  method: MongooseMethods;
   fn: MongoosePostHookCB<T>;
   options?: MongooseHookOptions;
 }

--- a/packages/orm/mongoose/src/utils/schemaOptions.ts
+++ b/packages/orm/mongoose/src/utils/schemaOptions.ts
@@ -4,7 +4,6 @@ import {Schema} from "mongoose";
 import {MONGOOSE_SCHEMA_OPTIONS} from "../constants/constants.js";
 import {
   MongooseHookPromised,
-  MongooseNextCB,
   MongoosePostHook,
   MongoosePreHook,
   MongoosePreHookCB,
@@ -40,8 +39,9 @@ export function buildPreHook(fn: MongoosePreHookCB) {
     ? function () {
         return (fn as MongooseHookPromised)(this);
       }
-    : function (next: MongooseNextCB) {
-        return fn(this, next);
+    : // we need to explicitly gives args to avoid a bug with mongoose
+      function (next: Function, arg1: unknown, arg2: unknown) {
+        return (fn as any)(this, next, arg1, arg2);
       };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for Mongoose decorators and hooks.
	- Introduced more flexible method handling for pre and post hooks.

- **Improvements**
	- Updated method signatures to use specific Mongoose method types.
	- Improved callback function flexibility for hooks.
	- Expanded options handling for schema configurations.

- **Bug Fixes**
	- Resolved potential argument handling issues in hook implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->