### PR TITLE
fix: `AcceptMimes` uses `Produces` now instead of `Consumes`

### DIFF
--- a/packages/specs/schema/src/decorators/operations/acceptMime.spec.ts
+++ b/packages/specs/schema/src/decorators/operations/acceptMime.spec.ts
@@ -18,6 +18,23 @@ describe("AcceptMime", () => {
 
     const endpoint = JsonMethodStore.get(Test, "test");
     expect(endpoint.acceptMimes).toEqual(["application/json"]);
+    expect(endpoint.operation.get("produces")).toEqual(["application/json"]);
+  });
+
+  it("should map the mime to produces (response), not consumes (requestBody)", () => {
+    class Test {
+      @Get("/")
+      @AcceptMime("application/xml")
+      test(@BodyParams() model: Model) {}
+    }
+
+    const endpoint = JsonMethodStore.get(Test, "test");
+
+    // The client's `Accept` header must contain the format described by
+    // `AcceptMime`, so the server must produce a response in that format.
+    expect(endpoint.acceptMimes).toEqual(["application/xml"]);
+    expect(endpoint.operation.get("produces")).toEqual(["application/xml"]);
+    expect(endpoint.operation.get("consumes")).toBeUndefined();
 
     const spec = getSpec(Test, {specType: SpecTypes.OPENAPI});
 

--- a/packages/specs/schema/src/decorators/operations/acceptMime.ts
+++ b/packages/specs/schema/src/decorators/operations/acceptMime.ts
@@ -1,6 +1,6 @@
 import {StoreSet, useDecorators} from "@tsed/core";
 
-import {Consumes} from "./consumes.js";
+import {Produces} from "./produces.js";
 
 /**
  * Set a mime list which are acceptable and checks if the specified content types are acceptable, based on the request’s Accept HTTP header field.
@@ -21,5 +21,5 @@ import {Consumes} from "./consumes.js";
  * @response
  */
 export function AcceptMime(...mimes: string[]): ClassDecorator & MethodDecorator {
-  return useDecorators(Consumes(...mimes), StoreSet("acceptMimes", mimes));
+  return useDecorators(Produces(...mimes), StoreSet("acceptMimes", mimes));
 }


### PR DESCRIPTION
Fixes #3382

## Information

| Type                  | Breaking change |
| --------------------- | --------------- |
| Fix| No          |

---

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/platform-http";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `AcceptMime` now maps supported MIME types to the response content type in generated OpenAPI output, instead of the request body.
  * Verified that the expected MIME type appears in the operation’s output metadata and that request-body content is left unset for this case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->