### PR TITLE
docs: Update PNPM commands

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,7 +69,7 @@ yarn dlx -p @tsed/cli tsed init .
 ```
 
 ```sh [pnpm]
-pnpx -p @tsed/cli tsed init .
+pnpm --package=@tsed/cli dlx tsed init .
 ```
 
 ```sh [bun]

--- a/docs/introduction/migrate-from-express.md
+++ b/docs/introduction/migrate-from-express.md
@@ -52,7 +52,7 @@ yarn dlx -p @tsed/cli tsed init .
 ```
 
 ```sh [pnpm]
-pnpx -p @tsed/cli tsed init .
+pnpm --package=@tsed/cli dlx tsed init .
 ```
 
 ```sh [bun]

--- a/docs/tutorials/prisma.md
+++ b/docs/tutorials/prisma.md
@@ -72,7 +72,7 @@ yarn dlx -p @tsed/cli tsed init tsed-prisma
 ```
 
 ```sh [pnpm]
-pnpx -p @tsed/cli tsed init tsed-prisma
+pnpm --package=@tsed/cli dlx tsed init tsed-prisma
 ```
 
 ```sh [bun]


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc| No          |

---

Installation command from https://tsed.dev/introduction/getting-started.html is wrong.

```
thanatos@DESKTOP-5NP8L7E:~/projects/tsed-repos$ pnpm --version
9.15.4

thanatos@DESKTOP-5NP8L7E:~/projects/tsed-repos/jest-test$ pnpx -p @tsed/cli tsed init .
/home/thanatos/.cache/pnpm/dlx/2eaiiergvzc3777g5qgjrb7sim/19474c44e0b-564:
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/-p: Not Found - 404

This error happened while installing a direct dependency of /home/thanatos/.cache/pnpm/dlx/2eaiiergvzc3777g5qgjrb7sim/19474c44e0b-564

-p is not in the npm registry, or you have no permission to fetch it.

No authorization header was set for the request.
```
### Fix

Instead of using the outdated/deprecated `pnpx` use `pnpm dlx` and also add peer dependencies.

E.g.
```bash
pnpm --package=@tsed/cli --package=@tsed/cli-core dlx tsed init .
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated project initialization commands in multiple documentation files to use the latest `pnpm` syntax.
  - Replaced `pnpx -p @tsed/cli tsed init` with `pnpm --package=@tsed/cli dlx tsed init .` and `pnpx -p @tsed/cli tsed init tsed-prisma` with `pnpm --package=@tsed/cli dlx tsed init tsed-prisma`.
  - Affected files: getting-started.md, migrate-from-express.md, prisma.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->