### PR TITLE
fix(core): methodsOf filters out getters and symbols

### DIFF
--- a/packages/core/src/utils/objects/methodsOf.spec.ts
+++ b/packages/core/src/utils/objects/methodsOf.spec.ts
@@ -1,0 +1,33 @@
+import {methodsOf} from "./methodsOf.js";
+
+describe("methodsOf()", () => {
+  it("should return methods", () => {
+    class TestClass {
+      method() {}
+
+      property: string;
+    }
+
+    const methods = methodsOf(TestClass);
+    expect(methods).toHaveLength(1);
+    expect(methods[0]).toMatchObject({
+      propertyKey: "method"
+    });
+  });
+  it("should not return getters", () => {
+    class TestClass {
+      method() {}
+
+      get property() {
+        return "";
+      }
+    }
+
+    const methods = methodsOf(TestClass);
+
+    expect(methods).toHaveLength(1);
+    expect(methods[0]).toMatchObject({
+      propertyKey: "method"
+    });
+  });
+});

--- a/packages/core/src/utils/objects/methodsOf.ts
+++ b/packages/core/src/utils/objects/methodsOf.ts
@@ -1,6 +1,7 @@
 import {Type} from "../../domain/Type.js";
 import {ancestorsOf} from "./ancestorsOf.js";
 import {classOf} from "./classOf.js";
+import {isSymbol} from "./isSymbol.js";
 import {prototypeOf} from "./prototypeOf.js";
 
 /**
@@ -15,9 +16,9 @@ export function methodsOf(target: any): {target: Type; propertyKey: string}[] {
     const keys = Reflect.ownKeys(prototypeOf(target));
 
     keys.forEach((propertyKey: string) => {
-      if (propertyKey !== "constructor") {
-        methods.set(propertyKey, {target, propertyKey});
-      }
+      if (isSymbol(propertyKey) || propertyKey === "constructor" || Object.getOwnPropertyDescriptor(prototypeOf(target), propertyKey)?.get)
+        return;
+      methods.set(propertyKey, {target, propertyKey});
     });
   });
 


### PR DESCRIPTION
## Information

fixes #2982

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/platform-http";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced functionality for extracting defined operations from components, ensuring that only the intended actions are recognized.

- **Tests**
  - Added comprehensive unit tests to validate correct extraction across various scenarios, including cases with getter properties.

- **Refactor**
  - Improved internal filtering to ignore unintended elements, bolstering overall reliability and consistency in behavior identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->