### PR TITLE
3112 support generic multi framework route path convention and automatic conversion utility

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,7 @@ import pkg from "../../package.json";
 import referenceSidebar from "../public/reference-sidebar.json";
 import team from "../team.json";
 
-const sort = (items: { text: string; link: string }[]) => items.sort((a, b) => a.text.localeCompare(b.text))
+const sort = (items: {text: string; link: string}[]) => items.sort((a, b) => a.text.localeCompare(b.text));
 
 const Introduction = [
   {
@@ -50,6 +50,10 @@ const Docs = [
       {
         text: "Introduction",
         link: `/docs/controllers`
+      },
+      {
+        text: "Routing",
+        link: `/docs/routing`
       },
       {
         text: "DI & Providers",
@@ -251,7 +255,7 @@ const Tutorials = [
       {
         text: "Schema Formio",
         link: `/tutorials/schema-formio`
-      },
+      }
     ])
   },
   {
@@ -302,7 +306,7 @@ const Tutorials = [
       {
         text: "Temporal",
         link: `/tutorials/temporal`
-      },
+      }
     ])
   },
   {
@@ -315,7 +319,7 @@ const Tutorials = [
       {
         text: "Vitest",
         link: `/tutorials/vitest`
-      },
+      }
     ])
   },
   {

--- a/docs/docs/controllers.md
+++ b/docs/docs/controllers.md
@@ -15,8 +15,7 @@ Controllers are responsible for handling incoming **requests** and returning **r
 ![Client controller](./assets/client-controllers.png)
 
 A controller is here to handle a specific request for a given HTTP verb and Route. The routing service is responsible
-for
-managing and dispatching request to the right Controller.
+for managing and dispatching requests to the right Controller.
 
 In order to create a basic controller, we use classes and **decorators**. Decorators associate classes with required
 metadata and enable Ts.ED to create a routing map.
@@ -33,6 +32,10 @@ We'll specify a path for the controller which will be used by the routing mechan
 The @@Get@@ decorator before the `findAll()` method tells Ts.ED to create an endpoint for this particular route path and
 map every corresponding request to this handler. Since we've declared a prefix for every route (`/calendars`), Ts.ED
 will map every `GET /calendars` request to this method.
+
+::: tip
+For more details about the routing, see our guide to [routing](/docs/routing).
+:::
 
 ### Decorators
 
@@ -134,11 +137,12 @@ Getting parameters from Request can be done by using the following decorators:
 
 ::: tip
 
-Some decorators run automatically `validator` and `json-mapper`. This behavior can be changed (if the decorator is flagged as configurable)
+Some decorators run automatically `validator` and `json-mapper`. This behavior can be changed (if the decorator is
+flagged as configurable)
 like this:
 
 ```typescript
-@HeaderParams({expression: "x-header",  useValidator: true, useMapper: true })
+@HeaderParams({expression: "x-header", useValidator: true, useMapper: true})
 ```
 
 :::
@@ -261,14 +265,15 @@ By default, the validator/json-mapper aren't executed on header parameters.
 You have to add extra parameter to enable it:
 
 ```typescript
-@HeaderParams({expression: "x-header", useValidator: true, useMapper: true })
+@HeaderParams({expression: "x-header", useValidator: true, useMapper: true})
 ```
 
 :::
 
 ### Accept Mime
 
-@@AcceptMime@@ decorator provides you quick access to the `request.accepts()` and add given mime type to the consumable data types.
+@@AcceptMime@@ decorator provides you quick access to the `request.accepts()` and add given mime type to the consumable
+data types.
 
 ```typescript
 import {BodyParams} from "@tsed/platform-params";
@@ -493,7 +498,10 @@ With @@Returns@@ you can document correctly your endpoint to reflect the correct
 
 :::
 
-> See a live example of generics with Swagger documentation in our [interactive demo](https://codesandbox.io/embed/tsed-swagger-example-ripfl?fontsize=14&hidenavigation=1&theme=dark). This demo showcases how to implement and document generic types with proper Swagger/OpenAPI specifications.
+> See a live example of generics with Swagger documentation in
+>
+> our [interactive demo](https://codesandbox.io/embed/tsed-swagger-example-ripfl?fontsize=14&hidenavigation=1&theme=dark).
+> This demo showcases how to implement and document generic types with proper Swagger/OpenAPI specifications.
 
 ### Throw exceptions
 

--- a/docs/docs/routing.md
+++ b/docs/docs/routing.md
@@ -26,7 +26,8 @@ Ts.ED supports several path syntax conventions that allow you to define routes w
 | `/{:param}` | Optional parameter (v5 syntax) | `/users/{:id}` matches both `/users/123` and `/users` |
 | `/(.*)`     | Regular expression wildcard    | `/files/(.*)` matches `/files/any/path`               |
 
-Ts.ED try to be compatible with the most common conventions used in web frameworks like Express.js, Koa.js, and Fastify.
+Ts.ED tries to be compatible with the most common conventions used in web frameworks like Express.js, Koa.js, and
+Fastify.
 
 ::: warning
 RegExp in string paths are not converted by Ts.ED. Express.js v5 has removed support for RegExp in string paths.

--- a/docs/docs/routing.md
+++ b/docs/docs/routing.md
@@ -1,0 +1,217 @@
+---
+head:
+  - - meta
+    - name: description
+      content: Learn how Ts.ED manages routing paths, including wildcards, optional parameters, and other path conventions.
+  - - meta
+    - name: keywords
+      content: routing paths wildcards optional parameters path conventions ts.ed typescript node.js javascript decorators mvc
+---
+
+# Routing Path Conventions
+
+Ts.ED provides a flexible and powerful routing system that supports various path conventions. This guide explains how
+paths are managed in Ts.ED, including wildcards, optional parameters, and other path patterns.
+
+## Path Syntax Overview
+
+Ts.ED supports several path syntax conventions that allow you to define routes with dynamic segments:
+
+| Syntax      | Description                    | Example                                               |
+| ----------- | ------------------------------ | ----------------------------------------------------- |
+| `:param`    | Named parameter                | `/users/:id` matches `/users/123`                     |
+| `*`         | Wildcard (matches everything)  | `/files/*` matches `/files/any/path`                  |
+| `/:param*`  | Named wildcard                 | `/files/:path*` matches `/files/any/path`             |
+| `/:param?`  | Optional parameter             | `/users/:id?` matches both `/users/123` and `/users`  |
+| `/{:param}` | Optional parameter (v5 syntax) | `/users/{:id}` matches both `/users/123` and `/users` |
+| `/(.*)`     | Regular expression wildcard    | `/files/(.*)` matches `/files/any/path`               |
+
+Ts.ED try to be compatible with the most common conventions used in web frameworks like Express.js, Koa.js, and Fastify.
+
+::: warning
+RegExp in string paths are not converted by Ts.ED. Express.js v5 has removed support for RegExp in string paths.
+In this case, adapt your paths that use RegExp to use the appropriate syntax depending on the framework you are using.
+:::
+
+## Named Parameters
+
+The most common way to define dynamic segments in routes is using named parameters:
+
+```typescript
+@Controller("/users")
+class UsersController {
+  @Get("/:id")
+  getUser(@PathParams("id") id: string) {
+    // id will contain the value from the URL
+    return `User ID: ${id}`;
+  }
+}
+```
+
+When a request is made to `/users/123`, the `id` parameter will be `"123"`.
+
+## Wildcards
+
+Wildcards allow you to match any path segment or multiple segments:
+
+### Simple Wildcard
+
+```typescript
+@Controller("/files")
+class FilesController {
+  @Get("/*")
+  getFile(@PathParams("*") path: string) {
+    // path will contain everything after /files/
+    return `File path: ${path}`;
+  }
+}
+```
+
+A request to `/files/documents/report.pdf` will set `path` to `"documents/report.pdf"`.
+
+### Named Wildcards
+
+```typescript
+@Controller("/files")
+class FilesController {
+  @Get("/:path*")
+  getFile(@PathParams("path") path: string) {
+    // path will contain everything after /files/
+    return `File path: ${path}`;
+  }
+}
+```
+
+This works the same as the simple wildcard but uses a named parameter.
+
+### Regular Expression Wildcard
+
+```typescript
+@Controller("/files")
+class FilesController {
+  @Get("/(.*)")
+  getFile(@PathParams("*") path: string) {
+    // path will contain everything after /files/
+    return `File path: ${path}`;
+  }
+}
+```
+
+This is an alternative syntax that uses a regular expression pattern.
+
+## Optional Parameters
+
+Optional parameters allow a segment to be present or absent:
+
+### Using Question Mark
+
+```typescript
+@Controller("/users")
+class UsersController {
+  @Get("/:id?")
+  getUser(@PathParams("id") id: string) {
+    if (id) {
+      return `User ID: ${id}`;
+    }
+    return "User list";
+  }
+}
+```
+
+This route will match both `/users/123` and `/users`.
+
+### Using Braces (Express v5 syntax)
+
+```typescript
+@Controller("/users")
+class UsersController {
+  @Get("/{:id}")
+  getUser(@PathParams("id") id: string) {
+    if (id) {
+      return `User ID: ${id}`;
+    }
+    return "User list";
+  }
+}
+```
+
+This is the v5 syntax for optional parameters, which is equivalent to the question mark syntax. Ts.ED adapts this syntax
+to his equivalent
+for Express.js v4, Koa.js and Fastify.
+
+## Path Parameter Validation
+
+You can add validation to path parameters using decorators:
+
+```typescript
+@Controller("/users")
+class UsersController {
+  @Get("/:id")
+  getUser(@PathParams("id") @Pattern(/^[0-9a-fA-F]{24}$/) id: string) {
+    // This will only match if id is a valid 24-character hex string
+    return `User ID: ${id}`;
+  }
+}
+```
+
+If the validation fails, Ts.ED will automatically return a 400 Bad Request response.
+
+## Platform Adapter Considerations
+
+Different web frameworks handle path patterns differently. Ts.ED's platform adapters (Express, Koa, Fastify)
+automatically convert Ts.ED path conventions to the format expected by the underlying framework.
+
+For example:
+
+- Express uses `:param` for parameters and `*` for wildcards
+- Koa uses similar syntax but with some differences in wildcard handling
+- Fastify has its own path parameter syntax
+
+The platform adapters handle these differences transparently, allowing you to use the same path conventions regardless
+of the underlying framework.
+
+## Examples
+
+Here are some examples of different path patterns and how they match:
+
+```typescript
+@Controller("/path-params")
+class PathParamsController {
+  // Simple named parameter
+  @Get("/users/:id")
+  getUser(@PathParams("id") id: string) {
+    return `User ID: ${id}`;
+  }
+
+  // Wildcard
+  @Get("/files/*")
+  getFile(@PathParams("*") path: string) {
+    return `File path: ${path}`;
+  }
+
+  // Named wildcard
+  @Get("/docs/:path*")
+  getDoc(@PathParams("path") path: string) {
+    return `Doc path: ${path}`;
+  }
+
+  // Optional parameter
+  @Get("/products/:id?")
+  getProduct(@PathParams("id") id: string) {
+    return id ? `Product ID: ${id}` : "All products";
+  }
+
+  // Optional parameter (v5 syntax)
+  @Get("/categories/{:id}")
+  getCategory(@PathParams("id") id: string) {
+    return id ? `Category ID: ${id}` : "All categories";
+  }
+}
+```
+
+## Conclusion
+
+Ts.ED's routing system provides a flexible way to define routes with dynamic segments. By supporting various path
+conventions, it allows you to create clean and expressive APIs that can handle a wide range of URL patterns.
+
+For more information on controllers and routing, see the [Controllers documentation](./controllers.md).

--- a/packages/platform/platform-express/src/components/PlatformExpress.ts
+++ b/packages/platform/platform-express/src/components/PlatformExpress.ts
@@ -116,7 +116,7 @@ export class PlatformExpress extends PlatformAdapter<Express.Application> {
 
   mapLayers(layers: PlatformLayer[]) {
     const rawApp: any = this.app.getApp();
-    const v = "v" + version.split(".")[0];
+    const v = `v${version.split(".")[0]}`;
 
     layers.forEach((layer) => {
       const handlers = layer.getArgs(false);

--- a/packages/platform/platform-express/src/utils/convertPath.spec.ts
+++ b/packages/platform/platform-express/src/utils/convertPath.spec.ts
@@ -1,0 +1,73 @@
+import {convertPath} from "./convertPath.js";
+
+describe("Path conversion", () => {
+  describe("v4", () => {
+    it("should convert path with parameters correctly", () => {
+      // v4
+      expect(convertPath("/*", "v4")).toEqual({path: "/*", wildcard: "*"});
+      expect(convertPath("/foo/*", "v4")).toEqual({path: "/foo/*", wildcard: "*"});
+      expect(convertPath("/test/foo/*", "v4")).toEqual({path: "/test/foo/*", wildcard: "*"});
+      expect(convertPath("/test/:foo/*", "v4")).toEqual({path: "/test/:foo/*", wildcard: "*"});
+      expect(convertPath("/:param?", "v4")).toEqual({path: "/:param?"});
+      expect(convertPath("/foo/:param?", "v4")).toEqual({path: "/foo/:param?"});
+      expect(convertPath("/test/:foo/:param?", "v4")).toEqual({path: "/test/:foo/:param?"});
+      expect(convertPath("/test/:foo?/:param?", "v4")).toEqual({path: "/test/:foo?/:param?"});
+
+      // Ts.ED syntax
+      expect(convertPath("/:param*", "v4")).toEqual({path: "/*", wildcard: "param"});
+      expect(convertPath("/foo/:param*", "v4")).toEqual({path: "/foo/*", wildcard: "param"});
+      expect(convertPath("/:foo/:param*", "v4")).toEqual({path: "/:foo/*", wildcard: "param"});
+
+      // v5 compatibility to v4
+      expect(convertPath("/*splat", "v4")).toEqual({path: "/*", wildcard: "splat"});
+      expect(convertPath("/foo/*splat", "v4")).toEqual({path: "/foo/*", wildcard: "splat"});
+      expect(convertPath("/{:param}", "v4")).toEqual({path: "/:param?"});
+      expect(convertPath("/foo/{:param}", "v4")).toEqual({path: "/foo/:param?"});
+      expect(convertPath("/test/{:foo}/{:param}", "v4")).toEqual({path: "/test/:foo?/:param?"});
+      expect(convertPath("/test/:foo/{:param}", "v4")).toEqual({path: "/test/:foo/:param?"});
+
+      // v4 pattern to v4 wildcard
+      expect(convertPath("/(.*)", "v4")).toEqual({path: "/*", wildcard: "*"});
+      expect(convertPath("/foo/(.*)", "v4")).toEqual({path: "/foo/*", wildcard: "*"});
+
+      // preserve the original path for v4, not supported in v5
+      expect(convertPath("/[discussion|page]/:slug", "v4")).toEqual({path: "/[discussion|page]/:slug"});
+      expect(convertPath("/test/(.*)/end", "v4")).toEqual({path: "/test/(.*)/end"});
+    });
+  });
+
+  describe("v5", () => {
+    it("should convert path with parameters correctly", () => {
+      // v4 to v5 conversion
+      expect(convertPath("/*", "v5")).toEqual({path: "/{*wildcard}", wildcard: "*"});
+      expect(convertPath("/foo/*", "v5")).toEqual({path: "/foo/{*wildcard}", wildcard: "*"});
+      expect(convertPath("/test/foo/*", "v5")).toEqual({path: "/test/foo/{*wildcard}", wildcard: "*"});
+      expect(convertPath("/:param?", "v5")).toEqual({path: "/{:param}"});
+      expect(convertPath("/foo/:param?", "v5")).toEqual({path: "/foo/{:param}"});
+      expect(convertPath("/test/foo/:param?", "v5")).toEqual({path: "/test/foo/{:param}"});
+      expect(convertPath("/test/:foo/:param?", "v5")).toEqual({path: "/test/:foo/{:param}"});
+      expect(convertPath("/test/:foo?/:param?", "v5")).toEqual({path: "/test/{:foo}/{:param}"});
+      expect(convertPath("/(.*)", "v5")).toEqual({path: "/{*wildcard}", wildcard: "*"});
+      expect(convertPath("/foo/(.*)", "v5")).toEqual({path: "/foo/{*wildcard}", wildcard: "*"});
+      expect(convertPath("/test/foo/(.*)", "v5")).toEqual({path: "/test/foo/{*wildcard}", wildcard: "*"});
+      expect(convertPath("/test/:foo/(.*)", "v5")).toEqual({path: "/test/:foo/{*wildcard}", wildcard: "*"});
+
+      // Ts.ED syntax
+      expect(convertPath("/:param*", "v5")).toEqual({path: "/{*param}", wildcard: "param"});
+      expect(convertPath("/foo/:param*", "v5")).toEqual({path: "/foo/{*param}", wildcard: "param"});
+      expect(convertPath("/test/:foo/:param*", "v5")).toEqual({path: "/test/:foo/{*param}", wildcard: "param"});
+
+      // v5
+      expect(convertPath("/*splat", "v5")).toEqual({path: "/*splat", wildcard: "splat"});
+      expect(convertPath("/foo/*splat", "v5")).toEqual({path: "/foo/*splat", wildcard: "splat"});
+      expect(convertPath("/{*splat}", "v5")).toEqual({path: "/{*splat}", wildcard: "splat"});
+      expect(convertPath("/foo/{*splat}", "v5")).toEqual({path: "/foo/{*splat}", wildcard: "splat"});
+      expect(convertPath("/{:param}", "v5")).toEqual({path: "/{:param}"});
+      expect(convertPath("/foo/{:param}", "v5")).toEqual({path: "/foo/{:param}"});
+
+      // fail in v5, let developers handle it
+      expect(convertPath("/[discussion|page]/:slug", "v5")).toEqual({path: "/[discussion|page]/:slug"});
+      expect(convertPath("/test/(.*)/end", "v5")).toEqual({path: "/test/(.*)/end"});
+    });
+  });
+});

--- a/packages/platform/platform-express/src/utils/convertPath.ts
+++ b/packages/platform/platform-express/src/utils/convertPath.ts
@@ -11,9 +11,11 @@ interface ConvertPathResult {
  * Converts a path to v4 format
  */
 function convertPathToV4(path: string): ConvertPathResult {
-  const parsed = path.split("/").reduce(
+  const segments = path.split("/");
+
+  const parsed = segments.reduce(
     (options, segment, index) => {
-      const isLastSegment = index === path.split("/").length - 1;
+      const isLastSegment = index === segments.length - 1;
 
       if (isLastSegment && (segment === "*" || segment === "(.*)")) {
         options.wildcard = "*";
@@ -60,9 +62,11 @@ function convertPathToV4(path: string): ConvertPathResult {
  * Converts a path to v5 format
  */
 function convertPathToV5(path: string): ConvertPathResult {
-  const parsed = path.split("/").reduce(
+  const segments = path.split("/");
+
+  const parsed = segments.reduce(
     (options, segment, index) => {
-      const isLastSegment = index === path.split("/").length - 1;
+      const isLastSegment = index === segments.length - 1;
 
       if (isLastSegment && (segment === "*" || segment === "(.*)")) {
         options.wildcard = "*";

--- a/packages/platform/platform-express/src/utils/convertPath.ts
+++ b/packages/platform/platform-express/src/utils/convertPath.ts
@@ -1,0 +1,126 @@
+import {isString} from "@tsed/core";
+
+type Framework = "v4" | "v5";
+
+interface ConvertPathResult {
+  path: string | RegExp;
+  wildcard?: string;
+}
+
+/**
+ * Converts a path to v4 format
+ */
+function convertPathToV4(path: string): ConvertPathResult {
+  const parsed = path.split("/").reduce(
+    (options, segment, index) => {
+      const isLastSegment = index === path.split("/").length - 1;
+
+      if (isLastSegment && (segment === "*" || segment === "(.*)")) {
+        options.wildcard = "*";
+        options.path.push("*");
+        return options;
+      }
+
+      if (isLastSegment && segment.startsWith("*")) {
+        options.wildcard = segment.substring(1);
+        options.path.push("*");
+
+        return options;
+      }
+
+      if (segment.startsWith(":") && segment.endsWith("*")) {
+        options.wildcard = segment.substring(1, segment.length - 1);
+
+        options.path.push("*");
+        return options;
+      }
+
+      if (segment.startsWith("{")) {
+        // Handle v5 style parameters like /{param}
+        const paramName = segment.substring(1, segment.length - 1);
+        options.path.push(`${paramName}?`);
+
+        return options;
+      }
+
+      options.path.push(segment);
+
+      return options;
+    },
+    {path: [], wildcard: undefined} as {path: string[]; wildcard?: string}
+  );
+
+  return {
+    path: parsed.path.join("/"),
+    wildcard: parsed.wildcard
+  };
+}
+
+/**
+ * Converts a path to v5 format
+ */
+function convertPathToV5(path: string): ConvertPathResult {
+  const parsed = path.split("/").reduce(
+    (options, segment, index) => {
+      const isLastSegment = index === path.split("/").length - 1;
+
+      if (isLastSegment && (segment === "*" || segment === "(.*)")) {
+        options.wildcard = "*";
+        options.path.push("{*wildcard}");
+
+        return options;
+      }
+
+      if (isLastSegment && segment.startsWith("*")) {
+        options.wildcard = segment.substring(1);
+        options.path.push(segment);
+
+        return options;
+      }
+
+      if (segment.startsWith(":")) {
+        if (segment.endsWith("?")) {
+          options.path.push(`{:${segment.substring(1, segment.length - 1)}}`);
+
+          return options;
+        }
+
+        if (isLastSegment && segment.endsWith("*")) {
+          options.wildcard = segment.substring(1, segment.length - 1);
+          options.path.push(`{*${options.wildcard}}`);
+
+          return options;
+        }
+      }
+
+      if (isLastSegment && segment.startsWith("{*")) {
+        // Handle v5 style parameters like /{param}
+        options.wildcard = segment.substring(2, segment.length - 1);
+      }
+
+      options.path.push(segment);
+
+      return options;
+    },
+    {path: [], wildcard: undefined} as {path: string[]; wildcard?: string}
+  );
+
+  return {
+    path: parsed.path.join("/"),
+    wildcard: parsed.wildcard
+  };
+}
+
+/**
+ * Converts a path between v4 and v5 formats
+ */
+export function convertPath(path: string | RegExp, framework: Framework): ConvertPathResult {
+  if (isString(path)) {
+    if (framework === "v4") {
+      return convertPathToV4(path);
+    } else {
+      return convertPathToV5(path);
+    }
+  }
+  return {path};
+}

--- a/packages/platform/platform-fastify/src/utils/convertPath.spec.ts
+++ b/packages/platform/platform-fastify/src/utils/convertPath.spec.ts
@@ -1,0 +1,36 @@
+import {convertPath} from "./convertPath.js";
+
+describe("Path conversion", () => {
+  it("should convert path with parameters correctly", () => {
+    // v4
+    expect(convertPath("/*")).toEqual({path: "/*", wildcard: "*"});
+    expect(convertPath("/foo/*")).toEqual({path: "/foo/*", wildcard: "*"});
+    expect(convertPath("/test/foo/*")).toEqual({path: "/test/foo/*", wildcard: "*"});
+    expect(convertPath("/test/:foo/*")).toEqual({path: "/test/:foo/*", wildcard: "*"});
+    expect(convertPath("/:param?")).toEqual({path: "/:param?"});
+    expect(convertPath("/foo/:param?")).toEqual({path: "/foo/:param?"});
+    expect(convertPath("/test/:foo/:param?")).toEqual({path: "/test/:foo/:param?"});
+    expect(convertPath("/test/:foo?/:param?")).toEqual({path: "/test/:foo?/:param?"});
+
+    // Ts.ED syntax
+    expect(convertPath("/:param*")).toEqual({path: "/*", wildcard: "param"});
+    expect(convertPath("/foo/:param*")).toEqual({path: "/foo/*", wildcard: "param"});
+    expect(convertPath("/:foo/:param*")).toEqual({path: "/:foo/*", wildcard: "param"});
+
+    // Express v5 compatibility to @koa/router
+    expect(convertPath("/*splat")).toEqual({path: "/*", wildcard: "splat"});
+    expect(convertPath("/foo/*splat")).toEqual({path: "/foo/*", wildcard: "splat"});
+    expect(convertPath("/{:param}")).toEqual({path: "/:param?"});
+    expect(convertPath("/foo/{:param}")).toEqual({path: "/foo/:param?"});
+    expect(convertPath("/test/{:foo}/{:param}")).toEqual({path: "/test/:foo?/:param?"});
+    expect(convertPath("/test/:foo/{:param}")).toEqual({path: "/test/:foo/:param?"});
+
+    // v4 pattern to v4 wildcard
+    expect(convertPath("/(.*)")).toEqual({path: "/*", wildcard: "*"});
+    expect(convertPath("/foo/(.*)")).toEqual({path: "/foo/*", wildcard: "*"});
+
+    // preserve the original path for v4, not supported in v5
+    expect(convertPath("/[discussion|page]/:slug")).toEqual({path: "/[discussion|page]/:slug"});
+    expect(convertPath("/test/(.*)/end")).toEqual({path: "/test/(.*)/end"});
+  });
+});

--- a/packages/platform/platform-fastify/src/utils/convertPath.ts
+++ b/packages/platform/platform-fastify/src/utils/convertPath.ts
@@ -1,0 +1,57 @@
+import {isString} from "@tsed/core";
+
+interface ConvertPathResult {
+  path: string | RegExp;
+  wildcard?: string;
+}
+
+export function convertPath(path: string | RegExp): ConvertPathResult {
+  if (isString(path)) {
+    const parsed = path.split("/").reduce(
+      (options, segment, index) => {
+        const isLastSegment = index === path.split("/").length - 1;
+
+        if (isLastSegment && (segment === "*" || segment === "(.*)")) {
+          options.wildcard = "*";
+          options.path.push("*");
+
+          return options;
+        }
+
+        if (isLastSegment && segment.startsWith("*")) {
+          options.wildcard = segment.substring(1);
+          options.path.push("*");
+
+          return options;
+        }
+
+        if (segment.startsWith(":") && segment.endsWith("*")) {
+          options.wildcard = segment.substring(1, segment.length - 1);
+          options.path.push("*");
+
+          return options;
+        }
+
+        if (segment.startsWith("{:") && segment.endsWith("}")) {
+          // Handle v5 style parameters like /{param}
+          const paramName = segment.substring(2, segment.length - 1);
+          options.path.push(`:${paramName}?`);
+
+          return options;
+        }
+
+        options.path.push(segment);
+
+        return options;
+      },
+      {path: [], wildcard: undefined} as {path: string[]; wildcard?: string}
+    );
+
+    return {
+      path: parsed.path.join("/"),
+      wildcard: parsed.wildcard
+    };
+  }
+
+  return {path};
+}

--- a/packages/platform/platform-fastify/src/utils/convertPath.ts
+++ b/packages/platform/platform-fastify/src/utils/convertPath.ts
@@ -7,9 +7,11 @@ interface ConvertPathResult {
 
 export function convertPath(path: string | RegExp): ConvertPathResult {
   if (isString(path)) {
-    const parsed = path.split("/").reduce(
+    const segments = path.split("/");
+
+    const parsed = segments.reduce(
       (options, segment, index) => {
-        const isLastSegment = index === path.split("/").length - 1;
+        const isLastSegment = index === segments.length - 1;
 
         if (isLastSegment && (segment === "*" || segment === "(.*)")) {
           options.wildcard = "*";

--- a/packages/platform/platform-http/src/common/services/PlatformRequest.ts
+++ b/packages/platform/platform-http/src/common/services/PlatformRequest.ts
@@ -1,6 +1,6 @@
 import {IncomingHttpHeaders, IncomingMessage} from "node:http";
 
-import {Injectable, injectable, ProviderScope, Scope} from "@tsed/di";
+import {injectable, ProviderScope} from "@tsed/di";
 
 import type {PlatformContext} from "../domain/PlatformContext.js";
 import type {PlatformResponse} from "./PlatformResponse.js";
@@ -20,6 +20,7 @@ declare global {
  */
 export class PlatformRequest<Req extends {[key: string]: any} = any> {
   constructor(readonly $ctx: PlatformContext) {}
+
   /**
    * The current @@PlatformResponse@@.
    */

--- a/packages/platform/platform-koa/src/utils/convertPath.spec.ts
+++ b/packages/platform/platform-koa/src/utils/convertPath.spec.ts
@@ -1,0 +1,36 @@
+import {convertPath} from "./convertPath.js";
+
+describe("Path conversion", () => {
+  it("should convert path with parameters correctly", () => {
+    // v4
+    expect(convertPath("/*")).toEqual({path: "/(.*)", wildcard: "*"});
+    expect(convertPath("/foo/*")).toEqual({path: "/foo/(.*)", wildcard: "*"});
+    expect(convertPath("/test/foo/*")).toEqual({path: "/test/foo/(.*)", wildcard: "*"});
+    expect(convertPath("/test/:foo/*")).toEqual({path: "/test/:foo/(.*)", wildcard: "*"});
+    expect(convertPath("/:param?")).toEqual({path: "/:param?"});
+    expect(convertPath("/foo/:param?")).toEqual({path: "/foo/:param?"});
+    expect(convertPath("/test/:foo/:param?")).toEqual({path: "/test/:foo/:param?"});
+    expect(convertPath("/test/:foo?/:param?")).toEqual({path: "/test/:foo?/:param?"});
+
+    // Ts.ED syntax
+    expect(convertPath("/:param*")).toEqual({path: "/:param*", wildcard: "param"});
+    expect(convertPath("/foo/:param*")).toEqual({path: "/foo/:param*", wildcard: "param"});
+    expect(convertPath("/:foo/:param*")).toEqual({path: "/:foo/:param*", wildcard: "param"});
+
+    // Express v5 compatibility to @koa/router
+    expect(convertPath("/*splat")).toEqual({path: "/:splat*", wildcard: "splat"});
+    expect(convertPath("/foo/*splat")).toEqual({path: "/foo/:splat*", wildcard: "splat"});
+    expect(convertPath("/{:param}")).toEqual({path: "/:param?"});
+    expect(convertPath("/foo/{:param}")).toEqual({path: "/foo/:param?"});
+    expect(convertPath("/test/{:foo}/{:param}")).toEqual({path: "/test/:foo?/:param?"});
+    expect(convertPath("/test/:foo/{:param}")).toEqual({path: "/test/:foo/:param?"});
+
+    // v4 pattern to v4 wildcard
+    expect(convertPath("/(.*)")).toEqual({path: "/(.*)", wildcard: "*"});
+    expect(convertPath("/foo/(.*)")).toEqual({path: "/foo/(.*)", wildcard: "*"});
+
+    // preserve the original path for v4, not supported in v5
+    expect(convertPath("/[discussion|page]/:slug")).toEqual({path: "/[discussion|page]/:slug"});
+    expect(convertPath("/test/(.*)/end")).toEqual({path: "/test/(.*)/end"});
+  });
+});

--- a/packages/platform/platform-koa/src/utils/convertPath.ts
+++ b/packages/platform/platform-koa/src/utils/convertPath.ts
@@ -7,9 +7,11 @@ interface ConvertPathResult {
 
 export function convertPath(path: string | RegExp): ConvertPathResult {
   if (isString(path)) {
-    const parsed = path.split("/").reduce(
+    const segments = path.split("/");
+
+    const parsed = segments.reduce(
       (options, segment, index) => {
-        const isLastSegment = index === path.split("/").length - 1;
+        const isLastSegment = index === segments.length - 1;
 
         if (isLastSegment && (segment === "*" || segment === "(.*)")) {
           options.wildcard = "*";

--- a/packages/platform/platform-koa/src/utils/convertPath.ts
+++ b/packages/platform/platform-koa/src/utils/convertPath.ts
@@ -1,0 +1,57 @@
+import {isString} from "@tsed/core";
+
+interface ConvertPathResult {
+  path: string | RegExp;
+  wildcard?: string;
+}
+
+export function convertPath(path: string | RegExp): ConvertPathResult {
+  if (isString(path)) {
+    const parsed = path.split("/").reduce(
+      (options, segment, index) => {
+        const isLastSegment = index === path.split("/").length - 1;
+
+        if (isLastSegment && (segment === "*" || segment === "(.*)")) {
+          options.wildcard = "*";
+          options.path.push("(.*)");
+
+          return options;
+        }
+
+        if (segment.startsWith(":") && segment.endsWith("*")) {
+          options.wildcard = segment.substring(1, segment.length - 1);
+          options.path.push(segment);
+
+          return options;
+        }
+
+        if (isLastSegment && segment.startsWith("*")) {
+          options.wildcard = segment.substring(1);
+          options.path.push(`:${options.wildcard}*`);
+
+          return options;
+        }
+
+        if (segment.startsWith("{:") && segment.endsWith("}")) {
+          // Handle v5 style parameters like /{param}
+          const paramName = segment.substring(2, segment.length - 1);
+          options.path.push(`:${paramName}?`);
+
+          return options;
+        }
+
+        options.path.push(segment);
+
+        return options;
+      },
+      {path: [], wildcard: undefined} as {path: string[]; wildcard?: string}
+    );
+
+    return {
+      path: parsed.path.join("/"),
+      wildcard: parsed.wildcard
+    };
+  }
+
+  return {path};
+}

--- a/packages/platform/platform-router/src/domain/PlatformLayer.ts
+++ b/packages/platform/platform-router/src/domain/PlatformLayer.ts
@@ -51,7 +51,7 @@ export class PlatformLayer {
     this.#args = args;
   }
 
-  getArgs(withPath: true): [SinglePathType, ...PlatformParamsCallback[]];
+  getArgs(withPath?: true): [SinglePathType, ...PlatformParamsCallback[]];
   getArgs(withPath: false): PlatformParamsCallback[];
   getArgs(withPath = true) {
     return [withPath ? this.path : null, ...this.#args].filter(Boolean);

--- a/packages/platform/platform-router/src/domain/PlatformLayer.ts
+++ b/packages/platform/platform-router/src/domain/PlatformLayer.ts
@@ -51,8 +51,10 @@ export class PlatformLayer {
     this.#args = args;
   }
 
-  getArgs() {
-    return [this.path, ...this.#args].filter(Boolean);
+  getArgs(withPath: true): [SinglePathType, ...PlatformParamsCallback[]];
+  getArgs(withPath: false): PlatformParamsCallback[];
+  getArgs(withPath = true) {
+    return [withPath ? this.path : null, ...this.#args].filter(Boolean);
   }
 
   isProvider() {

--- a/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
@@ -1,4 +1,5 @@
 import {Controller} from "@tsed/di";
+import type {PlatformContext} from "@tsed/platform-http";
 import {PlatformTest} from "@tsed/platform-http/testing";
 import {Context, PathParams} from "@tsed/platform-params";
 import {Get, Pattern, Post} from "@tsed/schema";
@@ -50,6 +51,27 @@ class TestPathParamsCtrl {
   testScenario6(@PathParams("id") id: number) {
     return {id};
   }
+
+  // test path syntaxes
+  @Get("/syntax-1/*")
+  testSyntax1(@PathParams("*") wildcard: string, @Context() ctx: PlatformContext) {
+    return {wildcard};
+  }
+
+  @Get("/syntax-2/(.*)")
+  testSyntax2(@PathParams("*") wildcard: string, @Context() ctx: PlatformContext) {
+    return {wildcard};
+  }
+
+  @Get("/syntax-3/:named*")
+  testSyntax3(@PathParams("named") wildcard: string, @Context() ctx: PlatformContext) {
+    return {wildcard};
+  }
+
+  @Get("/syntax-4/:named?")
+  testSyntax4(@PathParams("named") named: string, @Context() ctx: PlatformContext) {
+    return {named};
+  }
 }
 
 export function testPathParams(options: PlatformTestingSdkOpts) {
@@ -58,6 +80,9 @@ export function testPathParams(options: PlatformTestingSdkOpts) {
   beforeAll(
     PlatformTest.bootstrap(options.server, {
       ...options,
+      logger: {
+        level: "info"
+      },
       mount: {
         "/rest": [TestPathParamsCtrl]
       }
@@ -123,5 +148,31 @@ export function testPathParams(options: PlatformTestingSdkOpts) {
     const response = await request.get("/rest/path-params/scenario-6/1").expect(200);
 
     expect(response.body).toEqual({id: 1});
+  });
+
+  describe("path syntaxes", () => {
+    it("Syntax 1: GET /rest/path-params/syntax-1/*", async () => {
+      const response = await request.get("/rest/path-params/syntax-1/abc/def").expect(200);
+
+      expect(response.body).toEqual({wildcard: "abc/def"});
+    });
+
+    it("Syntax 2: GET /rest/path-params/syntax-2/(.*)", async () => {
+      const response = await request.get("/rest/path-params/syntax-2/abc/def").expect(200);
+
+      expect(response.body).toEqual({wildcard: "abc/def"});
+    });
+
+    it("Syntax 2: GET /rest/path-params/syntax-3/:named*", async () => {
+      const response = await request.get("/rest/path-params/syntax-3/abc/def").expect(200);
+
+      expect(response.body).toEqual({wildcard: "abc/def"});
+    });
+
+    it("Syntax 3: GET /rest/path-params/syntax-4/:named?", async () => {
+      const response = await request.get("/rest/path-params/syntax-4/named").expect(200);
+
+      expect(response.body).toEqual({named: "named"});
+    });
   });
 }

--- a/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
@@ -4,7 +4,7 @@ import {PlatformTest} from "@tsed/platform-http/testing";
 import {Context, PathParams} from "@tsed/platform-params";
 import {Get, Pattern, Post} from "@tsed/schema";
 import SuperTest from "supertest";
-import {afterAll, beforeAll, expect, it} from "vitest";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
 
 import {PlatformTestingSdkOpts} from "../interfaces/index.js";
 

--- a/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
@@ -81,9 +81,9 @@ export function testPathParams(options: PlatformTestingSdkOpts) {
   beforeAll(
     PlatformTest.bootstrap(options.server, {
       ...options,
-      logger: {
-        level: "info"
-      },
+      // logger: {
+      //   level: "info"
+      // },
       mount: {
         "/rest": [TestPathParamsCtrl]
       }
@@ -164,13 +164,13 @@ export function testPathParams(options: PlatformTestingSdkOpts) {
       expect(response.body).toEqual({wildcard: "abc/def"});
     });
 
-    it("Syntax 2: GET /rest/path-params/syntax-3/:named*", async () => {
+    it("Syntax 3: GET /rest/path-params/syntax-3/:named*", async () => {
       const response = await request.get("/rest/path-params/syntax-3/abc/def").expect(200);
 
       expect(response.body).toEqual({wildcard: "abc/def"});
     });
 
-    it("Syntax 3: GET /rest/path-params/syntax-4/:named?", async () => {
+    it("Syntax 4: GET /rest/path-params/syntax-4/:named?", async () => {
       const response = await request.get("/rest/path-params/syntax-4/named").expect(200);
 
       expect(response.body).toEqual({named: "named"});

--- a/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testPathParams.ts
@@ -53,6 +53,7 @@ class TestPathParamsCtrl {
   }
 
   // test path syntaxes
+
   @Get("/syntax-1/*")
   testSyntax1(@PathParams("*") wildcard: string, @Context() ctx: PlatformContext) {
     return {wildcard};


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---


## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive documentation on routing path conventions, including a new "Routing" guide and sidebar link.
  * Enhanced support for various route path patterns and wildcards across Express, Koa, and Fastify platforms.
  * Improved static asset route handling to support regular expressions.
  * Added new test endpoints demonstrating wildcard and optional path parameter usage.

* **Bug Fixes**
  * Ensured consistent extraction and mapping of wildcard parameters in route handlers for all supported platforms.

* **Documentation**
  * Expanded and clarified platform adapter and controller documentation, with new examples and formatting improvements.

* **Tests**
  * Introduced extensive test coverage for path conversion utilities and new route parameter patterns.

* **Style**
  * Minor formatting and code cleanup in documentation and codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->