### PR TITLE
fix(schema): fix typing for operation decorators

### DIFF
--- a/packages/specs/schema/src/decorators/generics/generics.ts
+++ b/packages/specs/schema/src/decorators/generics/generics.ts
@@ -13,7 +13,7 @@ import {JsonEntityStore} from "../../domain/JsonEntityStore.js";
  * @input
  * @generics
  */
-export function Generics(...generics: string[]) {
+export function Generics(...generics: string[]): ClassDecorator {
   return (target: any) => {
     const storedSchema = JsonEntityStore.from(target);
 

--- a/packages/specs/schema/src/decorators/operations/acceptMime.ts
+++ b/packages/specs/schema/src/decorators/operations/acceptMime.ts
@@ -20,6 +20,6 @@ import {Produces} from "./produces.js";
  * @operation
  * @response
  */
-export function AcceptMime(...mimes: string[]): Function {
+export function AcceptMime(...mimes: string[]): ClassDecorator & MethodDecorator {
   return useDecorators(Produces(...mimes), StoreSet("acceptMimes", mimes));
 }

--- a/packages/specs/schema/src/decorators/operations/consumes.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/consumes.spec.ts
@@ -79,6 +79,7 @@ describe("Consumes", () => {
 
     let actualError: any;
     try {
+      // @ts-ignore
       Consumes("text/json")(Test.prototype, "test", 0);
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/consumes.ts
+++ b/packages/specs/schema/src/decorators/operations/consumes.ts
@@ -20,7 +20,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * @classDecorator
  * @operation
  */
-export function Consumes(...consumes: string[]) {
+export function Consumes(...consumes: string[]): ClassDecorator & MethodDecorator {
   return JsonEntityFn((store, args) => {
     switch (store.decoratorType) {
       case DecoratorTypes.METHOD:

--- a/packages/specs/schema/src/decorators/operations/header.ts
+++ b/packages/specs/schema/src/decorators/operations/header.ts
@@ -50,7 +50,7 @@ import {Returns} from "./returns.js";
  * @operation
  * @response
  */
-export function Header(headers: string | number | JsonHeaders, value?: string | number | JsonHeader): Function {
+export function Header(headers: string | number | JsonHeaders, value?: string | number | JsonHeader) {
   if (value !== undefined) {
     headers = {[headers as string]: value};
   }

--- a/packages/specs/schema/src/decorators/operations/operationId.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/operationId.spec.ts
@@ -33,6 +33,7 @@ describe("OperationId", () => {
   it("should throw error for unsupported usage", () => {
     let actualError: any;
     try {
+      // @ts-ignore
       OperationId("id")(class Test {});
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/operationId.ts
+++ b/packages/specs/schema/src/decorators/operations/operationId.ts
@@ -11,7 +11,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * @schema
  * @operation
  */
-export function OperationId(operationId: string) {
+export function OperationId(operationId: string): MethodDecorator {
   return JsonEntityFn((store, args) => {
     if (store.decoratorType !== DecoratorTypes.METHOD) {
       throw new UnsupportedDecoratorType(OperationId, args);

--- a/packages/specs/schema/src/decorators/operations/operationPath.ts
+++ b/packages/specs/schema/src/decorators/operations/operationPath.ts
@@ -9,7 +9,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * ::: warning
  * Don't use decorator with Ts.ED application.
  *
- * Use theses decorators instead:
+ * Use these decorators instead:
  *
  * <ApiList query="status.includes('decorator') && status.includes('httpMethod')" />
  *

--- a/packages/specs/schema/src/decorators/operations/path.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/path.spec.ts
@@ -37,6 +37,7 @@ describe("Path", () => {
 
     let actualError: any;
     try {
+      // @ts-ignore
       Path("/")(Test.prototype, "test", 0);
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/path.ts
+++ b/packages/specs/schema/src/decorators/operations/path.ts
@@ -16,7 +16,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * @classDecorator
  * @operation
  */
-export function Path(path: string) {
+export function Path(path: string): ClassDecorator {
   return JsonEntityFn((store, args) => {
     if (store.decoratorType !== DecoratorTypes.CLASS) {
       throw new UnsupportedDecoratorType(Path, args);

--- a/packages/specs/schema/src/decorators/operations/produces.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/produces.spec.ts
@@ -79,6 +79,7 @@ describe("Produces", () => {
 
     let actualError: any;
     try {
+      // @ts-ignore
       Produces("text/json")(Test.prototype, "test", 0);
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/produces.ts
+++ b/packages/specs/schema/src/decorators/operations/produces.ts
@@ -27,7 +27,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * @operation
  * @response
  */
-export function Produces(...produces: string[]) {
+export function Produces(...produces: string[]): ClassDecorator & MethodDecorator {
   return JsonEntityFn((store, args) => {
     switch (store.decoratorType) {
       case DecoratorTypes.METHOD:

--- a/packages/specs/schema/src/decorators/operations/redirect.ts
+++ b/packages/specs/schema/src/decorators/operations/redirect.ts
@@ -53,9 +53,9 @@ import {Returns} from "./returns.js";
  * @response
  * @headers
  */
-export function Redirect(url: string, meta?: JsonHeader): Function;
-export function Redirect(status: number, url: string, meta?: JsonHeader): Function;
-export function Redirect(...args: any[]): Function {
+export function Redirect(url: string, meta?: JsonHeader): MethodDecorator;
+export function Redirect(status: number, url: string, meta?: JsonHeader): MethodDecorator;
+export function Redirect(...args: any[]): MethodDecorator {
   const {status, url, meta} = args.reduce(
     (options: any, value: any) => {
       if (isNumber(value)) {

--- a/packages/specs/schema/src/decorators/operations/security.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/security.spec.ts
@@ -152,6 +152,7 @@ describe("Security", () => {
 
     let actualError: any;
     try {
+      // @ts-ignore
       Security("POST", "/")(Test.prototype, "test", 0);
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/security.ts
+++ b/packages/specs/schema/src/decorators/operations/security.ts
@@ -25,7 +25,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * @classDecorator
  * @operation
  */
-export function Security(name: string, ...scopes: string[]): Function;
+export function Security(name: string, ...scopes: string[]): ClassDecorator & MethodDecorator;
 /**
  * Add security metadata on the decorated method.
  *
@@ -57,8 +57,8 @@ export function Security(name: string, ...scopes: string[]): Function;
  * @classDecorator
  * @operation
  */
-export function Security(security: OpenSpecSecurity): Function;
-export function Security(nameOrSecurity: string | OpenSpecSecurity, ...scopes: string[]): Function {
+export function Security(security: OpenSpecSecurity): ClassDecorator & MethodDecorator;
+export function Security(nameOrSecurity: string | OpenSpecSecurity, ...scopes: string[]): ClassDecorator & MethodDecorator {
   return JsonEntityFn((store, args) => {
     switch (store.decoratorType) {
       case DecoratorTypes.METHOD:

--- a/packages/specs/schema/src/decorators/operations/summary.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/summary.spec.ts
@@ -35,6 +35,7 @@ describe("Summary", () => {
   it("should throw error for unsupported usage", () => {
     let actualError: any;
     try {
+      // @ts-ignore
       Summary("summary")(class Test {});
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/summary.ts
+++ b/packages/specs/schema/src/decorators/operations/summary.ts
@@ -21,7 +21,7 @@ import {JsonEntityFn} from "../common/jsonEntityFn.js";
  * @schema
  * @operation
  */
-export function Summary(summary: string) {
+export function Summary(summary: string): MethodDecorator {
   return JsonEntityFn((store, args) => {
     if (store.decoratorType !== DecoratorTypes.METHOD) {
       throw new UnsupportedDecoratorType(Summary, args);

--- a/packages/specs/schema/src/decorators/operations/tags.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/tags.spec.ts
@@ -103,6 +103,7 @@ describe("Tags", () => {
 
     let actualError: any;
     try {
+      // @ts-ignore
       Tags("tags")(Test.prototype, "test", 0);
     } catch (er) {
       actualError = er;

--- a/packages/specs/schema/src/decorators/operations/tags.ts
+++ b/packages/specs/schema/src/decorators/operations/tags.ts
@@ -16,7 +16,7 @@ function mapTags(tags: (string | OpenSpecTag)[]) {
 }
 
 /**
- * Add tags metadata on the decorated element.
+ * Add metadata tags to the decorated element (class or method).
  *
  * ## Examples
  * ### On method
@@ -28,6 +28,15 @@ function mapTags(tags: (string | OpenSpecTag)[]) {
  *  get() {}
  * }
  * ```
+ * ### On Class
+ *
+ * ```typescript
+ * @Controller("/")
+ * @Tags("api")
+ * class MyController {
+ *  get() {}
+ * }
+ * ```
  *
  * @param tags
  * @decorator
@@ -36,7 +45,7 @@ function mapTags(tags: (string | OpenSpecTag)[]) {
  * @classDecorator
  * @operation
  */
-export function Tags(...tags: (string | OpenSpecTag)[]) {
+export function Tags(...tags: (string | OpenSpecTag)[]): ClassDecorator & MethodDecorator {
   return JsonEntityFn((store, args) => {
     switch (store.decoratorType) {
       case DecoratorTypes.METHOD:


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Type Safety Improvements**
	- Enhanced decorator type definitions for multiple schema-related decorators
	- Added explicit return types for decorators like `Generics`, `AcceptMime`, `Consumes`, `Produces`, `Security`, and others
	- Clarified decorator usage for classes and methods

- **Error Handling**
	- Added test cases to validate decorator usage constraints
	- Improved error messages for incorrect decorator applications
	- Ensured decorators throw appropriate errors when misused

- **Documentation**
	- Updated comments and examples for decorator usage
	- Clarified potential decorator application scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->