### PR TITLE
Improve scalar docs: document 'cdn' setting

### DIFF
--- a/docs/tutorials/scalar.md
+++ b/docs/tutorials/scalar.md
@@ -72,9 +72,10 @@ export class Server {}
 Some options are available to configure Scalar, Ts.ED and the default spec information.
 
 | Key                  | Example                                                       | Description                                                                                           |
-| -------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|----------------------| ------------------------------------------------------------- |-------------------------------------------------------------------------------------------------------|
 | path                 | `/api-doc`                                                    | The url subpath to access to the documentation.                                                       |
 | specVersion          | `3.0.1`                                                       | The OpenSpec version.                                                                                 |
+| cdn                  | `https://cdn.jsdelivr.net/npm/@scalar/api-reference`          | Url to the @scalar/api-reference package.                                                             |
 | fileName             | `openapi.json`                                                | OpenAPI file name. By default openapi.json.                                                           |
 | doc                  | `hidden-doc`                                                  | The documentation key used by `@Docs` decorator to create several openapi documentations.             |
 | viewPath             | `${rootDir}/views/scalar.ejs` or `false`                      | The path to the ejs template. Set false to disabled scalar.                                           |
@@ -89,6 +90,27 @@ Some options are available to configure Scalar, Ts.ED and the default spec infor
 | operationIdPattern   | `%c_%m`                                                       | A pattern to generate the operationId. Format of operationId field (%c: class name, %m: method name). |
 | pathPatterns         | `[]`                                                          | Include only controllers whose paths match the pattern list provided.                                 |
 | sortPaths            | `true`                                                        | Sort paths by alphabetical order.                                                                     |
+
+:::tip
+TsED relies on the latest version of the @scalar/api-reference package. If you need to use a specific version or have encountered an issue, you can specify the required version:
+```typescript
+import "@tsed/platform-express";
+import "@tsed/scalar"; // import scalar Ts.ED module
+
+import {Configuration} from "@tsed/di";
+
+@Configuration({
+  scalar: [
+    {
+      path: "/doc",
+      specVersion: "3.0.1",
+      cdn: "https://cdn.jsdelivr.net/npm/@scalar/api-reference@x.y.z"
+    }
+  ]
+})
+export class Server {}
+```
+:::
 
 ### Multi documentations
 

--- a/docs/tutorials/scalar.md
+++ b/docs/tutorials/scalar.md
@@ -72,7 +72,7 @@ export class Server {}
 Some options are available to configure Scalar, Ts.ED and the default spec information.
 
 | Key                  | Example                                                       | Description                                                                                           |
-|----------------------| ------------------------------------------------------------- |-------------------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | path                 | `/api-doc`                                                    | The url subpath to access to the documentation.                                                       |
 | specVersion          | `3.0.1`                                                       | The OpenSpec version.                                                                                 |
 | cdn                  | `https://cdn.jsdelivr.net/npm/@scalar/api-reference`          | Url to the @scalar/api-reference package.                                                             |
@@ -92,7 +92,9 @@ Some options are available to configure Scalar, Ts.ED and the default spec infor
 | sortPaths            | `true`                                                        | Sort paths by alphabetical order.                                                                     |
 
 :::tip
-TsED relies on the latest version of the @scalar/api-reference package. If you need to use a specific version or have encountered an issue, you can specify the required version:
+
+Ts.ED relies on the latest version of the @scalar/api-reference package. If you need to use a specific version or have encountered an issue, you can specify the required version:
+
 ```typescript
 import "@tsed/platform-express";
 import "@tsed/scalar"; // import scalar Ts.ED module
@@ -110,6 +112,7 @@ import {Configuration} from "@tsed/di";
 })
 export class Server {}
 ```
+
 :::
 
 ### Multi documentations

--- a/packages/specs/scalar/src/ScalarModule.ts
+++ b/packages/specs/scalar/src/ScalarModule.ts
@@ -19,7 +19,6 @@ export class ScalarModule extends OpenAPIBaseModule {
       return Object.assign(
         {
           disableSpec: false,
-          _integration: "tsed",
           cdn: "https://cdn.jsdelivr.net/npm/@scalar/api-reference",
           path: "/",
           fileName: "openapi.json",

--- a/packages/specs/scalar/src/middlewares/indexMiddleware.ts
+++ b/packages/specs/scalar/src/middlewares/indexMiddleware.ts
@@ -11,7 +11,6 @@ export function indexMiddleware(viewPath: string, conf: ScalarSettings) {
     const {path, options = {}, cssPath, cdn, fileName} = conf;
 
     const opts = {
-      _integration: "tsed",
       spec: {
         url: `${path}/${fileName}`
       },


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------- | ---------------- |
| Fix                     | No                       |
| Doc                   | No                       |

---

Document `cdn` setting of scalar and remove `_integration` from settings because the "tsed" value is not supported by the latest version of @scalar/api-reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined configuration settings by removing an obsolete integration detail for a cleaner structure.
- **Documentation**
	- Corrected the formatting of "Ts.ED" in the Scalar documentation for consistency.
	- Improved clarity in the documentation table header with formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->