### PR TITLE
3075 validation not run when typescript metadata not emitted for parameter decorated with bodyparams

### DIFF
--- a/packages/platform/platform-params/src/decorators/__snapshots__/bodyParams.spec.ts.snap
+++ b/packages/platform/platform-params/src/decorators/__snapshots__/bodyParams.spec.ts.snap
@@ -1,0 +1,105 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`@BodyParams > should generate the correct spec for BodyParams from given arg 1`] = `
+{
+  "components": {
+    "schemas": {
+      "TestModel": {
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "paths": {
+    "/": {
+      "post": {
+        "operationId": "myCtrlTest",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestModel",
+              },
+            },
+          },
+          "required": false,
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+          },
+        },
+        "tags": [
+          "MyCtrl",
+        ],
+      },
+    },
+  },
+  "tags": [
+    {
+      "name": "MyCtrl",
+    },
+  ],
+}
+`;
+
+exports[`@BodyParams > should generate the correct spec for BodyParams from metadata 1`] = `
+{
+  "components": {
+    "schemas": {
+      "TestModel": {
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "paths": {
+    "/": {
+      "post": {
+        "operationId": "myCtrlTest",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestModel",
+              },
+            },
+          },
+          "required": false,
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+          },
+        },
+        "tags": [
+          "MyCtrl",
+        ],
+      },
+    },
+  },
+  "tags": [
+    {
+      "name": "MyCtrl",
+    },
+  ],
+}
+`;

--- a/packages/platform/platform-params/src/decorators/bodyParams.spec.ts
+++ b/packages/platform/platform-params/src/decorators/bodyParams.spec.ts
@@ -295,27 +295,6 @@ describe("@BodyParams", () => {
         }
       ]
     });
