### PR TITLE
fix(prisma): model name generation, camelCase -> uncapitalize

### DIFF
--- a/packages/orm/prisma/src/__mock__/createDmmfFixture.ts
+++ b/packages/orm/prisma/src/__mock__/createDmmfFixture.ts
@@ -1,5 +1,6 @@
 import dmmf from "./dmmf.json" with {type: "json"};
 import dmmfTypes from "./dmmf.types.json" with {type: "json"};
+import dmmfMixedCase from "./dmmfMixedCase.json" with {type: "json"};
 
 export function createDmmfFixture(): any {
   return dmmf;
@@ -7,4 +8,8 @@ export function createDmmfFixture(): any {
 
 export function createDmmfWithTypesFixture(): any {
   return dmmfTypes;
+}
+
+export function createDmmfMixedCaseFixture(): any {
+  return dmmfMixedCase;
 }

--- a/packages/orm/prisma/src/__mock__/createProjectFixture.ts
+++ b/packages/orm/prisma/src/__mock__/createProjectFixture.ts
@@ -33,6 +33,9 @@ export function createProjectFixture(dir = "/") {
       const actualValue = sourceFile.getFullText();
 
       return {
+        toContain(value: string) {
+          expect(actualValue).toContain(value);
+        },
         not: {
           toContain(value: string) {
             expect(actualValue).not.toContain(value);

--- a/packages/orm/prisma/src/__mock__/dmmfMixedCase.json
+++ b/packages/orm/prisma/src/__mock__/dmmfMixedCase.json
@@ -1,0 +1,52 @@
+{
+  "datamodel": {
+    "enums": [],
+    "models": [
+      {
+        "name": "MyDBModel",
+        "isEmbedded": false,
+        "dbName": null,
+        "fields": [
+          {
+            "name": "id",
+            "kind": "scalar",
+            "isList": false,
+            "isRequired": true,
+            "isUnique": false,
+            "isId": true,
+            "isReadOnly": false,
+            "type": "Int",
+            "hasDefaultValue": true,
+            "default": {
+              "name": "autoincrement",
+              "args": []
+            },
+            "isGenerated": false,
+            "isUpdatedAt": false
+          }
+        ],
+        "isGenerated": false,
+        "idFields": [],
+        "uniqueFields": [],
+        "uniqueIndexes": []
+      }
+    ]
+  },
+  "schema": {
+    "inputObjectTypes": {
+      "prisma": []
+    },
+    "outputObjectTypes": {
+      "model": [
+        {
+          "name": "MyDBModel",
+          "fields": []
+        }
+      ],
+      "prisma": []
+    },
+    "enumTypes": {
+      "prisma": []
+    }
+  }
+}

--- a/packages/orm/prisma/src/generator/utils/generateRepositories.ts
+++ b/packages/orm/prisma/src/generator/utils/generateRepositories.ts
@@ -197,7 +197,7 @@ export function generateRepositories(dmmf: DMMF.Document, project: Project, base
     addDelegatedMethod({
       repository,
       name: "aggregate",
-      model: pascalCase(model.name),
+      model: model.name,
       isAsync: false
     });
 

--- a/packages/orm/prisma/src/generator/utils/generateRepositories.ts
+++ b/packages/orm/prisma/src/generator/utils/generateRepositories.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import {DMMF} from "@prisma/generator-helper";
 import {toMap} from "@tsed/core";
-import {camelCase, pascalCase} from "change-case";
+import {pascalCase} from "change-case";
 import pluralize from "pluralize";
 import {ClassDeclaration, Project, Scope} from "ts-morph";
 
@@ -107,7 +107,7 @@ export function generateRepositories(dmmf: DMMF.Document, project: Project, base
       .addGetAccessor({
         name: "collection"
       })
-      .setBodyText(`return this.prisma.${camelCase(model.name)}`);
+      .setBodyText(`return this.prisma.${uncapitalize(model.name)}`);
 
     repository
       .addGetAccessor({
@@ -205,4 +205,8 @@ export function generateRepositories(dmmf: DMMF.Document, project: Project, base
   });
 
   generateOutputsBarrelFile(repositoriesIndex, exportedModels);
+}
+
+function uncapitalize(str: string) {
+  return str.substring(0, 1).toLowerCase() + str.substring(1);
 }

--- a/packages/orm/prisma/src/generator/utils/generateRespositories.spec.ts
+++ b/packages/orm/prisma/src/generator/utils/generateRespositories.spec.ts
@@ -1,4 +1,4 @@
-import {createDmmfFixture} from "../../__mock__/createDmmfFixture.js";
+import {createDmmfFixture, createDmmfMixedCaseFixture} from "../../__mock__/createDmmfFixture.js";
 import {createProjectFixture} from "../../__mock__/createProjectFixture.js";
 import {generateRepositories} from "./generateRepositories.js";
 
@@ -25,5 +25,17 @@ describe("generateRepositories", () => {
 
     postsRepository.not.toContain("User");
     postsRepository.toMatchSnapshot();
+  });
+
+  it("should generate repositories (mixed case)", () => {
+    const {project, render, baseDir} = createProjectFixture("generate_repositories_mixed_case");
+    const dmmf = createDmmfMixedCaseFixture();
+
+    generateRepositories(dmmf, project, baseDir);
+
+    const myDBModelRepo = render("/repositories/MyDbModelsRepository.ts");
+
+    myDBModelRepo.toContain("return this.prisma.myDBModel");
+    myDBModelRepo.not.toContain("return this.prisma.myDbModel");
   });
 });


### PR DESCRIPTION
## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix | No          |

## Todos

- [X] Tests
- [X] Coverage
- [ ] Example
- [ ] Documentation

## Fix
Per the Prisma implementation, `model name` should be uncapitalized, not camelCase.
Issue example:
uncapitalize (Prisma) MyDBModel  -> myDBModel
camelCase MyDBModel  -> myDbModel

Aggregate Method delegation issue: removed Pascal case to correspond to other delegate methods
PascalCase MyDBModel  -> MyDbModel

Ref
https://github.com/prisma/prisma/blob/main/packages/client-generator-ts/src/TSClient/PrismaClient.ts#L317
https://github.com/prisma/prisma/blob/main/packages/client-common/src/casing.ts#L13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage validating repository code generation with mixed-case database model naming conventions
  * Enhanced test infrastructure with new mock DMMF payload fixtures supporting diverse model naming patterns

* **Chores**
  * Improved test assertion capabilities enabling more flexible validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->