### PR TITLE
feat(bullmq): allow control over log level

### DIFF
--- a/packages/third-parties/bullmq/README.md
+++ b/packages/third-parties/bullmq/README.md
@@ -259,11 +259,10 @@ class MyService {
 
 ## Logs
 
-Be default the module will log every job's start and completion/failure.
+By default, the module logs each job’s start, completion, and failure.
 
-Start and completion is logged on the level of `info`, failure is logged on the level of `error`.
-To change/disable this behaviour, pass `logLevel` in the configuration 
-
+Start and completion are logged at level `info`; failures are logged at level `error`.  
+To change or disable this behavior, set `logLevel` in the configuration.
 
 ```ts
 

--- a/packages/third-parties/bullmq/README.md
+++ b/packages/third-parties/bullmq/README.md
@@ -80,7 +80,9 @@ import "@tsed/bullmq"; // import bullmq ts.ed module
       special: {
         // Specify additional worker options by queue name
       }
-    }
+    },
+    // Specify the log level of the module
+    logLevel: "info"
   }
 })
 export class Server {}
@@ -254,6 +256,30 @@ class MyService {
   }
 }
 ```
+
+## Logs
+
+Be default the module will log every job's start and completion/failure.
+
+Start and completion is logged on the level of `info`, failure is logged on the level of `error`.
+To change/disable this behaviour, pass `logLevel` in the configuration 
+
+
+```ts
+
+@Configuration({
+  bullmq: {
+    // ...
+    logLevel: "off"
+    // ...
+  }
+})
+export class Server {}
+
+```
+
+**Note**: The module logs when job controller is missing as `warn`. This cannot be separetely controlled.
+
 
 ## Contributors
 

--- a/packages/third-parties/bullmq/src/BullMQModule.ts
+++ b/packages/third-parties/bullmq/src/BullMQModule.ts
@@ -116,6 +116,7 @@ export class BullMQModule implements OnInit, OnDestroy {
 
     const $ctx = new DIContext({
       id: job.id || v4().split("-").join(""),
+      level: this.config.logLevel ?? "info",
       additionalProps: {
         logType: "bullmq",
         name: job.name,

--- a/packages/third-parties/bullmq/src/config/config.ts
+++ b/packages/third-parties/bullmq/src/config/config.ts
@@ -48,6 +48,13 @@ export type BullMQConfig = {
    * Specify additional worker options by queue name
    */
   workerOptions?: Record<string, Partial<WorkerOptions>>;
+
+  /**
+   * Log level for the module
+   *
+   * Default: Info
+   */
+  logLevel?: "debug" | "info" | "warn" | "error" | "off" | "all";
 };
 
 declare global {


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Feature | No          |

---


## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
@Configuration({
  bullmq: {
    // ...
    logLevel: "off"
    // ...
  }
})
export class Server {}


```

## Todos

- [ ] Tests - N/A
- [ ] Coverage - N/A
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable logging for the BullMQ integration via a new logLevel option (debug, info, warn, error, off, all); job processing uses this setting and defaults to info.

* **Documentation**
  * README updated with a Logs section describing default behavior, available log levels, examples (including disabling logs), and a note that missing job controllers emit warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->