-
-    // const param = JsonParameterStore.get(MyCtrl, "test", 0);
-    //
-    // const entity = getJsonEntityStore(param);
-    //
-    // console.log(entity._type, entity.schema);
-    //
-    // const schema = getJsonSchema(param);
-    //
-    // expect(schema).toEqual({
-    //   "properties": {
-    //     "name": {
-    //       "minLength": 1,
-    //       "type": "string"
-    //     }
-    //   },
-    //   "required": [
-    //     "name"
-    //   ],
-    //   "type": "object"
-    // });
   });
   it("should generate the correct spec for BodyParams from given type (TestModel)", () => {
     class TestModel {

--- a/packages/platform/platform-params/src/decorators/bodyParams.spec.ts
+++ b/packages/platform/platform-params/src/decorators/bodyParams.spec.ts
@@ -1,5 +1,5 @@
 import {Controller} from "@tsed/di";
-import {getSpec, JsonParameterStore, Post, SpecTypes} from "@tsed/schema";
+import {Description, getJsonSchema, getSpec, JsonParameterStore, MaxLength, MinItems, Post, Required, SpecTypes} from "@tsed/schema";
 
 import {ParamTypes} from "../domain/ParamTypes.js";
 import {BodyParams, RawBodyParams} from "./bodyParams.js";
@@ -56,6 +56,338 @@ describe("@BodyParams", () => {
           name: "MyCtrl"
         }
       ]
+    });
+  });
+  it("should generate the correct spec for BodyParams from metadata (string)", () => {
+    class TestModel {
+      @Required()
+      name: string;
+    }
+
+    @Controller("/")
+    class MyCtrl {
+      @Post()
+      test(@BodyParams() @Required() @MaxLength(10) @Description("Description") body: string) {}
+    }
+
+    const spec = getSpec(MyCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec).toEqual({
+      paths: {
+        "/": {
+          post: {
+            operationId: "myCtrlTest",
+            parameters: [],
+            requestBody: {
+              description: "Description",
+              content: {
+                "application/json": {
+                  schema: {
+                    minLength: 1,
+                    maxLength: 10,
+                    type: "string"
+                  }
+                }
+              },
+              required: true
+            },
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            },
+            tags: ["MyCtrl"]
+          }
+        }
+      },
+      tags: [
+        {
+          name: "MyCtrl"
+        }
+      ]
+    });
+  });
+  it("should generate the correct spec for BodyParams from metadata (string[])", () => {
+    class TestModel {
+      @Required()
+      name: string;
+    }
+
+    @Controller("/")
+    class MyCtrl {
+      @Post()
+      test(@BodyParams(String) @Required() @MaxLength(10) @MinItems(3) @Description("Description") body: string[]) {}
+    }
+
+    const spec = getSpec(MyCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec).toEqual({
+      paths: {
+        "/": {
+          post: {
+            operationId: "myCtrlTest",
+            parameters: [],
+            requestBody: {
+              description: "Description",
+              content: {
+                "application/json": {
+                  schema: {
+                    items: {
+                      maxLength: 10,
+                      type: "string"
+                    },
+                    minItems: 3,
+                    type: "array"
+                  }
+                }
+              },
+              required: true
+            },
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            },
+            tags: ["MyCtrl"]
+          }
+        }
+      },
+      tags: [
+        {
+          name: "MyCtrl"
+        }
+      ]
+    });
+  });
+  it("should generate the correct spec for BodyParams from metadata (TestModel)", () => {
+    class TestModel {
+      @Required()
+      name: string;
+    }
+
+    @Controller("/")
+    class MyCtrl {
+      @Post()
+      test(@BodyParams() @Required() @Description("Description") body: TestModel) {}
+    }
+
+    const spec = getSpec(MyCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec).toEqual({
+      components: {
+        schemas: {
+          TestModel: {
+            properties: {
+              name: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["name"],
+            type: "object"
+          }
+        }
+      },
+      paths: {
+        "/": {
+          post: {
+            operationId: "myCtrlTest",
+            parameters: [],
+            requestBody: {
+              description: "Description",
+              content: {
+                "application/json": {
+                  schema: {$ref: "#/components/schemas/TestModel"}
+                }
+              },
+              required: true
+            },
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            },
+            tags: ["MyCtrl"]
+          }
+        }
+      },
+      tags: [
+        {
+          name: "MyCtrl"
+        }
+      ]
+    });
+    const param = JsonParameterStore.get(MyCtrl, "test", 0);
+    const schema = getJsonSchema(param);
+
+    expect(schema).toEqual({
+      properties: {
+        name: {
+          minLength: 1,
+          type: "string"
+        }
+      },
+      required: ["name"],
+      type: "object"
+    });
+  });
+  it("should generate the correct spec for BodyParams from metadata (TestModel[])", () => {
+    class TestModel {
+      @Required()
+      name: string;
+    }
+
+    @Controller("/")
+    class MyCtrl {
+      @Post()
+      test(@BodyParams(TestModel) @MinItems(2) @Required() @Description("Description") body: TestModel[]) {}
+    }
+
+    const spec = getSpec(MyCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec).toEqual({
+      components: {
+        schemas: {
+          TestModel: {
+            properties: {
+              name: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["name"],
+            type: "object"
+          }
+        }
+      },
+      paths: {
+        "/": {
+          post: {
+            operationId: "myCtrlTest",
+            parameters: [],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    items: {
+                      $ref: "#/components/schemas/TestModel"
+                    },
+                    minItems: 2,
+                    type: "array"
+                  }
+                }
+              },
+              description: "Description",
+              required: true
+            },
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            },
+            tags: ["MyCtrl"]
+          }
+        }
+      },
+      tags: [
+        {
+          name: "MyCtrl"
+        }
+      ]
+    });
+
+    // const param = JsonParameterStore.get(MyCtrl, "test", 0);
+    //
+    // const entity = getJsonEntityStore(param);
+    //
+    // console.log(entity._type, entity.schema);
+    //
+    // const schema = getJsonSchema(param);
+    //
+    // expect(schema).toEqual({
+    //   "properties": {
+    //     "name": {
+    //       "minLength": 1,
+    //       "type": "string"
+    //     }
+    //   },
+    //   "required": [
+    //     "name"
+    //   ],
+    //   "type": "object"
+    // });
+  });
+  it("should generate the correct spec for BodyParams from given type (TestModel)", () => {
+    class TestModel {
+      @Required()
+      name: string;
+    }
+
+    @Controller("/")
+    class MyCtrl {
+      @Post()
+      test(@BodyParams(TestModel) @Required() @Description("Description") body: any) {}
+    }
+
+    const spec = getSpec(MyCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec).toEqual({
+      components: {
+        schemas: {
+          TestModel: {
+            properties: {
+              name: {
+                minLength: 1,
+                type: "string"
+              }
+            },
+            required: ["name"],
+            type: "object"
+          }
+        }
+      },
+      paths: {
+        "/": {
+          post: {
+            operationId: "myCtrlTest",
+            parameters: [],
+            requestBody: {
+              description: "Description",
+              content: {
+                "application/json": {
+                  schema: {$ref: "#/components/schemas/TestModel"}
+                }
+              },
+              required: true
+            },
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            },
+            tags: ["MyCtrl"]
+          }
+        }
+      },
+      tags: [
+        {
+          name: "MyCtrl"
+        }
+      ]
+    });
+
+    const param = JsonParameterStore.get(MyCtrl, "test", 0);
+    const schema = getJsonSchema(param);
+
+    expect(schema).toEqual({
+      properties: {
+        name: {
+          minLength: 1,
+          type: "string"
+        }
+      },
+      required: ["name"],
+      type: "object"
     });
   });
 });

