### PR TITLE
fix(di): context.logger.level can be changed during request

### DIFF
--- a/packages/di/src/node/domain/ContextLogger.spec.ts
+++ b/packages/di/src/node/domain/ContextLogger.spec.ts
@@ -1,3 +1,5 @@
+import {levels, Logger} from "@tsed/logger";
+
 import {ContextLogger} from "./ContextLogger.js";
 
 function getIgnoreLogFixture(ignore: string[], url: string) {
@@ -97,6 +99,127 @@ describe("ContextLogger", () => {
     expect(logger.trace).toHaveBeenCalledWith({
       complete: "complete",
       duration: 1,
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+  });
+  it("should create a new Context with initial log level (error) and change the request log level (debug)", () => {
+    const logger = new Logger();
+    logger.level = "error";
+
+    vi.spyOn(logger, "error").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "debug").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "info").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "warn").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "trace").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "fatal").mockReturnValue(undefined as never);
+
+    const contextLogger = new ContextLogger({
+      event: {
+        request: {},
+        response: {}
+      },
+      logger,
+      id: "id",
+      dateStart: new Date("2019-01-01")
+    });
+
+    expect(logger.level).toEqual("ERROR");
+    expect(contextLogger.level).toEqual(levels().ERROR);
+
+    // WHEN
+    contextLogger.level = levels().DEBUG;
+
+    contextLogger.debug({test: "test"});
+    contextLogger.info({test: "test"});
+    contextLogger.warn({test: "test"});
+    contextLogger.error({test: "test"});
+    contextLogger.fatal({test: "test"});
+    contextLogger.trace({test: "test"});
+
+    contextLogger.flush();
+
+    // THEN
+    expect(logger.level).toEqual("ERROR");
+
+    expect(logger.info).toHaveBeenCalledWith({
+      duration: expect.any(Number),
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+
+    expect(logger.debug).toHaveBeenCalledWith({
+      duration: expect.any(Number),
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+    expect(logger.warn).toHaveBeenCalledWith({
+      duration: expect.any(Number),
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+    expect(logger.error).toHaveBeenCalledWith({
+      duration: expect.any(Number),
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+    expect(logger.fatal).toHaveBeenCalledWith({
+      duration: expect.any(Number),
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+  });
+  it("should create a new Context with initial log level (error) and not change the request log level", () => {
+    const logger = new Logger();
+    logger.level = "error";
+
+    vi.spyOn(logger, "error").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "debug").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "info").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "warn").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "trace").mockReturnValue(undefined as never);
+    vi.spyOn(logger, "fatal").mockReturnValue(undefined as never);
+
+    const contextLogger = new ContextLogger({
+      event: {
+        request: {},
+        response: {}
+      },
+      logger,
+      id: "id",
+      dateStart: new Date("2019-01-01")
+    });
+
+    expect(contextLogger.level).toEqual(levels().ERROR);
+
+    // WHEN
+    contextLogger.debug({test: "test"});
+    contextLogger.info({test: "test"});
+    contextLogger.warn({test: "test"});
+    contextLogger.error({test: "test"});
+    contextLogger.fatal({test: "test"});
+    contextLogger.trace({test: "test"});
+
+    contextLogger.flush();
+
+    // THEN
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.trace).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith({
+      duration: expect.any(Number),
+      reqId: "id",
+      test: "test",
+      time: expect.any(Date)
+    });
+    expect(logger.fatal).toHaveBeenCalledWith({
+      duration: expect.any(Number),
       reqId: "id",
       test: "test",
       time: expect.any(Date)

--- a/packages/di/src/node/domain/DIContext.spec.ts
+++ b/packages/di/src/node/domain/DIContext.spec.ts
@@ -27,6 +27,7 @@ describe("DIContext", () => {
       expect(context.env).toEqual("test");
       expect(context.PLATFORM).toEqual("DI");
 
+      context.logger.level = "info";
       context.logger.info("test");
 
       expect(logger().info).toHaveBeenCalled();
@@ -53,6 +54,7 @@ describe("DIContext", () => {
       expect(context.PLATFORM).toEqual("OTHER");
 
       context.next();
+      context.logger.level = "info";
       context.logger.info("test");
 
       expect(logger().info).toHaveBeenCalled();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added scenarios to verify that the logging behavior remains consistent across different log level settings.
  - Introduced new test cases for the `ContextLogger` to validate logging behavior with varying log levels.
  - Assigned the logger's level to "info" in test cases within the `DIContext` constructor tests to ensure proper logging behavior.

- **Refactor**
  - Enhanced the logging mechanism by improving internal state management and encapsulation for log levels, ensuring reliable and secure log processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->