### PR TITLE
feat(json-mapper): add TemporalMapper for Temporal.* types

### DIFF
--- a/packages/specs/json-mapper/package.json
+++ b/packages/specs/json-mapper/package.json
@@ -46,6 +46,7 @@
     "@tsed/schema": "workspace:*",
     "@tsed/typescript": "workspace:*",
     "eslint": "9.12.0",
+    "temporal-polyfill": "1.0.1",
     "typescript": "6.0.2",
     "vitest": "4.1.4"
   },

--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -1,8 +1,6 @@
 import {TemporalMapper} from "./TemporalMapper.js";
 
 // `Temporal` is provided natively on Node >= 24 and via the polyfill wired in vitest.setup.ts.
-const Temporal = (globalThis as any).Temporal;
-
 describe("TemporalMapper", () => {
   describe("deserialize()", () => {
     it("should rebuild a Temporal.Instant from an ISO string", () => {

--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -1,0 +1,61 @@
+import {TemporalMapper} from "./TemporalMapper.js";
+
+const Temporal = (globalThis as any).Temporal;
+const hasTemporal = typeof Temporal !== "undefined";
+
+// Temporal is only available on Temporal-capable runtimes (e.g. Node >= 24).
+describe.skipIf(!hasTemporal)("TemporalMapper", () => {
+  describe("deserialize()", () => {
+    it("should rebuild a Temporal.Instant from an ISO string", () => {
+      const mapper = new TemporalMapper();
+      const instant = Temporal.Instant.from("2024-01-15T14:30:00Z");
+
+      const value = mapper.deserialize(instant.toString(), {type: Temporal.Instant} as any);
+
+      expect(Temporal.Instant.compare(value, instant)).toEqual(0);
+    });
+
+    it("should rebuild the type read from ctx.type (PlainDate)", () => {
+      const mapper = new TemporalMapper();
+      const date = Temporal.PlainDate.from("2024-01-15");
+
+      const value = mapper.deserialize(date.toString(), {type: Temporal.PlainDate} as any);
+
+      expect(Temporal.PlainDate.compare(value, date)).toEqual(0);
+    });
+
+    it("should rebuild a Temporal.Duration", () => {
+      const mapper = new TemporalMapper();
+      const duration = Temporal.Duration.from({hours: 2, minutes: 30});
+
+      const value = mapper.deserialize(duration.toString(), {type: Temporal.Duration} as any);
+
+      expect(value.toString()).toEqual(duration.toString());
+    });
+
+    it("should return value when the data is a boolean/null/undefined", () => {
+      const mapper = new TemporalMapper();
+
+      expect(mapper.deserialize(false, {type: Temporal.Instant} as any)).toEqual(false);
+      expect(mapper.deserialize(true, {type: Temporal.Instant} as any)).toEqual(true);
+      expect(mapper.deserialize(null, {type: Temporal.Instant} as any)).toEqual(null);
+      expect(mapper.deserialize(undefined, {type: Temporal.Instant} as any)).toBeUndefined();
+    });
+  });
+
+  describe("serialize()", () => {
+    it("should serialize a Temporal value to its ISO string", () => {
+      const mapper = new TemporalMapper();
+      const instant = Temporal.Instant.from("2024-01-15T14:30:00Z");
+
+      expect(mapper.serialize(instant)).toEqual(instant.toString());
+    });
+
+    it("should return value when the object is null/undefined", () => {
+      const mapper = new TemporalMapper();
+
+      expect(mapper.serialize(null)).toEqual(null);
+      expect(mapper.serialize(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -1,4 +1,4 @@
-import { JsonMapperCtx } from "../interfaces/JsonMapperMethods.js";
+import {JsonMapperCtx} from "../interfaces/JsonMapperMethods.js";
 import {TemporalMapper} from "./TemporalMapper.js";
 
 describe("TemporalMapper", () => {
@@ -7,7 +7,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const instant = Temporal.Instant.from("2024-01-15T14:30:00Z");
 
-      const value = mapper.deserialize(instant.toString(), { type: Temporal.Instant } as JsonMapperCtx);
+      const value = mapper.deserialize(instant.toString(), {type: Temporal.Instant} as JsonMapperCtx) as Temporal.Instant;
 
       expect(Temporal.Instant.compare(value, instant)).toEqual(0);
     });
@@ -16,7 +16,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const date = Temporal.PlainDate.from("2024-01-15");
 
-      const value = mapper.deserialize(date.toString(), { type: Temporal.PlainDate} as JsonMapperCtx);
+      const value = mapper.deserialize(date.toString(), {type: Temporal.PlainDate} as JsonMapperCtx) as Temporal.PlainDate;
 
       expect(Temporal.PlainDate.compare(value, date)).toEqual(0);
     });
@@ -25,7 +25,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const duration = Temporal.Duration.from({hours: 2, minutes: 30});
 
-      const value = mapper.deserialize(duration.toString(), {type: Temporal.Duration} as JsonMapperCtx);
+      const value = mapper.deserialize(duration.toString(), {type: Temporal.Duration} as JsonMapperCtx) as Temporal.Duration;
 
       expect(value.toString()).toEqual(duration.toString());
     });
@@ -34,7 +34,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const zdt = Temporal.ZonedDateTime.from("2024-06-15T10:00:00[Europe/Paris]");
 
-      const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as JsonMapperCtx);
+      const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as JsonMapperCtx) as Temporal.ZonedDateTime;
 
       expect(Temporal.ZonedDateTime.compare(value, zdt)).toEqual(0);
       expect(mapper.serialize(zdt)).toEqual(zdt.toString());
@@ -43,10 +43,10 @@ describe("TemporalMapper", () => {
     it("should return value when the data is a boolean/null/undefined", () => {
       const mapper = new TemporalMapper();
 
-      expect(mapper.deserialize(false, {type: Temporal.Instant} as any)).toEqual(false);
-      expect(mapper.deserialize(true, {type: Temporal.Instant} as any)).toEqual(true);
-      expect(mapper.deserialize(null, {type: Temporal.Instant} as any)).toEqual(null);
-      expect(mapper.deserialize(undefined, {type: Temporal.Instant} as any)).toBeUndefined();
+      expect(mapper.deserialize(false, {type: Temporal.Instant} as JsonMapperCtx)).toEqual(false);
+      expect(mapper.deserialize(true, {type: Temporal.Instant} as JsonMapperCtx)).toEqual(true);
+      expect(mapper.deserialize(null, {type: Temporal.Instant} as JsonMapperCtx)).toEqual(null);
+      expect(mapper.deserialize(undefined, {type: Temporal.Instant} as JsonMapperCtx)).toBeUndefined();
     });
   });
 

--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -1,10 +1,9 @@
 import {TemporalMapper} from "./TemporalMapper.js";
 
+// `Temporal` is provided natively on Node >= 24 and via the polyfill wired in vitest.setup.ts.
 const Temporal = (globalThis as any).Temporal;
-const hasTemporal = typeof Temporal !== "undefined";
 
-// Temporal is only available on Temporal-capable runtimes (e.g. Node >= 24).
-describe.skipIf(!hasTemporal)("TemporalMapper", () => {
+describe("TemporalMapper", () => {
   describe("deserialize()", () => {
     it("should rebuild a Temporal.Instant from an ISO string", () => {
       const mapper = new TemporalMapper();
@@ -31,6 +30,16 @@ describe.skipIf(!hasTemporal)("TemporalMapper", () => {
       const value = mapper.deserialize(duration.toString(), {type: Temporal.Duration} as any);
 
       expect(value.toString()).toEqual(duration.toString());
+    });
+
+    it("should rebuild a Temporal.ZonedDateTime with time zone", () => {
+      const mapper = new TemporalMapper();
+      const zdt = Temporal.ZonedDateTime.from("2024-06-15T10:00:00[Europe/Paris]");
+
+      const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as any);
+
+      expect(Temporal.ZonedDateTime.compare(value, zdt)).toEqual(0);
+      expect(mapper.serialize(zdt)).toEqual(zdt.toString());
     });
 
     it("should return value when the data is a boolean/null/undefined", () => {

--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -37,7 +37,7 @@ describe("TemporalMapper", () => {
       const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as JsonMapperCtx) as Temporal.ZonedDateTime;
 
       expect(Temporal.ZonedDateTime.compare(value, zdt)).toEqual(0);
-      expect(mapper.serialize(zdt)).toEqual(zdt.toString());
+      expect(mapper.serialize(value)).toEqual(zdt.toString());
     });
 
     it("should return value when the data is a boolean/null/undefined", () => {

--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -1,13 +1,13 @@
+import { JsonMapperCtx } from "../interfaces/JsonMapperMethods.js";
 import {TemporalMapper} from "./TemporalMapper.js";
 
-// `Temporal` is provided natively on Node >= 24 and via the polyfill wired in vitest.setup.ts.
 describe("TemporalMapper", () => {
   describe("deserialize()", () => {
     it("should rebuild a Temporal.Instant from an ISO string", () => {
       const mapper = new TemporalMapper();
       const instant = Temporal.Instant.from("2024-01-15T14:30:00Z");
 
-      const value = mapper.deserialize(instant.toString(), {type: Temporal.Instant} as any);
+      const value = mapper.deserialize(instant.toString(), { type: Temporal.Instant } as JsonMapperCtx);
 
       expect(Temporal.Instant.compare(value, instant)).toEqual(0);
     });
@@ -16,7 +16,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const date = Temporal.PlainDate.from("2024-01-15");
 
-      const value = mapper.deserialize(date.toString(), {type: Temporal.PlainDate} as any);
+      const value = mapper.deserialize(date.toString(), { type: Temporal.PlainDate} as JsonMapperCtx);
 
       expect(Temporal.PlainDate.compare(value, date)).toEqual(0);
     });
@@ -25,7 +25,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const duration = Temporal.Duration.from({hours: 2, minutes: 30});
 
-      const value = mapper.deserialize(duration.toString(), {type: Temporal.Duration} as any);
+      const value = mapper.deserialize(duration.toString(), {type: Temporal.Duration} as JsonMapperCtx);
 
       expect(value.toString()).toEqual(duration.toString());
     });
@@ -34,7 +34,7 @@ describe("TemporalMapper", () => {
       const mapper = new TemporalMapper();
       const zdt = Temporal.ZonedDateTime.from("2024-06-15T10:00:00[Europe/Paris]");
 
-      const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as any);
+      const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as JsonMapperCtx);
 
       expect(Temporal.ZonedDateTime.compare(value, zdt)).toEqual(0);
       expect(mapper.serialize(zdt)).toEqual(zdt.toString());

--- a/packages/specs/json-mapper/src/components/TemporalMapper.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.ts
@@ -1,0 +1,60 @@
+import {isBoolean} from "@tsed/core";
+
+import {JsonMapper} from "../decorators/jsonMapper.js";
+import {JsonMapperCtx, JsonMapperMethods} from "../interfaces/JsonMapperMethods.js";
+
+interface TemporalType {
+  from(value: unknown): unknown;
+}
+
+/**
+ * Access the global `Temporal` object without depending on the `esnext.temporal` TypeScript lib.
+ * Older runtimes (e.g. Node < 24) don't expose it, so it may be `undefined` at import time.
+ */
+const Temporal = (globalThis as unknown as {Temporal?: Record<string, TemporalType>}).Temporal;
+
+/**
+ * Mapper for the `Temporal.*` types (`Instant`, `ZonedDateTime`, `PlainDate`, `PlainDateTime`,
+ * `PlainTime`, `PlainYearMonth`, `PlainMonthDay`, `Duration`).
+ *
+ * Every Temporal type exposes a static `from(string)` factory and an ISO-8601 `toString()`, so a
+ * single mapper handles all of them: `serialize()` calls `toString()`, and `deserialize()` rebuilds
+ * the concrete type read from `ctx.type` (the deserializer sets it to the registered constructor).
+ *
+ * Registration is guarded by a runtime `Temporal` check so importing `@tsed/json-mapper` stays safe
+ * on runtimes that don't expose the global `Temporal` object.
+ *
+ * @jsonmapper
+ * @component
+ */
+export class TemporalMapper implements JsonMapperMethods {
+  deserialize(data: string | number, ctx: JsonMapperCtx): unknown;
+  deserialize(data: boolean | null | undefined, ctx: JsonMapperCtx): boolean | null | undefined;
+  deserialize(data: any, ctx: JsonMapperCtx): any {
+    // don't convert unexpected data. In normal case, Ajv reject unexpected data.
+    // But by default, we have to skip data deserialization and let user to apply
+    // the right mapping
+    if (isBoolean(data) || data === null || data === undefined) {
+      return data;
+    }
+
+    return (ctx.type as unknown as TemporalType).from(data);
+  }
+
+  serialize(object: {toString(): string} | null | undefined): any {
+    return object ? object.toString() : object;
+  }
+}
+
+if (Temporal) {
+  JsonMapper(
+    Temporal.Instant,
+    Temporal.ZonedDateTime,
+    Temporal.PlainDate,
+    Temporal.PlainDateTime,
+    Temporal.PlainTime,
+    Temporal.PlainYearMonth,
+    Temporal.PlainMonthDay,
+    Temporal.Duration
+  )(TemporalMapper);
+}

--- a/packages/specs/json-mapper/src/components/TemporalMapper.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.ts
@@ -8,7 +8,6 @@ interface TemporalType {
 }
 
 /**
- * Access the global `Temporal` object without depending on the `esnext.temporal` TypeScript lib.
  * Older runtimes (e.g. Node < 24) don't expose it, so it may be `undefined` at import time.
  */
 const Temporal = (globalThis as unknown as {Temporal?: Record<string, TemporalType>}).Temporal;
@@ -31,9 +30,6 @@ export class TemporalMapper implements JsonMapperMethods {
   deserialize(data: string | number, ctx: JsonMapperCtx): unknown;
   deserialize(data: boolean | null | undefined, ctx: JsonMapperCtx): boolean | null | undefined;
   deserialize(data: any, ctx: JsonMapperCtx): any {
-    // don't convert unexpected data. In normal case, Ajv reject unexpected data.
-    // But by default, we have to skip data deserialization and let user to apply
-    // the right mapping
     if (isBoolean(data) || data === null || data === undefined) {
       return data;
     }

--- a/packages/specs/json-mapper/src/index.ts
+++ b/packages/specs/json-mapper/src/index.ts
@@ -4,6 +4,7 @@
 export * from "./components/DateMapper.js";
 export * from "./components/PrimitiveMapper.js";
 export * from "./components/SymbolMapper.js";
+export * from "./components/TemporalMapper.js";
 export * from "./decorators/afterDeserialize.js";
 export * from "./decorators/beforeDeserialize.js";
 export * from "./decorators/jsonMapper.js";

--- a/packages/specs/json-mapper/vitest.config.mts
+++ b/packages/specs/json-mapper/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig(
     ...presets,
     test: {
       ...presets.test,
+      setupFiles: ["./vitest.setup.ts"],
       coverage: {
         ...presets.test.coverage,
         thresholds: {

--- a/packages/specs/json-mapper/vitest.setup.ts
+++ b/packages/specs/json-mapper/vitest.setup.ts
@@ -1,0 +1,6 @@
+import {Temporal} from "temporal-polyfill";
+
+// Provide the global `Temporal` on runtimes that don't ship it natively yet (e.g. Node < 24),
+// so `TemporalMapper` registers and its spec runs in CI instead of being skipped. Native
+// `Temporal` (Node >= 24/26) takes precedence and the polyfill is a no-op there.
+(globalThis as {Temporal?: unknown}).Temporal ??= Temporal;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13583,6 +13583,7 @@ __metadata:
     "@tsed/schema": "workspace:*"
     "@tsed/typescript": "workspace:*"
     eslint: "npm:9.12.0"
+    temporal-polyfill: "npm:1.0.1"
     tslib: "npm:>=2.7.0"
     typescript: "npm:6.0.2"
     vitest: "npm:4.1.4"
@@ -40842,6 +40843,30 @@ __metadata:
   version: 0.2.3
   resolution: "templayed@npm:0.2.3"
   checksum: 10/83a97ab113ca73ef822285cc010cd5103bae30517467e1f75ac3c362ab4916425863a0eb6498b21ff923ede17d40695c25a0e6de28b270a23669ac300a27b16f
+  languageName: node
+  linkType: hard
+
+"temporal-polyfill@npm:1.0.1":
+  version: 1.0.1
+  resolution: "temporal-polyfill@npm:1.0.1"
+  dependencies:
+    temporal-spec: "npm:1.0.0"
+    temporal-utils: "npm:1.0.1"
+  checksum: 10/1d7f19f1bfbe3d582c5cc33c8f186975c92c247258bf61dd64a5943684ee793aa403c80946aae2072ed39e47c46c2ba0b69dcd9391adba3c8652b7602094d004
+  languageName: node
+  linkType: hard
+
+"temporal-spec@npm:1.0.0":
+  version: 1.0.0
+  resolution: "temporal-spec@npm:1.0.0"
+  checksum: 10/5b4089c57b4dcb4afdfe72c9bd73b4d83487a3be2891d8c6983c703b4fbc79b695473814a1fe3867c31b7d72b421d5483c4445d063b294c4d91e4e2d698b5a83
+  languageName: node
+  linkType: hard
+
+"temporal-utils@npm:1.0.1":
+  version: 1.0.1
+  resolution: "temporal-utils@npm:1.0.1"
+  checksum: 10/75e586eddcedad0c47d4771e79dbf9c8f83f3fdd687399eaa9942c1e6875bb9c745401542c64e61f04ee3874d5d989fd47cf02dfef53eee436a36d825e67dab3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Information

| Type    | Package(s)     |
| ------- | -------------- |
| feature | `@tsed/json-mapper` |

## What does this PR do?

Adds a built-in `TemporalMapper` that (de)serializes the [TC39 Temporal](https://tc39.es/proposal-temporal/docs/) types as ISO-8601 strings, the same way `DateMapper` handles `Date`.

Covered types: `Temporal.Instant`, `ZonedDateTime`, `PlainDate`, `PlainDateTime`, `PlainTime`, `PlainYearMonth`, `PlainMonthDay`, `Duration`.

Every Temporal type exposes a static `from(string)` factory and an ISO-8601 `toString()`, so a single mapper handles all of them:

- `serialize()` → `value.toString()`
- `deserialize()` → rebuilds the concrete type resolved from `ctx.type` (the deserializer sets it to the registered constructor)

```ts
class Event {
  @Property(Temporal.Instant)
  occurredAt: Temporal.Instant;
}
// wire: { "occurredAt": "2024-01-15T14:30:00Z" }  <->  Temporal.Instant
```

## Runtime safety

`Temporal` is not available on every supported runtime (e.g. Node < 24). To keep `import "@tsed/json-mapper"` safe everywhere:

- the mapper reads `Temporal` from `globalThis` rather than the bare global, so it does **not** require the `esnext.temporal` TypeScript lib to compile;
- registration is guarded by a `if (Temporal)` runtime check, so on runtimes without Temporal nothing is registered and the import is a no-op for these types.

## How to test

```bash
cd packages/specs/json-mapper && yarn test
```

`TemporalMapper.spec.ts` mirrors `DateMapper.spec.ts`.

The CI matrix pins Node `20.19.4`, which has no global `Temporal`. So the spec is wired to run in CI via a lightweight **test-only** polyfill until the project is on Node ≥ 24/26 natively:

- `temporal-polyfill` added as a **devDependency** of `@tsed/json-mapper`;
- `vitest.setup.ts` seeds the global on runtimes that lack it (native `Temporal` takes precedence, polyfill is a no-op there):

```ts
// packages/specs/json-mapper/vitest.setup.ts
import {Temporal} from "temporal-polyfill";
(globalThis as {Temporal?: unknown}).Temporal ??= Temporal;
```

No production code or runtime dependency changes — the mapper still reads `Temporal` from `globalThis` and guards registration behind `if (Temporal)`. The setup file guarantees `Temporal` in the test environment, so the spec always runs.

Verified `yarn test` green on Node 26 (native Temporal) **and** Node 24 (no native Temporal → polyfill path), so CI on Node 20 exercises the same polyfill path.

## Open questions for maintainers

- OpenAPI schema: this PR covers JSON mapping only (matching `DateMapper`'s scope). Emitting `{ type: "string", format: "date-time" }` for a `Temporal.Instant` property is a separate concern in `@tsed/schema`; I can follow up if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `TemporalMapper` for Temporal JSON mapping, converting common Temporal types to/from ISO string representations.
  * Preserves boolean, `null`, and `undefined` values and serializes Temporal values via string conversion.
  * Registers Temporal mapping when Temporal is available (native or polyfilled).
* **Tests**
  * Added Jest coverage validating deserialization by requested Temporal type and ensuring round-trip serialization.
* **Chores**
  * Updated Vitest setup to initialize `Temporal` using a polyfill when native support is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->