### PR TITLE
fix(socketio): socket adapter registered twice

### DIFF
--- a/packages/third-parties/socketio/src/SocketIOModule.spec.ts
+++ b/packages/third-parties/socketio/src/SocketIOModule.spec.ts
@@ -55,7 +55,7 @@ describe("SocketIOModule", () => {
         expect(socketIOServer.attach).toHaveBeenCalledTimes(2);
 
         expect((socketIOModule as any).getWebsocketServices).toHaveBeenCalledWith();
-        expect(socketIOServer.adapter).toHaveBeenCalled();
+        expect(socketIOServer.adapter).not.toHaveBeenCalled();
         expect(socketIOService.addSocketProvider).toHaveBeenCalledWith({provider: "provider"});
       });
     });

--- a/packages/third-parties/socketio/src/SocketIOModule.ts
+++ b/packages/third-parties/socketio/src/SocketIOModule.ts
@@ -47,10 +47,6 @@ export class SocketIOModule implements AfterListen, OnDestroy {
       this.io.attach(this.httpsServer, {...this.settings});
     }
 
-    if (this.settings.adapter) {
-      this.io.adapter(this.settings.adapter);
-    }
-
     this.getWebsocketServices().forEach((provider) => this.socketIOService.addSocketProvider(provider));
 
     if (!this.disableRoutesSummary) {


### PR DESCRIPTION
Socket adapter already registered in socket.io

https://github.com/socketio/socket.io/blob/3be6481d9db90a8d6933e2a7dd39fcbb373e30a1/packages/socket.io/lib/index.ts#L325

as it passes through options here:

https://github.com/tsedio/tsed/blob/93dc76e02810d21d4e7230e93f3d75ce66c3b36f/packages/third-parties/socketio/src/services/SocketIOServer.ts#L12

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature/Fix/Doc/Chore | No          |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed automatic Socket.IO adapter initialization after server start. Adapters are no longer set from configuration implicitly, which may affect environments relying on this behavior.

- Tests
  - Updated tests to verify that the adapter is not invoked automatically in the HTTP server scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->