### PR TITLE
fix(di): fix injection issue when a custom DIConfiguration is used by…

### DIFF
--- a/packages/di/src/common/decorators/configuration.spec.ts
+++ b/packages/di/src/common/decorators/configuration.spec.ts
@@ -5,7 +5,6 @@ import {Container} from "../domain/Container.js";
 import {Provider} from "../domain/Provider.js";
 import {destroyInjector, injector} from "../fn/injector.js";
 import {GlobalProviders} from "../registries/GlobalProviders.js";
-import {InjectorService} from "../services/InjectorService.js";
 import {Configuration} from "./configuration.js";
 import {Injectable} from "./injectable.js";
 
@@ -22,7 +21,7 @@ describe("@Configuration", () => {
     expect(Store.from(Test).get("configuration")).toEqual({});
   });
 
-  it("should inject configuration", async () => {
+  it("should inject configuration (constructor)", async () => {
     @Configuration({
       feature: "feature"
     })
@@ -41,5 +40,23 @@ describe("@Configuration", () => {
 
     expect(instance.config).toEqual(injector().settings);
     expect(instance.config.get("feature")).toEqual("feature");
+  });
+  it("should inject configuration (props)", async () => {
+    @Injectable()
+    class Test {
+      @Configuration() public config: Configuration;
+
+      constructor() {}
+    }
+
+    const container = new Container();
+
+    injector().setProvider(Test, GlobalProviders.get(Test)!.clone());
+
+    await injector().load(container);
+
+    const instance = injector().invoke<Test>(Test);
+
+    expect(instance.config).toEqual(injector().settings);
   });
 });

--- a/packages/di/src/common/services/InjectorService.ts
+++ b/packages/di/src/common/services/InjectorService.ts
@@ -158,6 +158,11 @@ export class InjectorService extends Container {
       return options.useOpts as Type;
     }
 
+    if (token === DIConfiguration) {
+      // keep this configuration for legacy code that use as custom Configuration service
+      return this.settings as Type;
+    }
+
     instance = !options.rebuild ? this.#cache.get(token) : undefined;
 
     if (instance != undefined) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for injecting configuration via property decorators, in addition to constructor injection.

* **Bug Fixes**
  * The legacy configuration token now resolves directly to application settings, improving compatibility and avoiding unnecessary provider construction.

* **Tests**
  * Added tests covering configuration injection via constructor and property to ensure expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->