### PR TITLE
docs(queryParams): add info about metadata for arrays

### DIFF
--- a/packages/platform/platform-params/src/decorators/queryParams.ts
+++ b/packages/platform/platform-params/src/decorators/queryParams.ts
@@ -6,7 +6,8 @@ import {mapParamsOptions} from "../utils/mapParamsOptions.js";
 import {UseParam} from "./useParam.js";
 
 /**
- * QueryParams return the value from [request.query](http://expressjs.com/en/4x/api.html#req.query) object.
+ * QueryParams returns the value from [request.query](http://expressjs.com/en/4x/api.html#req.query) object.
+ * N.B.: If the query parameter is an array, the type of the array elements needs to be specified.
  *
  * #### Example
  *
@@ -21,6 +22,11 @@ import {UseParam} from "./useParam.js";
  *    @Get('/')
  *    get(@QueryParams('id') id: string) {
  *       console.log('ID', id);
+ *    }
+ *
+ *    @Get('/')
+ *    get(@QueryParams('ids', String) ids: string[]) {
+ *       console.log('IDs', ids);
  *    }
  *
  *    @Get('/')

--- a/packages/platform/platform-test-sdk/src/tests/testQueryParams.ts
+++ b/packages/platform/platform-test-sdk/src/tests/testQueryParams.ts
@@ -47,6 +47,11 @@ class TestQueryParamsCtrl {
   testScenario8(@QueryParams("test", String) value: string[]): any {
     return {value};
   }
+
+  @Get("/scenario-7")
+  testScenario7(@QueryParams("test") value: string[]): any {
+    return {value};
+  }
 }
 
 export function testQueryParams(options: PlatformTestingSdkOpts) {
@@ -233,6 +238,14 @@ export function testQueryParams(options: PlatformTestingSdkOpts) {
       const response = await request.get(`${endpoint}?test=1&test=2`).expect(200);
 
       expect(response.body).toEqual({value: ["1", "2"]});
+    });
+  });
+  describe("Scenario7: String[] value without correct metadata", () => {
+    const endpoint = "/rest/query-params/scenario-7";
+    it("should throw Bad Request", async () => {
+      const response = await request.get(`${endpoint}?test=1&test=2`).expect(400);
+
+      expect(response.badRequest).toEqual(true);
     });
   });
 }


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

---

Add info for users about QueryParams decorator: for an array, the type must be specified (even if primitive).


## Todos

- [ ] Tests
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced QueryParams documentation with comprehensive array support examples, clarifying required type declarations for array elements.

* **Tests**
  * Added new test scenarios validating array query parameter handling, including verification of proper error conditions and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->