### PR TITLE
Fix fastify statics configuration

### DIFF
--- a/packages/platform/platform-express/src/components/PlatformExpress.ts
+++ b/packages/platform/platform-express/src/components/PlatformExpress.ts
@@ -136,7 +136,7 @@ export class PlatformExpress extends PlatformAdapter<Express.Application> {
     const rawApp: any = this.app.getApp();
     const version = getVersion();
 
-    layers.forEach((layer) => {
+    for (const layer of layers) {
       const handlers = layer.getArgs(false);
       const {path, wildcard} = convertPath(layer.path, version as "v4" | "v5");
 
@@ -144,7 +144,7 @@ export class PlatformExpress extends PlatformAdapter<Express.Application> {
 
       if (layer.method === "statics") {
         rawApp.use(path, this.statics(path, layer.opts as any));
-        return;
+        continue;
       }
 
       if (wildcard) {
@@ -166,7 +166,7 @@ export class PlatformExpress extends PlatformAdapter<Express.Application> {
       }
 
       rawApp[layer.method](path, ...handlers);
-    });
+    }
   }
 
   mapHandler(handler: Function, metadata: PlatformHandlerMetadata) {

--- a/packages/platform/platform-fastify/src/components/PlatformFastify.ts
+++ b/packages/platform/platform-fastify/src/components/PlatformFastify.ts
@@ -5,7 +5,7 @@ import {IncomingMessage, ServerResponse} from "node:http";
 import * as Https from "node:https";
 
 import fastifyMiddie from "@fastify/middie";
-import fastifyStatics from "@fastify/static";
+import fastifyStatics, {type FastifyStaticOptions} from "@fastify/static";
 import {type Env, isFunction, isString, ReturnHostInfoFromPort, Type} from "@tsed/core";
 import {constant, inject, logger, runInContext} from "@tsed/di";
 import {NotFound} from "@tsed/exceptions";
@@ -269,12 +269,13 @@ export class PlatformFastify extends PlatformAdapter<FastifyInstance> {
     return null;
   }
 
-  statics(endpoint: string, options: PlatformStaticsOptions): any {
+  statics(endpoint: string, options: PlatformStaticsOptions & FastifyStaticOptions): any {
     this.app.getApp().register(fastifyStatics, {
-      root: options.root,
-      prefix: endpoint,
+      prefix: endpoint === "/" ? "/" : endpoint.endsWith("/") ? endpoint : `${endpoint}/`,
+      ...options,
       decorateReply: !this.staticsDecorated
     });
+
     this.staticsDecorated = true;
 
     return null;

--- a/packages/platform/platform-fastify/src/components/PlatformFastify.ts
+++ b/packages/platform/platform-fastify/src/components/PlatformFastify.ts
@@ -9,7 +9,7 @@ import fastifyStatics, {type FastifyStaticOptions} from "@fastify/static";
 import {type Env, isFunction, isString, ReturnHostInfoFromPort, Type} from "@tsed/core";
 import {constant, inject, logger, runInContext} from "@tsed/di";
 import {NotFound} from "@tsed/exceptions";
-import {$alter} from "@tsed/hooks";
+import {$alter, $asyncEmit} from "@tsed/hooks";
 import {PlatformExceptions} from "@tsed/platform-exceptions";
 import {
   adapter,
@@ -30,6 +30,7 @@ import type {PlatformFastifySettings} from "../interfaces/PlatformFastifySetting
 import {PlatformFastifyRequest} from "../services/PlatformFastifyRequest.js";
 import {PlatformFastifyResponse} from "../services/PlatformFastifyResponse.js";
 import {convertPath} from "../utils/convertPath.js";
+import {toPrefix} from "../utils/toPrefix.js";
 
 declare global {
   namespace TsED {
@@ -73,11 +74,11 @@ export class PlatformFastify extends PlatformAdapter<FastifyInstance> {
     });
   }
 
-  mapLayers(layers: PlatformLayer[]) {
+  async mapLayers(layers: PlatformLayer[]) {
     const {app} = this;
     const rawApp: FastifyInstance = app.getApp();
 
-    layers.forEach((layer) => {
+    for (const layer of layers) {
       const {path, wildcard} = convertPath(layer.path);
       const handlers = layer.getArgs(false);
 
@@ -86,10 +87,10 @@ export class PlatformFastify extends PlatformAdapter<FastifyInstance> {
           if ((rawApp as any).use) {
             (rawApp as any).use(path, handlers);
           }
-          return;
+          continue;
         case "statics":
-          this.statics(path as string, layer.opts as any);
-          return;
+          await this.statics(path as string, layer.opts as any);
+          continue;
       }
 
       try {
@@ -107,7 +108,7 @@ export class PlatformFastify extends PlatformAdapter<FastifyInstance> {
           error_message: er.message
         });
       }
-    });
+    }
   }
 
   mapHandler(handler: (...args: any[]) => any, metadata: PlatformHandlerMetadata) {
@@ -269,16 +270,18 @@ export class PlatformFastify extends PlatformAdapter<FastifyInstance> {
     return null;
   }
 
-  statics(endpoint: string, options: PlatformStaticsOptions & FastifyStaticOptions): any {
-    this.app.getApp().register(fastifyStatics, {
-      prefix: endpoint === "/" ? "/" : endpoint.endsWith("/") ? endpoint : `${endpoint}/`,
+  async statics(endpoint: string, options: PlatformStaticsOptions & FastifyStaticOptions): Promise<void> {
+    options = {
+      prefix: toPrefix(endpoint),
       ...options,
       decorateReply: !this.staticsDecorated
-    });
+    };
+
+    await this.app.getApp().register(fastifyStatics, options);
 
     this.staticsDecorated = true;
 
-    return null;
+    await $asyncEmit("$staticsMounted", [endpoint, options]);
   }
 
   protected compose(layer: PlatformLayer, wildcard?: string) {

--- a/packages/platform/platform-fastify/src/interfaces/PlatformFastifySettings.ts
+++ b/packages/platform/platform-fastify/src/interfaces/PlatformFastifySettings.ts
@@ -1,5 +1,5 @@
-import type {FastifyInstance} from "fastify";
+import type {FastifyHttpOptions, FastifyInstance} from "fastify";
 
-export interface PlatformFastifySettings {
+export interface PlatformFastifySettings extends FastifyHttpOptions<any, any> {
   app?: FastifyInstance;
 }

--- a/packages/platform/platform-fastify/src/utils/toPrefix.spec.ts
+++ b/packages/platform/platform-fastify/src/utils/toPrefix.spec.ts
@@ -1,0 +1,13 @@
+import {toPrefix} from "./toPrefix.js";
+
+describe("toPrefix", () => {
+  it('should return "/" for root endpoint', () => {
+    expect(toPrefix("/")).toBe("/");
+  });
+  it('should append "/" to endpoint not ending with "/"', () => {
+    expect(toPrefix("/api")).toBe("/api/");
+  });
+  it('should return the same endpoint if it already ends with "/"', () => {
+    expect(toPrefix("/api/")).toBe("/api/");
+  });
+});

--- a/packages/platform/platform-fastify/src/utils/toPrefix.ts
+++ b/packages/platform/platform-fastify/src/utils/toPrefix.ts
@@ -1,0 +1,3 @@
+export function toPrefix(endpoint: string) {
+  return endpoint === "/" ? "/" : endpoint.endsWith("/") ? endpoint : `${endpoint}/`;
+}

--- a/packages/platform/platform-http/src/common/builder/PlatformBuilder.ts
+++ b/packages/platform/platform-http/src/common/builder/PlatformBuilder.ts
@@ -319,10 +319,10 @@ export class PlatformBuilder<App = TsED.Application> {
     return this.#promise;
   }
 
-  protected mapRouters() {
+  protected async mapRouters() {
     const layers = this.platform.getLayers();
 
-    this.adapter.mapLayers(layers);
+    await this.adapter.mapLayers(layers);
 
     const rawBody =
       constant("rawBody") ||

--- a/packages/platform/platform-http/src/common/services/PlatformAdapter.ts
+++ b/packages/platform/platform-http/src/common/services/PlatformAdapter.ts
@@ -57,7 +57,7 @@ export abstract class PlatformAdapter<App = TsED.Application> {
   /**
    * Map router layer to the targeted framework
    */
-  abstract mapLayers(layer: PlatformLayer[]): void;
+  abstract mapLayers(layer: PlatformLayer[]): void | Promise<void>;
 
   /**
    * Map handler to the targeted framework

--- a/packages/platform/platform-http/src/common/utils/closeServer.spec.ts
+++ b/packages/platform/platform-http/src/common/utils/closeServer.spec.ts
@@ -8,4 +8,11 @@ describe("closeServer", () => {
     expect(await closeServer(server)).toEqual(undefined);
     expect(server.close).toHaveBeenCalledWith(expect.any(Function));
   });
+
+  it("should handle undefined close method (fastify)", async () => {
+    const server: any = {
+      close: undefined
+    };
+    expect(await closeServer(server)).toEqual(undefined);
+  });
 });

--- a/packages/platform/platform-http/src/common/utils/closeServer.ts
+++ b/packages/platform/platform-http/src/common/utils/closeServer.ts
@@ -4,5 +4,7 @@ import type Https from "node:https";
 import type Http2 from "http2";
 
 export function closeServer(server: Http.Server | Https.Server | Http2.Http2Server) {
-  return new Promise((resolve) => server.close(() => resolve(undefined)));
+  if (server.close) {
+    return new Promise((resolve) => server.close(() => resolve(undefined)));
+  }
 }

--- a/packages/platform/platform-koa/src/components/PlatformKoa.ts
+++ b/packages/platform/platform-koa/src/components/PlatformKoa.ts
@@ -90,13 +90,13 @@ export class PlatformKoa extends PlatformAdapter<Koa> {
     const options = constant("koa.router", {});
     const rawRouter = new KoaRouter(options) as any;
 
-    layers.forEach((layer) => {
+    for (const layer of layers) {
       const {path, wildcard} = convertPath(layer.path);
       layer.path = path;
 
       if (layer.method === "statics") {
         rawRouter.use(path, this.statics(layer.path as string, layer.opts as any));
-        return;
+        continue;
       }
 
       const handlers = layer.getArgs(false);
@@ -110,7 +110,7 @@ export class PlatformKoa extends PlatformAdapter<Koa> {
       }
 
       rawRouter[layer.method](path, ...handlers);
-    });
+    }
 
     application().getApp().use(rawRouter.routes()).use(rawRouter.allowedMethods());
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful server shutdown now safely handles servers without a close method.
  * Static assets mounting no longer aborts early; all layers are processed reliably.

* **Tests**
  * Added tests for server shutdown edge cases and endpoint prefix normalization.

* **Refactor**
  * Standardized iteration and async flow across platform adapters for more consistent mounting and lifecycle ordering.

* **New Features**
  * Endpoint prefix normalization helper to ensure consistent trailing-slash behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->