### PR TITLE
fix(prisma): decimal type transform

### DIFF
--- a/packages/orm/prisma/src/generator/domain/ScalarTsTypes.ts
+++ b/packages/orm/prisma/src/generator/domain/ScalarTsTypes.ts
@@ -1,4 +1,4 @@
-import {DecoratorStructure, StructureKind} from "ts-morph";
+import {DecoratorStructure} from "ts-morph";
 
 export enum PrismaScalars {
   String = "String",
@@ -17,7 +17,7 @@ export const ScalarTsTypes: Record<string, string> = {
   [PrismaScalars.Boolean]: "boolean",
   [PrismaScalars.Int]: "number",
   [PrismaScalars.Float]: "number",
-  [PrismaScalars.Decimal]: "number",
+  [PrismaScalars.Decimal]: "Prisma.Decimal",
   [PrismaScalars.BigInt]: "bigint",
   [PrismaScalars.DateTime]: "Date",
   [PrismaScalars.Json]: "any",
@@ -29,7 +29,7 @@ export const ScalarJsClasses: Record<string, string> = {
   [PrismaScalars.Boolean]: "Boolean",
   [PrismaScalars.Int]: "Number",
   [PrismaScalars.Float]: "Number",
-  [PrismaScalars.Decimal]: "Number",
+  [PrismaScalars.Decimal]: "Prisma.Decimal",
   [PrismaScalars.BigInt]: "BigInt",
   [PrismaScalars.DateTime]: "Date",
   [PrismaScalars.Json]: "Object",

--- a/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
+++ b/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
@@ -100,6 +100,29 @@ describe("transformScalarToType()", () => {
     expect(field.model.addImportDeclaration).toHaveBeenCalledWith("@prisma/client", "Prisma");
   });
 
+  it("should transform Decimal to Decimal (nullable)", () => {
+    const ctx = createContextFixture();
+    const field = createDmmfFieldFixture({
+      kind: "scalar",
+      type: PrismaScalars.Decimal,
+      isRequired: false
+    });
+    expect(transformScalarToType(field, ctx)).toEqual("Prisma.Decimal | null");
+    expect(field.model.addImportDeclaration).toHaveBeenCalledWith("@prisma/client", "Prisma");
+  });
+
+  it("should transform Decimal to Decimal (list)", () => {
+    const ctx = createContextFixture();
+    const field = createDmmfFieldFixture({
+      kind: "scalar",
+      type: PrismaScalars.Decimal,
+      isRequired: true,
+      isList: true
+    });
+    expect(transformScalarToType(field, ctx)).toEqual("Prisma.Decimal[]");
+    expect(field.model.addImportDeclaration).toHaveBeenCalledWith("@prisma/client", "Prisma");
+  });
+
   it("should transform enumTypes to Date", () => {
     const ctx = createContextFixture();
     const field = createDmmfFieldFixture({

--- a/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
+++ b/packages/orm/prisma/src/generator/transform/transformScalarToType.spec.ts
@@ -89,6 +89,17 @@ describe("transformScalarToType()", () => {
     expect(transformScalarToType(field, ctx)).toEqual("Date | null");
   });
 
+  it("should transform Decimal to Decimal", () => {
+    const ctx = createContextFixture();
+    const field = createDmmfFieldFixture({
+      kind: "scalar",
+      type: PrismaScalars.Decimal,
+      isRequired: true
+    });
+    expect(transformScalarToType(field, ctx)).toEqual("Prisma.Decimal");
+    expect(field.model.addImportDeclaration).toHaveBeenCalledWith("@prisma/client", "Prisma");
+  });
+
   it("should transform enumTypes to Date", () => {
     const ctx = createContextFixture();
     const field = createDmmfFieldFixture({

--- a/packages/orm/prisma/src/generator/transform/transformScalarToType.ts
+++ b/packages/orm/prisma/src/generator/transform/transformScalarToType.ts
@@ -1,7 +1,7 @@
 import {DmmfEnum} from "../domain/DmmfEnum.js";
 import {DmmfField} from "../domain/DmmfField.js";
 import {DmmfModel} from "../domain/DmmfModel.js";
-import {ScalarTsTypes} from "../domain/ScalarTsTypes.js";
+import {PrismaScalars, ScalarTsTypes} from "../domain/ScalarTsTypes.js";
 import type {TransformContext} from "../domain/TransformContext.js";
 import {isCircularRef} from "../utils/isCircularRef.js";
 
@@ -13,6 +13,10 @@ export function transformScalarToType(field: DmmfField, ctx: TransformContext): 
   switch (location) {
     case "scalar":
       TSType = ScalarTsTypes[field.type];
+      // Import Prisma namespace when Decimal is used
+      if (field.type === PrismaScalars.Decimal) {
+        field.model.addImportDeclaration("@prisma/client", "Prisma");
+      }
       break;
     case "enumTypes":
       TSType = DmmfEnum.symbolName(type);


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix      | No          |

---

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prisma Decimal scalar now generates as the precise Prisma.Decimal type in TypeScript and runtime outputs.
  * Generated models automatically add the Prisma namespace import when Decimal fields are present.

* **Tests**
  * Added unit tests verifying Decimal scalar transformations produce correct TypeScript types (required, nullable, list) and include necessary imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tsedio/tsed/pull/3364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->