### PR TITLE
fix(platform-http): ensure $onDestroy is called only once

### DIFF
--- a/packages/platform/platform-http/src/common/builder/PlatformBuilder.spec.ts
+++ b/packages/platform/platform-http/src/common/builder/PlatformBuilder.spec.ts
@@ -259,7 +259,7 @@ describe("PlatformBuilder", () => {
         expect(server.name).toEqual("custom");
 
         await server.stop();
-        expect($asyncEmit).toHaveBeenCalledWith("$onDestroy", []);
+        expect($asyncEmit).toHaveBeenCalledWith("$onDestroy");
       });
     });
     describe("adapter()", () => {

--- a/packages/platform/platform-http/src/common/builder/PlatformBuilder.ts
+++ b/packages/platform/platform-http/src/common/builder/PlatformBuilder.ts
@@ -264,7 +264,6 @@ export class PlatformBuilder<App = TsED.Application> {
   }
 
   async stop() {
-    await this.callHook("$onDestroy");
     await destroyInjector();
 
     this.#listeners.map(closeServer);


### PR DESCRIPTION
Closes: #3030


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the platform's shutdown process by removing a redundant cleanup step.
- **Tests**
  - Updated test expectations for the `$asyncEmit` function to simplify parameter checks during the server lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->