### PR TITLE
Feat add methods to pulse agenda module

### DIFF
--- a/packages/third-parties/agenda/src/AgendaModule.spec.ts
+++ b/packages/third-parties/agenda/src/AgendaModule.spec.ts
@@ -22,6 +22,7 @@ vi.mock("agenda", () => {
         save: vi.fn()
       });
       start = vi.fn();
+      on = vi.fn();
     }
   };
 });
@@ -135,6 +136,46 @@ describe("AgendaModule", () => {
 
         expect(agendaModule.agenda.stop).toHaveBeenCalledWith();
         expect(agendaModule.agenda.close).toHaveBeenCalledWith({force: true});
+      });
+    });
+
+    describe("_collection", () => {
+      it("should expose _collection", () => {
+        const agendaModule = PlatformTest.get<any>(AgendaModule)!;
+
+        agendaModule.agenda._collection = {fake: "collection"};
+
+        expect(agendaModule._collection).toEqual({fake: "collection"});
+      });
+    });
+    describe("_mdb", () => {
+      it("should expose _mdb", () => {
+        const agendaModule = PlatformTest.get<any>(AgendaModule)!;
+
+        agendaModule.agenda._mdb = {fake: "mdb"};
+
+        expect(agendaModule._mdb).toEqual({fake: "mdb"});
+      });
+    });
+    describe("cancel()", () => {
+      it("should call agenda.cancel", async () => {
+        const agendaModule = PlatformTest.get<any>(AgendaModule)!;
+        agendaModule.agenda.cancel = vi.fn().mockResolvedValue(42);
+
+        const result = await agendaModule.cancel({});
+
+        expect(agendaModule.agenda.cancel).toHaveBeenCalledWith({});
+        expect(result).toEqual(42);
+      });
+    });
+    describe("on()", () => {
+      it("should call agenda.on", () => {
+        const agendaModule = PlatformTest.get<any>(AgendaModule)!;
+        const listener = vi.fn();
+
+        agendaModule.on("fail", listener);
+
+        expect(agendaModule.agenda.on).toHaveBeenCalledWith("fail", listener);
       });
     });
   });

--- a/packages/third-parties/agenda/src/AgendaModule.ts
+++ b/packages/third-parties/agenda/src/AgendaModule.ts
@@ -2,6 +2,7 @@ import {Constant, DIContext, Inject, InjectorService, Module, OnDestroy, Provide
 import {Logger} from "@tsed/logger";
 import {AfterListen} from "@tsed/platform-http";
 import {Job, Processor} from "agenda";
+import type {Collection, Db, Document, Filter} from "agenda/node_modules/mongodb";
 import {v4 as uuid} from "uuid";
 
 import {PROVIDER_TYPE_AGENDA} from "./constants/constants.js";
@@ -106,6 +107,23 @@ export class AgendaModule implements OnDestroy, AfterListen {
 
   create(name: string, data?: any) {
     return this.agenda.create(name, data);
+  }
+
+  get _collection(): Collection | undefined {
+    return this.agenda._collection;
+  }
+
+  get _mdb(): Db | undefined {
+    return this.agenda._mdb;
+  }
+
+  on(event: string, listener: (jobOrErr: any, job?: Job) => void): this {
+    this.agenda.on(event, listener);
+    return this;
+  }
+
+  cancel(query: Filter<Document>): Promise<number | undefined> {
+    return this.agenda.cancel(query);
   }
 
   protected getProviders(): Provider<any>[] {

--- a/packages/third-parties/pulse/src/PulseModule.spec.ts
+++ b/packages/third-parties/pulse/src/PulseModule.spec.ts
@@ -22,6 +22,8 @@ vi.mock("@pulsecron/pulse", () => {
         save: vi.fn()
       });
       start = vi.fn();
+      on = vi.fn();
+      cancel = vi.fn();
     }
   };
 });
@@ -135,6 +137,45 @@ describe("PulseModule", () => {
 
         expect(pulseModule.pulse.stop).toHaveBeenCalledWith();
         expect(pulseModule.pulse.close).toHaveBeenCalledWith({force: true});
+      });
+    });
+    describe("_collection", () => {
+      it("should expose _collection", () => {
+        const pulseModule = PlatformTest.get<any>(PulseModule)!;
+
+        pulseModule.pulse._collection = {fake: "collection"};
+
+        expect(pulseModule._collection).toEqual({fake: "collection"});
+      });
+    });
+    describe("_mdb", () => {
+      it("should expose _mdb", () => {
+        const pulseModule = PlatformTest.get<any>(PulseModule)!;
+
+        pulseModule.pulse._mdb = {fake: "mdb"};
+
+        expect(pulseModule._mdb).toEqual({fake: "mdb"});
+      });
+    });
+    describe("cancel()", () => {
+      it("should call pulse.cancel", async () => {
+        const pulseModule = PlatformTest.get<any>(PulseModule)!;
+        pulseModule.pulse.cancel = vi.fn().mockResolvedValue(42);
+
+        const result = await pulseModule.cancel({});
+
+        expect(pulseModule.pulse.cancel).toHaveBeenCalledWith({});
+        expect(result).toEqual(42);
+      });
+    });
+    describe("on()", () => {
+      it("should call pulse.on", () => {
+        const pulseModule = PlatformTest.get<any>(PulseModule)!;
+        const listener = vi.fn();
+
+        pulseModule.on("fail", listener);
+
+        expect(pulseModule.pulse.on).toHaveBeenCalledWith("fail", listener);
       });
     });
   });

--- a/packages/third-parties/pulse/src/PulseModule.ts
+++ b/packages/third-parties/pulse/src/PulseModule.ts
@@ -1,4 +1,5 @@
-import {DefineOptions, Job, JobAttributesData, Processor} from "@pulsecron/pulse";
+import {DefineOptions, Job, JobAttributesData, Processor, PulseOnEventType} from "@pulsecron/pulse";
+import type {Collection, Db, Document, Filter} from "@pulsecron/pulse/node_modules/mongodb";
 import {Constant, DIContext, Inject, InjectorService, Module, OnDestroy, Provider, runInContext} from "@tsed/di";
 import {Logger} from "@tsed/logger";
 import {AfterListen} from "@tsed/platform-http";
@@ -76,6 +77,23 @@ export class PulseModule implements OnDestroy, AfterListen {
 
       this.logger.info({event: "PULSE_STOP", message: "Pulse stopped"});
     }
+  }
+
+  get _collection(): Collection | undefined {
+    return this.pulse._collection;
+  }
+
+  get _mdb(): Db | undefined {
+    return this.pulse._mdb;
+  }
+
+  on(event: PulseOnEventType, listener: (jobOrErr: any, job?: Job) => void): this {
+    this.pulse.on(event, listener);
+    return this;
+  }
+
+  cancel(query: Filter<Document>): Promise<number | undefined> {
+    return this.pulse.cancel(query);
   }
 
   define<T extends JobAttributesData>(name: string, processor: Processor<T>, options?: DefineOptions) {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---

In order to support agendash with Pulse, we need to access some vars like _collection and _mdb.

Moreover, this PR allows access to agenda.on() and pulse.on() method to be able to add an event listening. For example, you will be able to listen on "fail" event and add some logic in case of job failing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added access to underlying MongoDB collection and database instances in Agenda and Pulse modules.
  - Introduced event listener registration and job cancellation methods in Agenda and Pulse modules.

- **Tests**
  - Added tests to verify the new accessors and methods for Agenda and Pulse modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->