### PR TITLE
fix(schema): enforce items when type is array

### DIFF
--- a/packages/platform/platform-express/test/__snapshots__/array-body.spec.ts.snap
+++ b/packages/platform/platform-express/test/__snapshots__/array-body.spec.ts.snap
@@ -44,6 +44,7 @@ exports[`Array Body > swagger > should return the swagger (OS3) 1`] = `
                       "type": "boolean",
                     },
                     {
+                      "items": {},
                       "type": "array",
                     },
                     {
@@ -92,6 +93,7 @@ exports[`Array Body > swagger > should return the swagger (OS3) 1`] = `
                       "type": "boolean",
                     },
                     {
+                      "items": {},
                       "type": "array",
                     },
                     {
@@ -217,6 +219,7 @@ exports[`Array Body > swagger > should return the swagger (OS3) 1`] = `
                     "type": "boolean",
                   },
                   {
+                    "items": {},
                     "type": "array",
                   },
                   {

--- a/packages/platform/platform-express/test/pageable.spec.ts
+++ b/packages/platform/platform-express/test/pageable.spec.ts
@@ -191,6 +191,7 @@ describe("Pageable", () => {
             "Pagination": {
               "properties": {
                 "data": {
+                  "items": {},
                   "type": "array",
                 },
                 "page": {

--- a/packages/specs/schema/src/components/default/schemaMapper.ts
+++ b/packages/specs/schema/src/components/default/schemaMapper.ts
@@ -135,6 +135,10 @@ function serializeSchema(schema: JsonSchema, options: JsonSchemaOptions) {
   obj = execMapper("discriminatorMapping", [obj, schema], options);
   obj = execMapper("generics", [obj, schema], options);
 
+  if (obj.type === "array" && !obj.items && !obj.contains) {
+    obj.items = {};
+  }
+
   return obj;
 }
 

--- a/packages/specs/schema/src/decorators/common/any.spec.ts
+++ b/packages/specs/schema/src/decorators/common/any.spec.ts
@@ -10,37 +10,40 @@ describe("@Any", () => {
     }
 
     // THEN
-    expect(getJsonSchema(Model)).toEqual({
-      properties: {
-        prop: {
-          anyOf: [
-            {
-              type: "null"
-            },
-            {
-              multipleOf: 1,
-              type: "integer"
-            },
-            {
-              type: "number"
-            },
-            {
-              type: "string"
-            },
-            {
-              type: "boolean"
-            },
-            {
-              type: "array"
-            },
-            {
-              type: "object"
-            }
-          ]
-        }
-      },
-      type: "object"
-    });
+    expect(getJsonSchema(Model)).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "prop": {
+            "anyOf": [
+              {
+                "type": "null",
+              },
+              {
+                "multipleOf": 1,
+                "type": "integer",
+              },
+              {
+                "type": "number",
+              },
+              {
+                "type": "string",
+              },
+              {
+                "type": "boolean",
+              },
+              {
+                "items": {},
+                "type": "array",
+              },
+              {
+                "type": "object",
+              },
+            ],
+          },
+        },
+        "type": "object",
+      }
+    `);
   });
   it("should declare any prop (uniq type)", () => {
     // WHEN

--- a/packages/specs/schema/src/domain/JsonSchema.spec.ts
+++ b/packages/specs/schema/src/domain/JsonSchema.spec.ts
@@ -750,7 +750,8 @@ describe("JsonSchema", () => {
         const validate = new Ajv({strict: true}).compile(schema);
 
         expect(schema).toEqual({
-          type: "array"
+          type: "array",
+          items: {}
         });
 
         expect(validate([1, 2, 3, 4, 5])).toBe(true);
@@ -1253,7 +1254,8 @@ describe("JsonSchema", () => {
       const result = JsonSchema.from({type: Array}).toObject();
       expect(JsonSchema.from({type: Array}).isCollection).toBe(true);
       expect(result).toEqual({
-        type: "array"
+        type: "array",
+        items: {}
       });
     });
 
@@ -1270,6 +1272,7 @@ describe("JsonSchema", () => {
 
       expect(result).toEqual({
         type: "array",
+        items: {},
         uniqueItems: true
       });
     });
@@ -1494,7 +1497,8 @@ describe("JsonSchema", () => {
             type: "boolean"
           },
           {
-            type: "array"
+            type: "array",
+            items: {}
           },
           {
             type: "object"

--- a/packages/specs/schema/src/fn/from.spec.ts
+++ b/packages/specs/schema/src/fn/from.spec.ts
@@ -55,13 +55,14 @@ describe("from", () => {
     });
     expect(set().toJSON()).toEqual({
       type: "array",
+      items: {},
       uniqueItems: true
     });
     expect(map().toJSON()).toEqual({
       additionalProperties: true,
       type: "object"
     });
-    expect(array().toJSON()).toEqual({type: "array"});
+    expect(array().toJSON()).toEqual({type: "array", items: {}});
     expect(any().toJSON()).toEqual({
       anyOf: [
         {
@@ -81,7 +82,8 @@ describe("from", () => {
           type: "boolean"
         },
         {
-          type: "array"
+          type: "array",
+          items: {}
         },
         {
           type: "object"

--- a/packages/specs/schema/test/integrations/__snapshots__/body-params-any.integration.spec.ts.snap
+++ b/packages/specs/schema/test/integrations/__snapshots__/body-params-any.integration.spec.ts.snap
@@ -193,6 +193,7 @@ exports[`Integration: BodyParams any > should generate the right spec (any[]) 1`
                       "type": "boolean",
                     },
                     {
+                      "items": {},
                       "type": "array",
                     },
                     {
@@ -264,6 +265,7 @@ exports[`Integration: BodyParams any > should generate the right spec (any[]) 1`
                     "type": "boolean",
                   },
                   {
+                    "items": {},
                     "type": "array",
                   },
                   {

--- a/packages/specs/schema/test/integrations/body-params-any.integration.spec.ts
+++ b/packages/specs/schema/test/integrations/body-params-any.integration.spec.ts
@@ -71,6 +71,7 @@ describe("Integration: BodyParams any", () => {
                           "type": "boolean",
                         },
                         {
+                          "items": {},
                           "type": "array",
                         },
                         {

--- a/packages/specs/schema/test/integrations/generics.integration.spec.ts
+++ b/packages/specs/schema/test/integrations/generics.integration.spec.ts
@@ -51,7 +51,8 @@ describe("Generics: basic", () => {
         additionalProperties: false,
         properties: {
           data: {
-            type: "array"
+            type: "array",
+            items: {}
           },
           totalCount: {
             type: "number"
@@ -81,47 +82,50 @@ describe("Generics: basic", () => {
           Data: [Product]
         }
       });
-      expect(schema).toEqual({
-        allOf: [
-          {
-            $ref: "#/definitions/Paginated"
-          },
-          {
-            properties: {
-              data: {
-                items: {
-                  $ref: "#/definitions/Product"
+      expect(schema).toMatchInlineSnapshot(`
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Paginated",
+            },
+            {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/definitions/Product",
+                  },
+                  "type": "array",
                 },
-                type: "array"
-              }
-            },
-            type: "object"
-          }
-        ],
-        definitions: {
-          Paginated: {
-            additionalProperties: false,
-            properties: {
-              data: {
-                type: "array"
               },
-              totalCount: {
-                type: "number"
-              }
+              "type": "object",
             },
-            type: "object"
+          ],
+          "definitions": {
+            "Paginated": {
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "items": {},
+                  "type": "array",
+                },
+                "totalCount": {
+                  "type": "number",
+                },
+              },
+              "type": "object",
+            },
+            "Product": {
+              "properties": {
+                "label": {
+                  "minLength": 10,
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
           },
-          Product: {
-            properties: {
-              label: {
-                type: "string",
-                minLength: 10
-              }
-            },
-            type: "object"
-          }
         }
-      });
+      `);
 
       const value = await catchAsyncError(() =>
         validate(
@@ -373,6 +377,7 @@ describe("Generics: basic", () => {
             "Paginated": {
               "properties": {
                 "data": {
+                  "items": {},
                   "type": "array",
                 },
                 "totalCount": {
@@ -526,6 +531,7 @@ describe("Generics: basic", () => {
             "Paginated": {
               "properties": {
                 "data": {
+                  "items": {},
                   "type": "array",
                 },
                 "totalCount": {
@@ -719,6 +725,7 @@ describe("Generics: basic", () => {
             "Paginated": {
               "properties": {
                 "data": {
+                  "items": {},
                   "type": "array",
                 },
                 "totalCount": {
@@ -1235,6 +1242,7 @@ describe("Generics: basic", () => {
               "Pagination": {
                 "properties": {
                   "data": {
+                    "items": {},
                     "type": "array",
                   },
                   "totalCount": {
@@ -1363,6 +1371,7 @@ describe("Generics: basic", () => {
               "Pagination": {
                 "properties": {
                   "data": {
+                    "items": {},
                     "type": "array",
                   },
                   "totalCount": {
@@ -1509,6 +1518,7 @@ describe("Generics: basic", () => {
               "Pagination": {
                 "properties": {
                   "data": {
+                    "items": {},
                     "type": "array",
                   },
                   "totalCount": {
@@ -1759,6 +1769,7 @@ describe("Generics: basic", () => {
               "Pagination": {
                 "properties": {
                   "data": {
+                    "items": {},
                     "type": "array",
                   },
                   "totalCount": {
@@ -1936,6 +1947,7 @@ describe("Generics: basic", () => {
               "Pagination": {
                 "properties": {
                   "data": {
+                    "items": {},
                     "type": "array",
                   },
                   "totalCount": {

--- a/packages/specs/schema/test/integrations/generics.pageable.integration.spec.ts
+++ b/packages/specs/schema/test/integrations/generics.pageable.integration.spec.ts
@@ -210,6 +210,7 @@ describe("Generics: Pageable - Testing pagination functionality with generic typ
             "Pagination": {
               "properties": {
                 "data": {
+                  "items": {},
                   "type": "array",
                 },
                 "page": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON schema and OpenAPI specifications for array types now explicitly include an empty "items" property, improving schema clarity and consistency in generated documentation.

* **Tests**
  * Updated test expectations and snapshots to reflect the addition of the empty "items" property in array schemas across various scenarios, including generics, collections, and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->