### PR TITLE
fix(json-mapper): optimize eval function in JsonMapperCompiler and im…

### DIFF
--- a/packages/specs/json-mapper/src/domain/JsonDeserializer.ts
+++ b/packages/specs/json-mapper/src/domain/JsonDeserializer.ts
@@ -13,7 +13,7 @@ import {alterAfterDeserialize} from "../hooks/alterAfterDeserialize.js";
 import {alterBeforeDeserialize} from "../hooks/alterBeforeDeserialize.js";
 import {alterOnDeserialize} from "../hooks/alterOnDeserialize.js";
 import {JsonDeserializerOptions} from "./JsonDeserializerOptions.js";
-import {CachedJsonMapper, JsonMapperCompiler} from "./JsonMapperCompiler.js";
+import {CachedGroupsJsonMapper, CachedJsonMapper, JsonMapperCompiler} from "./JsonMapperCompiler.js";
 import {JsonMapperSettings} from "./JsonMapperSettings.js";
 import {getJsonMapperTypes} from "./JsonMapperTypesContainer.js";
 import {Writer} from "./Writer.js";
@@ -103,16 +103,20 @@ export class JsonDeserializer extends JsonMapperCompiler<JsonDeserializerOptions
     {
       id,
       groupsId,
-      model
+      model,
+      storeGroups
     }: {
       id: string;
-      model: Type<any>;
+      model: Type<any> | string;
       groupsId: string;
+      storeGroups: CachedGroupsJsonMapper<JsonDeserializerOptions>;
     }
   ): CachedJsonMapper<JsonDeserializerOptions> {
-    this.constructors[id] = model;
+    if (typeof model === "function") {
+      this.constructors[id] = model;
+    }
 
-    return super.eval(mapper, {id, groupsId, model});
+    return super.eval(mapper, {id, groupsId, model, storeGroups});
   }
 
   protected newInstanceOf(id: string, obj: any, options: any) {

--- a/packages/specs/json-mapper/src/domain/JsonMapperCompiler.ts
+++ b/packages/specs/json-mapper/src/domain/JsonMapperCompiler.ts
@@ -121,9 +121,20 @@ export abstract class JsonMapperCompiler<Options extends Record<string, any> = a
     return this;
   }
 
-  eval(mapper: string, {id, groupsId, model}: {id: string; model: Type<any> | string; groupsId: string}) {
-    this.addGlobal("cache", this.cache);
-
+  eval(
+    mapper: string,
+    {
+      id,
+      groupsId,
+      model,
+      storeGroups
+    }: {
+      id: string;
+      groupsId: string;
+      model: Type<any> | string;
+      storeGroups: CachedGroupsJsonMapper<Options>;
+    }
+  ) {
     const {globals, schemes} = this;
 
     const injectGlobals = Object.keys(globals)
@@ -132,11 +143,24 @@ export abstract class JsonMapperCompiler<Options extends Record<string, any> = a
       })
       .join("\n");
 
-    eval(`${injectGlobals};
+    const compileMapper = new Function(
+      "globals",
+      "storeGroups",
+      "schemes",
+      "groupsId",
+      "id",
+      `${injectGlobals}
+      storeGroups.set(groupsId, {id, fn: (${mapper})});
+      return storeGroups.get(groupsId);`
+    ) as (
+      globals: Record<string, any>,
+      storeGroups: CachedGroupsJsonMapper<Options>,
+      schemes: Record<string, any>,
+      groupsId: string,
+      id: string
+    ) => CachedJsonMapper<Options>;
 
-    cache.get(model).set(groupsId, { id: '${id}', fn: ${mapper} })`);
-
-    const store = this.cache.get(model)!.get(groupsId)!;
+    const store = compileMapper(globals, storeGroups, schemes, groupsId, id)!;
 
     this.mappers[id] = store.fn;
 
@@ -185,7 +209,7 @@ export abstract class JsonMapperCompiler<Options extends Record<string, any> = a
       const mapper = opts.mapper ? opts.mapper(id, groups) : this.createMapper(token as Type<any>, id, groups);
 
       try {
-        return this.eval(mapper, {id, model: token, groupsId});
+        return this.eval(mapper, {id, groupsId, model: token, storeGroups});
       } catch (err) {
         throw new Error(`Fail to compile mapper for ${nameOf(model)}. See the error above: ${err.message}.\n${mapper}`);
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal compilation and caching flow rewritten for clearer, explicit handling of compiled mapper groups, improving reliability and maintainability.
* **Breaking Change**
  * Public evaluation API updated: callers must now supply the compiled-group container as an additional parameter.
* **Behavior**
  * Runtime now only registers constructors when a concrete constructor is provided, reducing spurious registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->