### PR TITLE
fix(schema): fix Default decorator signature

### DIFF
--- a/packages/specs/schema/src/components/default/schemaMapper.ts
+++ b/packages/specs/schema/src/components/default/schemaMapper.ts
@@ -1,4 +1,4 @@
-import {getValue, isObject} from "@tsed/core";
+import {getValue, isFunction, isObject} from "@tsed/core";
 
 import {mapAliasedProperties} from "../../domain/JsonAliasMap.js";
 import {JsonSchema} from "../../domain/JsonSchema.js";
@@ -125,6 +125,10 @@ function serializeSchema(schema: JsonSchema, options: JsonSchemaOptions) {
       ...obj,
       ...schema.get(options.specType as string).toJSON(options)
     };
+  }
+
+  if (isFunction(obj.default)) {
+    obj.default = obj.default();
   }
 
   obj = execMapper("required", [obj, schema], options);

--- a/packages/specs/schema/src/decorators/common/default.spec.ts
+++ b/packages/specs/schema/src/decorators/common/default.spec.ts
@@ -22,4 +22,24 @@ describe("@Default", () => {
       type: "object"
     });
   });
+  it("should declare prop (Date.now)", () => {
+    // WHEN
+    class Model {
+      @Default(Date.now)
+      num: Date = new Date();
+
+      constructor() {}
+    }
+
+    // THEN
+    expect(getJsonSchema(Model)).toEqual({
+      properties: {
+        num: {
+          default: expect.any(Number),
+          type: "string"
+        }
+      },
+      type: "object"
+    });
+  });
 });

--- a/packages/specs/schema/src/decorators/common/default.ts
+++ b/packages/specs/schema/src/decorators/common/default.ts
@@ -42,7 +42,7 @@ import {JsonEntityFn} from "./jsonEntityFn.js";
  * @schema
  * @input
  */
-export function Default(defaultValue: JSONSchema6Type | undefined) {
+export function Default(defaultValue: JSONSchema6Type | undefined | (() => JSONSchema6Type)) {
   return JsonEntityFn((store) => {
     store.itemSchema.default(defaultValue);
   });

--- a/packages/specs/schema/src/domain/JsonSchema.ts
+++ b/packages/specs/schema/src/domain/JsonSchema.ts
@@ -259,7 +259,7 @@ export class JsonSchema extends Map<string, any> implements NestedGenerics {
    * It is RECOMMENDED that a default value be valid against the associated schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.3
    */
-  default(value: JSONSchema6Type | undefined) {
+  default(value: JSONSchema6Type | undefined | (() => JSONSchema6Type)) {
     super.set("default", value);
 
     return this;


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature/Fix/Doc/Chore | Yes/No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/platform-http";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for dynamic default values. Users can now provide a function to dynamically generate default values when defining schemas or using property decorators.

- **Tests**
	- Introduced new test cases to verify the correct execution of dynamic default functions, including scenarios with date values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->