### PR TITLE
chore(deps): bump stripe from 9.16.0 to 17.7.0

### DIFF
--- a/packages/third-parties/stripe/package.json
+++ b/packages/third-parties/stripe/package.json
@@ -45,7 +45,7 @@
     "@tsed/schema": "workspace:*",
     "@tsed/typescript": "workspace:*",
     "eslint": "9.12.0",
-    "stripe": "^8.222.0",
+    "stripe": "^17.7.0",
     "typescript": "5.4.5",
     "vitest": "2.1.2"
   },
@@ -56,7 +56,7 @@
     "@tsed/schema": ">=8.5.2",
     "@types/body-parser": "^1.19.0",
     "body-parser": "^1.19.0",
-    "stripe": "^9.16.0"
+    "stripe": "^17.7.0"
   },
   "peerDependenciesMeta": {
     "@tsed/exceptions": {

--- a/packages/third-parties/stripe/src/middlewares/WebhookEventMiddleware.spec.ts
+++ b/packages/third-parties/stripe/src/middlewares/WebhookEventMiddleware.spec.ts
@@ -98,7 +98,14 @@ describe("WebhookEventMiddleware", () => {
     const actualError: any = catchError(() => middleware.use(signature, Buffer.from(payloadString), ctx));
 
     expect(actualError.message).toEqual(
-      "Stripe webhook error: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? https://github.com/stripe/stripe-node#webhook-signing, innerException: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? https://github.com/stripe/stripe-node#webhook-signing"
+      `Stripe webhook error: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? 
+ If a webhook request is being forwarded by a third-party tool, ensure that the exact request body, including JSON formatting and new line style, is preserved.
+
+Learn more about webhook signing and explore webhook integration examples for various frameworks at https://docs.stripe.com/webhooks/signature
+, innerException: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? 
+ If a webhook request is being forwarded by a third-party tool, ensure that the exact request body, including JSON formatting and new line style, is preserved.
+
+Learn more about webhook signing and explore webhook integration examples for various frameworks at https://docs.stripe.com/webhooks/signature`
     );
   });
   it("should throw error when secret is missing", async () => {

--- a/packages/third-parties/stripe/src/middlewares/WebhookEventMiddleware.spec.ts
+++ b/packages/third-parties/stripe/src/middlewares/WebhookEventMiddleware.spec.ts
@@ -17,7 +17,7 @@ describe("WebhookEventMiddleware", () => {
     PlatformTest.create({
       stripe: {
         apiKey: "the_api_key",
-        apiVersion: "2020-08-27",
+        apiVersion: "2025-02-24.acacia",
         webhooks: {
           secret: "whsec_test_secret",
           tolerance: 1

--- a/packages/third-parties/stripe/src/services/StripeFactory.spec.ts
+++ b/packages/third-parties/stripe/src/services/StripeFactory.spec.ts
@@ -9,7 +9,7 @@ describe("StripeFactory", () => {
       PlatformTest.create({
         stripe: {
           apiKey: "the_api_key",
-          apiVersion: "2020-08-27"
+          apiVersion: "2025-02-24.acacia"
         }
       })
     );

--- a/packages/third-parties/stripe/test/app/Server.ts
+++ b/packages/third-parties/stripe/test/app/Server.ts
@@ -15,7 +15,7 @@ export {rootDir};
   },
   stripe: {
     apiKey: "the_api_key",
-    apiVersion: "2020-08-27",
+    apiVersion: "2025-02-24.acacia",
     webhooks: {
       secret: "whsec_test_secret",
       tolerance: 1

--- a/packages/third-parties/stripe/test/stripe.integration.spec.ts
+++ b/packages/third-parties/stripe/test/stripe.integration.spec.ts
@@ -88,8 +88,14 @@ describe("Stripe", () => {
 
     expect(response.body).toEqual({
       errors: [],
-      message:
-        "Stripe webhook error: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? https://github.com/stripe/stripe-node#webhook-signing, innerException: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? https://github.com/stripe/stripe-node#webhook-signing",
+      message: `Stripe webhook error: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? 
+ If a webhook request is being forwarded by a third-party tool, ensure that the exact request body, including JSON formatting and new line style, is preserved.
+
+Learn more about webhook signing and explore webhook integration examples for various frameworks at https://docs.stripe.com/webhooks/signature
+, innerException: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? 
+ If a webhook request is being forwarded by a third-party tool, ensure that the exact request body, including JSON formatting and new line style, is preserved.
+
+Learn more about webhook signing and explore webhook integration examples for various frameworks at https://docs.stripe.com/webhooks/signature`,
       name: "Error",
       status: 400
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8581,7 +8581,7 @@ __metadata:
     "@tsed/schema": "workspace:*"
     "@tsed/typescript": "workspace:*"
     eslint: "npm:9.12.0"
-    stripe: "npm:^8.222.0"
+    stripe: "npm:^17.7.0"
     tslib: "npm:2.7.0"
     typescript: "npm:5.4.5"
     vitest: "npm:2.1.2"
@@ -8592,7 +8592,7 @@ __metadata:
     "@tsed/schema": ">=8.5.2"
     "@types/body-parser": ^1.19.0
     body-parser: ^1.19.0
-    stripe: ^9.16.0
+    stripe: ^17.7.0
   peerDependenciesMeta:
     "@tsed/exceptions":
       optional: false
@@ -25250,7 +25250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.3, qs@npm:^6.5.2":
+"qs@npm:^6.5.2":
   version: 6.10.3
   resolution: "qs@npm:6.10.3"
   dependencies:
@@ -27884,13 +27884,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stripe@npm:^8.222.0":
-  version: 8.222.0
-  resolution: "stripe@npm:8.222.0"
+"stripe@npm:^17.7.0":
+  version: 17.7.0
+  resolution: "stripe@npm:17.7.0"
   dependencies:
     "@types/node": "npm:>=8.1.0"
-    qs: "npm:^6.10.3"
-  checksum: 10/5d88142ec118c2799c9d96d96703e3136bb41b3c74609c1b532a4b2892d4611c73ef0ebad5f2fd1c6585591c1aca0ddcd1ab484bd1634e0632a00fd357d2bac2
+    qs: "npm:^6.11.0"
+  checksum: 10/376f945f9c194c8ea2d47d1fda50d141ed985cbb6f94041e11880084f830e502962d434967f1c90a3cb27a9b6e26c606f2830d9448bde636ebd6c067d5cbfecc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Chore | Yes          |

Update Stripe Node.js dependency version since a lot have changed since June 2022.

Refer to breaking changes from v9 to v17 on Stripe [docs](https://docs.stripe.com/changelog?breaking=true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the Stripe integration to version 17.7.0 for enhanced compatibility and performance.
  - Updated API configuration to version 2025-02-24.acacia for improved payment processing.
  - Enhanced error messages for webhook signature verification to provide clearer guidance and links to documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->