### PR TITLE
fix(objection): fix decorators to allow to work with circular imports  in esbuild

### DIFF
--- a/packages/orm/objection/src/decorators/belongsToOne.spec.ts
+++ b/packages/orm/objection/src/decorators/belongsToOne.spec.ts
@@ -57,4 +57,82 @@ describe("@BelongsToOne", () => {
       }
     });
   });
+  it("should set custom relationship model", () => {
+    @Entity("user")
+    class User extends Model {
+      @IdColumn()
+      id!: string;
+    }
+    @Entity("movie")
+    class Movie extends Model {
+      @IdColumn()
+      id!: string;
+      userId!: string;
+      @BelongsToOne(() => User)
+      user?: User;
+    }
+    expect(Movie.relationMappings).toEqual({
+      user: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: User,
+        join: {
+          from: "movie.userId",
+          to: "user.id"
+        }
+      }
+    });
+  });
+
+  it("should set custom relationship model and relationship path", () => {
+    @Entity("user")
+    class User extends Model {
+      @IdColumn()
+      id!: string;
+      userId!: string;
+    }
+    @Entity("movie")
+    class Movie extends Model {
+      @IdColumn()
+      id!: string;
+      ownerId!: string;
+      @BelongsToOne(() => User, {from: "ownerId", to: "userId"})
+      user?: User;
+    }
+    expect(Movie.relationMappings).toEqual({
+      user: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: User,
+        join: {
+          from: "movie.ownerId",
+          to: "user.userId"
+        }
+      }
+    });
+  });
+  it("should work when options supplied as 2nd argument without first provided", () => {
+    @Entity("user")
+    class User extends Model {
+      @IdColumn()
+      id!: string;
+      userId!: string;
+    }
+    @Entity("movie")
+    class Movie extends Model {
+      @IdColumn()
+      id!: string;
+      ownerId!: string;
+      @BelongsToOne(undefined, {from: "ownerId", to: "userId"})
+      user?: User;
+    }
+    expect(Movie.relationMappings).toEqual({
+      user: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: User,
+        join: {
+          from: "movie.ownerId",
+          to: "user.userId"
+        }
+      }
+    });
+  });
 });

--- a/packages/orm/objection/src/decorators/belongsToOne.ts
+++ b/packages/orm/objection/src/decorators/belongsToOne.ts
@@ -1,14 +1,53 @@
-import {Model} from "objection";
+import {Model, ModelClassSpecifier} from "objection";
 
-import {RelationshipOptsWithoutThrough} from "../domain/RelationshipOpts.js";
+import {isModelClassSpecifier, RelationshipOpts, RelationshipOptsWithoutThrough} from "../domain/RelationshipOpts.js";
 import {RelatesTo} from "./relatesTo.js";
 
+/**
+ *
+ * @param type
+ * @decorator
+ * @objection
+ */
+export function BelongsToOne(type?: ModelClassSpecifier): PropertyDecorator;
 /**
  *
  * @param opts
  * @decorator
  * @objection
  */
