### PR TITLE
fix(swagger): avoid join error issue by return default string value when import.meta.dirname isn't available

### DIFF
--- a/packages/specs/scalar/src/constants.ts
+++ b/packages/specs/scalar/src/constants.ts
@@ -1,3 +1,4 @@
+import {getValue} from "@tsed/core";
 import {join} from "path";
 
-export const ROOT_DIR = join(import.meta.dirname, "..");
+export const ROOT_DIR = join(getValue(import.meta, "dirname", ""), "..");

--- a/packages/specs/swagger/src/constants.ts
+++ b/packages/specs/swagger/src/constants.ts
@@ -1,5 +1,7 @@
-import {join} from "path";
+import {join} from "node:path";
+
+import {getValue} from "@tsed/core";
 import getAbsoluteFSPath from "swagger-ui-dist/absolute-path.js";
 
 export const SWAGGER_UI_DIST = getAbsoluteFSPath();
-export const ROOT_DIR = join(import.meta.dirname, "..");
+export const ROOT_DIR = join(getValue(import.meta, "dirname", ""), "..");


### PR DESCRIPTION
…

fix issue with jest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated directory path resolution mechanism to improve robustness and flexibility when retrieving root directory information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->