--- a/packages/specs/json-mapper/test/integration/discriminator.integration.spec.ts
+++ b/packages/specs/json-mapper/test/integration/discriminator.integration.spec.ts
@@ -1,4 +1,3 @@
-import {classOf} from "@tsed/core";
 import {Controller} from "@tsed/di";
 import {BodyParams, PathParams} from "@tsed/platform-params";
 import {DiscriminatorKey, DiscriminatorValue, JsonParameterStore, OneOf, Property, Put, Required, Returns} from "@tsed/schema";

--- a/packages/specs/json-mapper/test/integration/discriminator.integration.spec.ts
+++ b/packages/specs/json-mapper/test/integration/discriminator.integration.spec.ts
@@ -1,3 +1,4 @@
+import {classOf} from "@tsed/core";
 import {Controller} from "@tsed/di";
 import {BodyParams, PathParams} from "@tsed/platform-params";
 import {DiscriminatorKey, DiscriminatorValue, JsonParameterStore, OneOf, Property, Put, Required, Returns} from "@tsed/schema";

--- a/packages/specs/schema/src/components/open-spec/operationRequestBodyMapper.ts
+++ b/packages/specs/schema/src/components/open-spec/operationRequestBodyMapper.ts
@@ -68,9 +68,11 @@ function buildSchemaFromBodyParameters(parameters: JsonParameter[], options: Jso
 }
 
 export function operationRequestBodyMapper(bodyParameters: JsonParameter[], {consumes, ...options}: JsonSchemaOptions) {
-  const {schema, examples, in: _, ...props} = buildSchemaFromBodyParameters(bodyParameters, options);
+  const {schema, description, examples, in: _, ...props} = buildSchemaFromBodyParameters(bodyParameters, options);
 
   const requestBody = new JsonRequestBody(props);
+
+  description && requestBody.description(description);
 
   consumes.forEach((consume: string) => {
     requestBody.addContent(consume, schema, examples);

--- a/packages/specs/schema/src/decorators/collections/collectionOf.ts
+++ b/packages/specs/schema/src/decorators/collections/collectionOf.ts
@@ -13,6 +13,7 @@ export interface ArrayOfChainedDecorators {
    * ::: tip
    * Omitting this keyword has the same behavior as a value of 0.
    * :::
+   * @deprecated Since 2025-05-12. Use MinItems decorator instead.
    */
   MinItems(minItems: number): this;
 
@@ -24,6 +25,7 @@ export interface ArrayOfChainedDecorators {
    * :: warning
    * The value `maxItems` MUST be a non-negative integer.
    * :::
+   * @deprecated Since 2025-05-12. Use MaxItems decorator instead.
    */
   MaxItems(maxItems: number): this;
 
@@ -31,11 +33,13 @@ export interface ArrayOfChainedDecorators {
    * Set the type of the item collection. The possible value is String, Boolean, Number, Date, Object, Class, etc...
    *
    * The array instance will be valid against "contains" if at least one of its elements is valid against the given schema.
+   * @deprecated Since 2025-05-12. Use Contains decorator instead.
    */
   Contains(): this;
 
   /**
    * If this keyword has boolean value false, the instance validates successfully. If it has boolean value true, the instance validates successfully if all of its elements are unique.
+   * @deprecated Since 2025-05-12. Use UniqueItems decorator instead.
    */
   UniqueItems(uniqueItems?: boolean): this;
 }
@@ -49,6 +53,7 @@ export interface MapOfChainedDecorators {
    * ::: warning
    * The value of this keyword MUST be a non-negative integer.
    * :::
+   * @deprecated Since 2025-05-12. Use MinProperties decorator instead.
    */
   MinProperties(minProperties: number): this;
 
@@ -58,6 +63,7 @@ export interface MapOfChainedDecorators {
    * ::: warning
    * The value of this keyword MUST be a non-negative integer.
    * :::
+   * @deprecated Since 2025-05-12. Use MaxProperties decorator instead.
    */
   MaxProperties(maxProperties: number): this;
 }
@@ -124,36 +130,51 @@ export function CollectionOf(type: any, collectionType?: any): CollectionOfChain
       store.schema.delete("items");
     }
   };
-
+  /**
+   * @deprecated Since 2025-05-12. Use MinItems decorator instead.
+   */
   decorator.MinItems = (minItems: number) => {
     schema.minItems = minItems;
 
     return decorator;
   };
-
+  /**
+   * @deprecated Since 2025-05-12. Use MaxItems decorator instead.
+   */
   decorator.MaxItems = (maxItems: number) => {
     schema.maxItems = maxItems;
 
     return decorator;
   };
+  /**
+   * @deprecated Since 2025-05-12. Use MinProperties decorator instead.
+   */
   decorator.MinProperties = (minProperties: number) => {
     schema.minProperties = minProperties;
 
     return decorator;
   };
-
+  /**
+   * @deprecated Since 2025-05-12. Use MaxProperties decorator instead.
+   */
   decorator.MaxProperties = (maxProperties: number) => {
     schema.maxProperties = maxProperties;
 
     return decorator;
   };
 
+  /**
+   * @deprecated Since 2025-05-12. Use Contains decorator instead.
+   */
   decorator.Contains = () => {
     contains = true;
 
     return decorator;
   };
 
+  /**
+   * @deprecated Since 2025-05-12. Use UniqueItems decorator instead.
+   */
   decorator.UniqueItems = (uniqueItems = true) => {
     schema.uniqueItems = uniqueItems;
 

--- a/packages/specs/schema/src/decorators/common/oneOf.ts
+++ b/packages/specs/schema/src/decorators/common/oneOf.ts
@@ -19,6 +19,5 @@ import {JsonEntityFn} from "./jsonEntityFn.js";
 export function OneOf(...oneOf: AnyJsonSchema[]) {
   return JsonEntityFn((entity) => {
     entity.itemSchema.oneOf(oneOf);
-    entity.type = Object;
   });
 }

--- a/packages/specs/schema/src/domain/JsonParameter.ts
+++ b/packages/specs/schema/src/domain/JsonParameter.ts
@@ -58,9 +58,12 @@ export class JsonParameter extends JsonMap<OS3Parameter<JsonSchema>> implements 
     return this;
   }
 
-  schema(schema?: JsonSchema): JsonSchema {
+  public schema(): JsonSchema;
+  public schema(schema: JsonSchema): this;
+  public schema(schema?: JsonSchema): JsonSchema | this {
     if (schema) {
       this.$schema = schema;
+      return this;
     }
 
     return this.$schema;
@@ -73,7 +76,9 @@ export class JsonParameter extends JsonMap<OS3Parameter<JsonSchema>> implements 
       return this.$schema.itemSchema();
     }
 
-    return this.schema(schema);
+    schema && this.schema(schema);
+    // non-collection: delegate to main schema would
+    return this.schema();
   }
 
   toJSON(options?: JsonSchemaOptions) {

--- a/packages/specs/schema/src/domain/JsonParameter.ts
+++ b/packages/specs/schema/src/domain/JsonParameter.ts
@@ -14,7 +14,7 @@ export class JsonParameter extends JsonMap<OS3Parameter<JsonSchema>> implements 
   nestedGenerics: Type<any>[][] = [];
   groups: string[];
   groupsName: string;
-  $schema: JsonSchema;
+  $schema: JsonSchema = new JsonSchema();
   expression: string;
 
   getName() {
@@ -58,10 +58,22 @@ export class JsonParameter extends JsonMap<OS3Parameter<JsonSchema>> implements 
     return this;
   }
 
-  schema(schema: JsonSchema): this {
-    this.$schema = schema;
+  schema(schema?: JsonSchema): JsonSchema {
+    if (schema) {
+      this.$schema = schema;
+    }
 
-    return this;
+    return this.$schema;
+  }
+
+  itemSchema(schema?: JsonSchema) {
+    if (this.$schema.isCollection) {
+      schema && this.$schema.itemSchema(schema);
+
+      return this.$schema.itemSchema();
+    }
+
+    return this.schema(schema);
   }
 
   toJSON(options?: JsonSchemaOptions) {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

---

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling and propagation of request body descriptions in OpenAPI documentation.
	- Enhanced support for managing collection item schemas in API parameter definitions.

- **Bug Fixes**
	- Correct propagation of required flags and descriptions in generated OpenAPI specs.

- **Documentation**
	- Added deprecation notices to certain collection-related decorators, with suggested alternatives.

- **Tests**
	- Added comprehensive new tests for body parameter validation, OpenAPI spec generation, and schema handling.
	- Introduced new validation scenarios for payloads with unspecified types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->