### PR TITLE
fix(ioredis): update registerConnectionProvider to use FactoryTokenPr…

### DIFF
--- a/packages/orm/ioredis/src/utils/registerConnectionProvider.ts
+++ b/packages/orm/ioredis/src/utils/registerConnectionProvider.ts
@@ -1,4 +1,4 @@
-import {constant, injectable, TokenProvider} from "@tsed/di";
+import {constant, type FactoryTokenProvider, injectable, TokenProvider} from "@tsed/di";
 import type {Redis} from "ioredis";
 
 import {IORedisConfiguration} from "../domain/IORedisConfiguration.js";
@@ -16,7 +16,7 @@ export interface CreateConnectionProviderProps {
 export const IOREDIS_CONNECTIONS = Symbol.for("ioredis:connections");
 export type IORedis = Redis & {name: string};
 
-export function registerConnectionProvider({token, provide, name = "default"}: CreateConnectionProviderProps) {
+export function registerConnectionProvider({token, provide, name = "default"}: CreateConnectionProviderProps): FactoryTokenProvider<Redis> {
   return injectable(provide || token, {
     connectionName: name
   })
@@ -27,5 +27,5 @@ export function registerConnectionProvider({token, provide, name = "default"}: C
 
       return item ? createConnection({...item, name}) : ({name} as any);
     })
-    .token();
+    .token() as FactoryTokenProvider<Redis>;
 }


### PR DESCRIPTION
…ovider type

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature/Fix/Doc/Chore | Yes/No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/platform-http";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved type safety and clarity for connection provider registration. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->