### PR TITLE
fix(platform-http): pass cookie options to clearCookie method

### DIFF
--- a/packages/platform/platform-http/src/common/services/PlatformResponse.spec.ts
+++ b/packages/platform/platform-http/src/common/services/PlatformResponse.spec.ts
@@ -354,7 +354,7 @@ describe("PlatformResponse", () => {
     it("should clear cookie", () => {
       const {res, response} = createResponse();
 
-      response.cookie("token", null, { maxAge: 0, path: "/", httpOnly: true, secure: true, sameSite: "none" });
+      response.cookie("token", null, {maxAge: 0, path: "/", httpOnly: true, secure: true, sameSite: "none"});
       expect(res.headers).toEqual({
         "set-cookie": "token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=None",
         "x-request-id": "id"

--- a/packages/platform/platform-http/src/common/services/PlatformResponse.spec.ts
+++ b/packages/platform/platform-http/src/common/services/PlatformResponse.spec.ts
@@ -350,5 +350,15 @@ describe("PlatformResponse", () => {
         "x-request-id": "id"
       });
     });
+
+    it("should clear cookie", () => {
+      const {res, response} = createResponse();
+
+      response.cookie("token", null, { maxAge: 0, path: "/", httpOnly: true, secure: true, sameSite: "none" });
+      expect(res.headers).toEqual({
+        "set-cookie": "token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=None",
+        "x-request-id": "id"
+      });
+    });
   });
 });

--- a/packages/platform/platform-http/src/common/services/PlatformResponse.ts
+++ b/packages/platform/platform-http/src/common/services/PlatformResponse.ts
@@ -343,7 +343,7 @@ export class PlatformResponse<Res extends Record<string, any> = any> {
 
   cookie(name: string, value: string | null, opts?: TsED.SetCookieOpts) {
     if (value === null) {
-      this.raw.clearCookie(name);
+      this.raw.clearCookie(name, opts);
       return this;
     }
 

--- a/packages/platform/platform-http/src/testing/FakeResponse.ts
+++ b/packages/platform/platform-http/src/testing/FakeResponse.ts
@@ -1,4 +1,5 @@
 import {EventEmitter} from "node:events";
+
 import cookie from "cookie";
 
 export class FakeResponse extends EventEmitter {
@@ -19,9 +20,7 @@ export class FakeResponse extends EventEmitter {
 
     if (prev) {
       // concat the new and prev vals
-      value = Array.isArray(prev) ? prev.concat(val)
-        : Array.isArray(val) ? [prev].concat(val)
-          : [prev, val]
+      value = Array.isArray(prev) ? prev.concat(val) : Array.isArray(val) ? [prev].concat(val) : [prev, val];
     }
 
     return this.set(field, value);
@@ -41,33 +40,31 @@ export class FakeResponse extends EventEmitter {
   }
 
   cookie(name: string, value: string, options?: TsED.SetCookieOpts) {
-    const opts = { ...options };
-    
-    const val = typeof value === 'object'
-      ? 'j:' + JSON.stringify(value)
-      : String(value);
+    const opts = {...options};
+
+    const val = typeof value === "object" ? "j:" + JSON.stringify(value) : String(value);
 
     if (opts.maxAge != null) {
-      const maxAge = opts.maxAge - 0
+      const maxAge = opts.maxAge - 0;
 
       if (!isNaN(maxAge)) {
-        opts.expires = new Date(Date.now() + maxAge)
-        opts.maxAge = Math.floor(maxAge / 1000)
+        opts.expires = new Date(Date.now() + maxAge);
+        opts.maxAge = Math.floor(maxAge / 1000);
       }
     }
 
     if (opts.path == null) {
-      opts.path = '/';
+      opts.path = "/";
     }
 
-    this.append('Set-Cookie', cookie.serialize(name, String(val), opts));
+    this.append("Set-Cookie", cookie.serialize(name, String(val), opts));
 
     return this;
   }
 
   clearCookie(name: string, options?: TsED.SetCookieOpts) {
-    const opts = { path: "/", ...options, expires: new Date(1) };
-    delete opts.maxAge
+    const opts = {path: "/", ...options, expires: new Date(1)};
+    delete opts.maxAge;
     return this.cookie(name, "", opts);
   }
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature/Fix/Doc/Chore | No          |

---

## Usage example

Usage is the same. It just passes the value of the opts parameter to clearCookie as it is needed to remove cookie properly.

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cookie removal to ensure cookie options are respected when clearing cookies.
- **New Features**
  - Added support for setting, appending, and clearing cookies with detailed options in response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->