### PR TITLE
docs(snippets): fix wrong attribute name used in providers example

### DIFF
--- a/docs/docs/snippets/providers/decorators/interface-abstraction-declaration.ts
+++ b/docs/docs/snippets/providers/decorators/interface-abstraction-declaration.ts
@@ -6,7 +6,7 @@ export interface RetryPolicy {
 
 export const RetryPolicy: unique symbol = Symbol("RetryPolicy");
 
-@Injectable({token: RetryPolicy})
+@Injectable({provide: RetryPolicy})
 export class TokenBucket implements RetryPolicy {
   public retry<T extends (...args: unknown[]) => unknown>(task: T): Promise<ReturnType<T>> {
     // ...


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Doc | No          |

---

Just a very minor adjustment in documentation on providers and interface abstraction declaration.
It should be `@Injectable({` **provide**: `SomeInterface })` and not a `@Injectable({` **token**: `SomeInterface })`, as the documentation itself states.

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider configuration code examples to match the latest API specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tsedio/tsed/pull/3370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->