### PR TITLE
docs: update incorrect "init" command for bun in "getting-started.md" file

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -73,7 +73,7 @@ pnpm --package=@tsed/cli dlx tsed init .
 ```
 
 ```sh [bun]
-bunx -p @tsed/cli init .
+bunx -p @tsed/cli tsed init .
 ```
 
 :::


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

---

The init command for Bun was incorrect and throws an error:
```
error: Package @tsed/cli does not provide a binary named init
```
Fixies #3193 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated Getting Started guide for Bun: replaced the command to use “bunx tsed init” to correctly invoke the Ts.ED CLI. This aligns instructions with current CLI syntax, clarifies the Bun-based setup flow, and helps prevent misconfiguration during project initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->