### PR TITLE
Fix typo on koa configuration page

### DIFF
--- a/docs/docs/configuration/koa.md
+++ b/docs/docs/configuration/koa.md
@@ -6,7 +6,7 @@
 To create Ts.ED application based on Koa.js, use [Ts.ED CLI](/introduction/getting-started.md).
 :::
 
-To configure the Fastify server, you can use the `koa` property in the `@Configuration` decorator.
+To configure the Koa server, you can use the `koa` property in the `@Configuration` decorator.
 
 ## koa.bodyParser
 


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/platform-http";

```
-->

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected documentation to accurately reference the Koa server instead of Fastify in configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->