### PR TITLE
fix(schema): add support for wildcard path parameters in OpenAPI spec…

### DIFF
--- a/packages/platform/platform-serverless-http/test/integration/aws-basic/yarn.lock
+++ b/packages/platform/platform-serverless-http/test/integration/aws-basic/yarn.lock
@@ -4445,9 +4445,9 @@ picocolors@^1.0.0:
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pify@^2.3.0:
   version "2.3.0"

--- a/packages/specs/schema/src/utils/getJsonPathParameters.spec.ts
+++ b/packages/specs/schema/src/utils/getJsonPathParameters.spec.ts
@@ -123,4 +123,42 @@ describe("getJsonPathParameters", () => {
       }
     ]);
   });
+
+  it("should return params and path /merged/:moduleUri*", () => {
+    expect(getJsonPathParameters("/rest/", "/merged/:moduleUri*")).toEqual([
+      {
+        path: "/rest/merged/{moduleUri}",
+        parameters: [
+          {
+            in: "path",
+            name: "moduleUri",
+            required: true,
+            type: "string"
+          }
+        ]
+      }
+    ]);
+  });
+
+  it("should return params and path /:moduleUri*/child/:id*", () => {
+    expect(getJsonPathParameters("/rest/", "/:moduleUri*/child/:id*")).toEqual([
+      {
+        path: "/rest/{moduleUri}/child/{id}",
+        parameters: [
+          {
+            in: "path",
+            name: "moduleUri",
+            required: true,
+            type: "string"
+          },
+          {
+            in: "path",
+            name: "id",
+            required: true,
+            type: "string"
+          }
+        ]
+      }
+    ]);
+  });
 });

--- a/packages/specs/schema/src/utils/getJsonPathParameters.ts
+++ b/packages/specs/schema/src/utils/getJsonPathParameters.ts
@@ -50,7 +50,7 @@ export function getJsonPathParameters(base: string, path: string | RegExp | (str
   let current = "";
 
   parseUrl(`${base}${path}`).map((key) => {
-    const subpath = key.replace(":", "").replace("?", "");
+    const subpath = key.replace(":", "").replace("?", "").replace(/\*/g, "");
 
     if (key.includes(":")) {
       const optional = key.includes("?");

--- a/packages/specs/schema/test/integrations/wildcard-path-params.integration.spec.ts
+++ b/packages/specs/schema/test/integrations/wildcard-path-params.integration.spec.ts
@@ -1,0 +1,91 @@
+import "../../src/index.js";
+
+import {Controller} from "@tsed/di";
+import {PathParams} from "@tsed/platform-params";
+
+import {Get, getSpec, SpecTypes} from "../../src/index.js";
+import {validateSpec} from "../helpers/validateSpec.js";
+
+@Controller("/merged")
+class TestWildcardPathCtrl {
+  @Get("/:moduleUri*")
+  get(@PathParams("moduleUri") moduleUri: string) {
+    return moduleUri;
+  }
+}
+
+@Controller("/rest")
+class TestWildcardMultiplePathCtrl {
+  @Get("/:moduleUri*/child/:id*")
+  get(@PathParams("moduleUri") moduleUri: string, @PathParams("id") id: string) {
+    return {moduleUri, id};
+  }
+}
+
+describe("Spec: wildcard path params", () => {
+  it("should generate the OS3 for a single wildcard path param", async () => {
+    const spec = getSpec(TestWildcardPathCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec.paths).toEqual({
+      "/merged/{moduleUri}": {
+        get: {
+          operationId: "testWildcardPathCtrlGet",
+          parameters: [
+            {
+              in: "path",
+              name: "moduleUri",
+              required: true,
+              schema: {
+                type: "string"
+              }
+            }
+          ],
+          responses: {
+            "200": {
+              description: "Success"
+            }
+          },
+          tags: ["TestWildcardPathCtrl"]
+        }
+      }
+    });
+    expect(await validateSpec(spec, SpecTypes.OPENAPI)).toBe(true);
+  });
+
+  it("should generate the OS3 for multiple wildcard path params", async () => {
+    const spec = getSpec(TestWildcardMultiplePathCtrl, {specType: SpecTypes.OPENAPI});
+
+    expect(spec.paths).toEqual({
+      "/rest/{moduleUri}/child/{id}": {
+        get: {
+          operationId: "testWildcardMultiplePathCtrlGet",
+          parameters: [
+            {
+              in: "path",
+              name: "moduleUri",
+              required: true,
+              schema: {
+                type: "string"
+              }
+            },
+            {
+              in: "path",
+              name: "id",
+              required: true,
+              schema: {
+                type: "string"
+              }
+            }
+          ],
+          responses: {
+            "200": {
+              description: "Success"
+            }
+          },
+          tags: ["TestWildcardMultiplePathCtrl"]
+        }
+      }
+    });
+    expect(await validateSpec(spec, SpecTypes.OPENAPI)).toBe(true);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized wildcard-attached route parameters so generated OpenAPI paths and parameters no longer include wildcard characters.
* **Tests**
  * Added unit and integration tests verifying correct OpenAPI path/parameter generation for routes with single and multiple wildcard-attached parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->