### PR TITLE
fix(ajv): enhance type safety by adding generic return types to valid…

### DIFF
--- a/docs/docs/model.md
+++ b/docs/docs/model.md
@@ -366,6 +366,27 @@ class Model {
 > Note: Nullable means the value can be null. It does not mean the property can be omitted. Use @@Optional@@ (or remove
 > @@Required@@) to make a property optional.
 
+## Vendor extensions with `@Schema`
+
+You can pass OpenAPI vendor extensions (`x-*`) directly to @@Schema@@:
+
+```ts
+import {Schema} from "@tsed/schema";
+
+class SecretFieldModel {
+  @Schema({
+    type: "string",
+    "x-secret": true
+  })
+  token: string;
+}
+```
+
+The `x-*` key is preserved in generated schemas, including OpenAPI output.
+
+Use this when the extension belongs to the schema definition itself. For other custom metadata cases, you can still use
+@@CustomKey@@ / @@CustomKeys@@.
+
 ## Regular expressions
 
 The @@Pattern@@ decorator is used to restrict a string to a particular regular expression. The regular expression syntax

--- a/packages/specs/ajv/src/fn/validate.ts
+++ b/packages/specs/ajv/src/fn/validate.ts
@@ -4,10 +4,21 @@ import {JsonSchema} from "@tsed/schema";
 import {AjvService, type AjvValidateOptions} from "../services/AjvService.js";
 
 /**
- * Validate a value against a JSON schema or a type.
- * @param value
- * @param options
+ * Validate a value against a JSON schema or a type using the configured `AjvService`.
+ *
+ * The return type is inferred from `value` by default and can be overridden with an explicit generic:
+ * `validate<MyType>(value, options)`.
+ *
+ * @typeParam TReturn Explicit return type override. When omitted, `TValue` is returned.
+ * @typeParam TValue Input value type.
+ * @param value Value to validate.
+ * @param options Validation options, a JSON schema, or a target type descriptor.
+ * @returns The validated value. If `returnsCoercedValues` is enabled, it may contain coerced values.
+ * @throws {AjvValidationError} When validation fails.
  */
-export function validate(value: unknown, options: AjvValidateOptions | JsonSchema) {
+export function validate<TReturn = never, TValue = unknown>(
+  value: TValue,
+  options: AjvValidateOptions | JsonSchema
+): Promise<[TReturn] extends [never] ? TValue : TReturn> {
   return inject(AjvService).validate(value, options);
 }

--- a/packages/specs/ajv/src/services/AjvService.ts
+++ b/packages/specs/ajv/src/services/AjvService.ts
@@ -23,7 +23,27 @@ export class AjvService {
   protected returnsCoercedValues = constant<boolean>("ajv.returnsCoercedValues");
   protected ajv = inject(Ajv);
 
-  async validate(value: any, options: AjvValidateOptions | JsonSchema): Promise<any> {
+  /**
+   * Validate a value against a JSON schema, a model type, or explicit AJV options.
+   *
+   * The return type is inferred from `value` by default and can be overridden with an explicit generic:
+   * `ajvService.validate<MyType>(value, options)`.
+   *
+   * If `returnsCoercedValues` is enabled globally or in `options`, coercions performed by AJV are returned.
+   *
+   * @typeParam TReturn Explicit return type override. When omitted, `TValue` is returned.
+   * @typeParam TValue Input value type.
+   * @param value Value to validate.
+   * @param options Validation options or `JsonSchema`.
+   * @returns The validated value (possibly coerced when configured).
+   * @throws {AjvValidationError} When validation fails.
+   */
+  async validate<TReturn = never, TValue = unknown>(
+    value: TValue,
+    options: AjvValidateOptions | JsonSchema
+  ): Promise<[TReturn] extends [never] ? TValue : TReturn> {
+    type ValidateResult = [TReturn] extends [never] ? TValue : TReturn;
+
     let {
       schema: defaultSchema,
       type,
@@ -51,11 +71,11 @@ export class AjvService {
       }
 
       if (returnsCoercedValues) {
-        return localValue;
+        return localValue as ValidateResult;
       }
     }
 
-    return value;
+    return value as ValidateResult;
   }
 
   protected mapOptions(options: AjvValidateOptions | JsonSchema): AjvValidateOptions {

--- a/packages/specs/schema/src/components/default/schemaMapper.ts
+++ b/packages/specs/schema/src/components/default/schemaMapper.ts
@@ -37,7 +37,6 @@ function shouldMapAlias(key: string, value: any, useAlias: boolean) {
 function shouldSkipKey(key: string, {specType = SpecTypes.JSON, customKeys = false}: JsonSchemaOptions) {
   return (
     IGNORES.includes(key) ||
-    key.startsWith("x-") ||
     (key.startsWith("#") && (!customKeys || specType !== SpecTypes.JSON)) ||
     (specType !== SpecTypes.JSON && IGNORES_OPENSPEC.includes(key))
   );

--- a/packages/specs/schema/src/decorators/common/schema.spec.ts
+++ b/packages/specs/schema/src/decorators/common/schema.spec.ts
@@ -1,4 +1,4 @@
-import {getJsonSchema} from "../../index.js";
+import {getJsonSchema, SpecTypes} from "../../index.js";
 import {Schema} from "./schema.js";
 
 describe("Schema()", () => {
@@ -27,5 +27,35 @@ describe("Schema()", () => {
         "type": "object",
       }
     `);
+  });
+
+  it("should support vendor extensions passed to @Schema", () => {
+    class Test {
+      @Schema({
+        type: "string",
+        "x-secret": true
+      })
+      test: string;
+    }
+
+    expect(getJsonSchema(Test)).toEqual({
+      properties: {
+        test: {
+          type: "string",
+          "x-secret": true
+        }
+      },
+      type: "object"
+    });
+
+    expect(getJsonSchema(Test, {specType: SpecTypes.OPENAPI})).toEqual({
+      properties: {
+        test: {
+          type: "string",
+          "x-secret": true
+        }
+      },
+      type: "object"
+    });
   });
 });

--- a/packages/specs/schema/src/domain/JsonSchema.ts
+++ b/packages/specs/schema/src/domain/JsonSchema.ts
@@ -44,6 +44,7 @@ import type {Infer, PropsToShape, SchemaKey, SchemaMerge, SchemaOmit, SchemaPart
  * @public
  */
 export interface JsonSchemaObject extends Omit<JSONSchema7, "type" | "additionalProperties" | "items" | "pattern"> {
+  [key: `x-${string}`]: unknown;
   type?: JSONSchema7["type"] | Type | null | (String | null | Date | Number | Object | Boolean)[];
   additionalProperties?: JsonSchemaObject | boolean | Type | JsonSchema;
   items?: JsonSchemaObject | boolean | Type | JsonSchema | (JsonSchemaObject | Type | JsonSchema)[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type inference and safety for validation APIs to enhance developer experience.

* **New Behavior**
  * Vendor extension keys (x-*) are now preserved in generated schemas and outputs.

* **Documentation**
  * Added guidance showing how to include vendor extensions via schema decorators.

* **Tests**
  * Added tests verifying vendor extensions are retained across schema outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->