### PR TITLE
fix(mongoose): fix schema when default value is used on collection

### DIFF
--- a/packages/orm/mongoose/src/utils/createSchema.spec.ts
+++ b/packages/orm/mongoose/src/utils/createSchema.spec.ts
@@ -465,12 +465,10 @@ describe("createSchema", () => {
 
     // THEN
     expect(testSchema.obj).toEqual({
-      tests: [
-        {
-          type: childrenSchema,
-          required: false
-        }
-      ]
+      tests: {
+        type: [childrenSchema],
+        required: false
+      }
     });
 
     expect(childrenSchema.obj).toEqual({
@@ -496,6 +494,54 @@ describe("createSchema", () => {
         min: 0,
         required: false,
         type: Number
+      }
+    });
+  });
+  it("should create schema with collection (Array of subdocument and default value undefined)", () => {
+    // GIVEN
+    enum MyEnum {
+      V1 = "v1",
+      V2 = "v2"
+    }
+
+    @Schema()
+    class Children {
+      @Name("id")
+      _id: string;
+
+      @Enum(MyEnum)
+      @Default(undefined)
+      enum?: MyEnum[];
+    }
+
+    @Model()
+    class Test6 {
+      @CollectionOf(Children)
+      @Default(undefined)
+      tests?: Children[];
+    }
+
+    // WHEN
+    const testSchema = getSchema(Test6);
+    const childrenSchema = getSchema(Children);
+
+    // THEN
+    expect(testSchema.obj).toEqual({
+      tests: {
+        type: [childrenSchema],
+        required: false
+      }
+    });
+
+    expect(childrenSchema.obj).toEqual({
+      _id: {
+        required: false,
+        type: String
+      },
+      enum: {
+        enum: ["v1", "v2"],
+        required: false,
+        type: [String]
       }
     });
   });
@@ -536,13 +582,11 @@ describe("createSchema", () => {
 
     // THEN
     expect(testSchema.obj).toEqual({
-      tests: [
-        {
-          type: SchemaMongoose.Types.ObjectId,
-          ref: "Children3",
-          required: false
-        }
-      ]
+      tests: {
+        type: [SchemaMongoose.Types.ObjectId],
+        ref: "Children3",
+        required: false
+      }
     });
   });
   it("should create schema with collection (Array of virtual ref", () => {
@@ -632,9 +676,9 @@ describe("createSchema", () => {
       tests: {
         type: Map,
         of: {
-          type: childrenSchema,
-          required: false
-        }
+          type: childrenSchema
+        },
+        required: false
       }
     });
 
@@ -729,6 +773,7 @@ describe("createSchema", () => {
       @DiscriminatorKey()
       kind: string;
     }
+
     const testSchema = getSchema(Test11);
     // @ts-ignore
     const options = testSchema.options;
@@ -741,6 +786,7 @@ describe("createSchema", () => {
       @VersionKey()
       version: number;
     }
+
     const testSchema = getSchema(Test12);
     // @ts-ignore
     const options = testSchema.options;

--- a/packages/specs/schema/src/decorators/common/default.ts
+++ b/packages/specs/schema/src/decorators/common/default.ts
@@ -1,3 +1,5 @@
+import type {JSONSchema6Type} from "json-schema";
+
 import {JsonEntityFn} from "./jsonEntityFn.js";
 
 /**
@@ -40,7 +42,7 @@ import {JsonEntityFn} from "./jsonEntityFn.js";
  * @schema
  * @input
  */
-export function Default(defaultValue: string | number | boolean | {}) {
+export function Default(defaultValue: JSONSchema6Type | undefined) {
   return JsonEntityFn((store) => {
     store.itemSchema.default(defaultValue);
   });

--- a/packages/specs/schema/src/domain/JsonSchema.ts
+++ b/packages/specs/schema/src/domain/JsonSchema.ts
@@ -259,7 +259,7 @@ export class JsonSchema extends Map<string, any> implements NestedGenerics {
    * It is RECOMMENDED that a default value be valid against the associated schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.3
    */
-  default(value: JSONSchema6Type) {
+  default(value: JSONSchema6Type | undefined) {
     super.set("default", value);
 
     return this;


### PR DESCRIPTION
Closes: #2968

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| fix | No          |

---

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added new test cases for schema creation to verify:
		- Schemas with collection of subdocuments and default values
		- Schemas with discriminator keys
		- Schemas with version keys

- **Refactor**
	- Updated schema type handling and definition structures
	- Modified function signatures to support more flexible type definitions

- **Documentation**
	- Improved type support for default values in schema decorators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->