-export function BelongsToOne(opts?: RelationshipOptsWithoutThrough): PropertyDecorator {
-  return RelatesTo(Model.BelongsToOneRelation, opts);
+export function BelongsToOne(opts?: RelationshipOptsWithoutThrough): PropertyDecorator;
+/**
+ *
+ * @param opts
+ * @param type
+ * @decorator
+ * @objection
+ */
+export function BelongsToOne(type?: ModelClassSpecifier, opts?: RelationshipOptsWithoutThrough): PropertyDecorator;
+/**
+ *
+ * @param typeOrOpts
+ * @param opts
+ * @decorator
+ * @objection
+ */
+export function BelongsToOne(
+  typeOrOpts?: ModelClassSpecifier | RelationshipOptsWithoutThrough,
+  opts?: RelationshipOptsWithoutThrough
+): PropertyDecorator {
+  // For backwards compatibility
+  if (!typeOrOpts && !opts) return RelatesTo(Model.BelongsToOneRelation, undefined);
+  if (!typeOrOpts && opts) {
+    typeOrOpts = opts;
+    opts = undefined;
+  }
+
+  const options: RelationshipOpts | undefined = isModelClassSpecifier(typeOrOpts)
+    ? opts
+      ? {...opts, type: typeOrOpts}
+      : {type: typeOrOpts}
+    : typeOrOpts;
+
+  return RelatesTo(Model.BelongsToOneRelation, options);
 }

--- a/packages/orm/objection/src/decorators/relatesTo.ts
+++ b/packages/orm/objection/src/decorators/relatesTo.ts
@@ -17,9 +17,6 @@ export function RelatesTo(relation: RelationType, opts?: RelationshipOpts): Prop
   return useDecorators(
     opts?.type ? CollectionOf(opts.type) : Property(),
     StoreFn((store, params) => {
-      if (opts && isModelClassFactory(opts.type)) {
-        opts.type = opts.type();
-      }
       store.set(OBJECTION_RELATIONSHIP_KEY, createRelationshipMapping(params, relation, opts));
     })
   );

--- a/packages/orm/objection/src/domain/RelationshipOpts.ts
+++ b/packages/orm/objection/src/domain/RelationshipOpts.ts
@@ -12,3 +12,7 @@ export const isRelationshipOptsWithThrough = (opts?: RelationshipOpts): opts is 
 
 export const isModelClassFactory = (type?: ModelClassSpecifier): type is ModelClassFactory =>
   type !== undefined && !isString(type) && isFunction(type) && !("prototype" in type);
+
+export const isModelClassSpecifier = (specifierOrOther: unknown): specifierOrOther is ModelClassSpecifier => {
+  return !!specifierOrOther && (isString(specifierOrOther) || isFunction(specifierOrOther));
+};

--- a/packages/orm/objection/src/utils/createRelationshipMapping.ts
+++ b/packages/orm/objection/src/utils/createRelationshipMapping.ts
@@ -1,21 +1,29 @@
 import {DecoratorParameters, getClass, Metadata} from "@tsed/core";
 import {RelationType} from "objection";
 
-import {RelationshipOpts} from "../domain/RelationshipOpts.js";
+import {isModelClassFactory, RelationshipOpts} from "../domain/RelationshipOpts.js";
 import {createJoinKeys} from "./createJoinKeys.js";
 
 /**
  * @ignore
  */
 export function createRelationshipMapping([target, propertyKey]: DecoratorParameters, relation: RelationType, opts?: RelationshipOpts) {
-  return (targetClass: any) => ({
-    [propertyKey]: {
-      relation,
-      modelClass: opts?.type || Metadata.getType(target, propertyKey),
-      join: createJoinKeys(targetClass, target, String(propertyKey), relation, opts),
-      modify: opts?.modify,
-      filter: opts?.filter,
-      beforeInsert: opts?.beforeInsert
-    }
-  });
+  return (targetClass: any) => {
+    opts = opts
+      ? {
+          ...opts,
+          type: isModelClassFactory(opts.type) ? opts.type() : opts.type
+        }
+      : undefined;
+    return {
+      [propertyKey]: {
+        relation,
+        modelClass: opts?.type || Metadata.getType(target, propertyKey),
+        join: createJoinKeys(targetClass, target, String(propertyKey), relation, opts),
+        modify: opts?.modify,
+        filter: opts?.filter,
+        beforeInsert: opts?.beforeInsert
+      }
+    };
+  };
 }


### PR DESCRIPTION
## Information

Fixes issue, where esbuild does not put decorators at the end, which results in usage of types (module references) before their initialization.

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/platform-http";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
    - Added new test cases for `@BelongsToOne` decorator to validate:
        - Custom relationship model specification
        - Custom relationship path configuration
        - Functionality with options supplied in different configurations

- **Improvements**
    - Enhanced flexibility of the `BelongsToOne` decorator to accept various parameter types
    - Improved type-checking for model class specifications
    - Updated relationship mapping logic for better handling of options
    - Simplified logic in the `RelatesTo` function for direct use of `opts.type`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->