### PR TITLE
feat(json-mapper): serialize time-bearing Temporal types at millisecond precision

### DIFF
--- a/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.spec.ts
@@ -37,7 +37,7 @@ describe("TemporalMapper", () => {
       const value = mapper.deserialize(zdt.toString(), {type: Temporal.ZonedDateTime} as JsonMapperCtx) as Temporal.ZonedDateTime;
 
       expect(Temporal.ZonedDateTime.compare(value, zdt)).toEqual(0);
-      expect(mapper.serialize(value)).toEqual(zdt.toString());
+      expect(mapper.serialize(value)).toEqual(zdt.toString({fractionalSecondDigits: 3}));
     });
 
     it("should return value when the data is a boolean/null/undefined", () => {
@@ -51,11 +51,27 @@ describe("TemporalMapper", () => {
   });
 
   describe("serialize()", () => {
-    it("should serialize a Temporal value to its ISO string", () => {
+    it("should serialize a time-bearing Temporal value at millisecond precision", () => {
       const mapper = new TemporalMapper();
-      const instant = Temporal.Instant.from("2024-01-15T14:30:00Z");
 
-      expect(mapper.serialize(instant)).toEqual(instant.toString());
+      // sub-millisecond precision is truncated to milliseconds (like Date#toISOString)
+      expect(mapper.serialize(Temporal.Instant.from("2024-01-15T14:30:00.195360107Z"))).toEqual("2024-01-15T14:30:00.195Z");
+      // whole seconds still render three fractional digits
+      expect(mapper.serialize(Temporal.Instant.from("2024-01-15T14:30:00Z"))).toEqual("2024-01-15T14:30:00.000Z");
+      expect(mapper.serialize(Temporal.PlainDateTime.from("2024-01-15T14:30:00.195360107"))).toEqual("2024-01-15T14:30:00.195");
+      expect(mapper.serialize(Temporal.PlainTime.from("14:30:00.195360107"))).toEqual("14:30:00.195");
+      expect(mapper.serialize(Temporal.ZonedDateTime.from("2024-06-15T10:00:00.195360107[Europe/Paris]"))).toEqual(
+        "2024-06-15T10:00:00.195+02:00[Europe/Paris]"
+      );
+    });
+
+    it("should serialize date-only and duration values with their default toString", () => {
+      const mapper = new TemporalMapper();
+
+      expect(mapper.serialize(Temporal.PlainDate.from("2024-01-15"))).toEqual("2024-01-15");
+      expect(mapper.serialize(Temporal.PlainYearMonth.from("2024-01"))).toEqual("2024-01");
+      expect(mapper.serialize(Temporal.PlainMonthDay.from("01-15"))).toEqual("01-15");
+      expect(mapper.serialize(Temporal.Duration.from({hours: 2, minutes: 30}))).toEqual("PT2H30M");
     });
 
     it("should return value when the object is null/undefined", () => {

--- a/packages/specs/json-mapper/src/components/TemporalMapper.ts
+++ b/packages/specs/json-mapper/src/components/TemporalMapper.ts
@@ -13,12 +13,21 @@ interface TemporalType {
 const Temporal = (globalThis as unknown as {Temporal?: Record<string, TemporalType>}).Temporal;
 
 /**
+ * Temporal types that carry a sub-second time component. These serialize at millisecond precision
+ * (`fractionalSecondDigits: 3`) to match the historical `Date#toISOString()` output that JSON
+ * consumers expect, instead of leaking nanoseconds. The date-only types (`PlainDate`,
+ * `PlainYearMonth`, `PlainMonthDay`) and `Duration` keep their default `toString()`.
+ */
+const TIME_BEARING_TYPES = Temporal ? [Temporal.Instant, Temporal.ZonedDateTime, Temporal.PlainDateTime, Temporal.PlainTime] : [];
+
+/**
  * Mapper for the `Temporal.*` types (`Instant`, `ZonedDateTime`, `PlainDate`, `PlainDateTime`,
  * `PlainTime`, `PlainYearMonth`, `PlainMonthDay`, `Duration`).
  *
  * Every Temporal type exposes a static `from(string)` factory and an ISO-8601 `toString()`, so a
- * single mapper handles all of them: `serialize()` calls `toString()`, and `deserialize()` rebuilds
- * the concrete type read from `ctx.type` (the deserializer sets it to the registered constructor).
+ * single mapper handles all of them: `serialize()` calls `toString()` (at millisecond precision for
+ * the time-bearing types, see {@link TIME_BEARING_TYPES}), and `deserialize()` rebuilds the concrete
+ * type read from `ctx.type` (the deserializer sets it to the registered constructor).
  *
  * Registration is guarded by a runtime `Temporal` check so importing `@tsed/json-mapper` stays safe
  * on runtimes that don't expose the global `Temporal` object.
@@ -37,8 +46,16 @@ export class TemporalMapper implements JsonMapperMethods {
     return (ctx.type as unknown as TemporalType).from(data);
   }
 
-  serialize(object: {toString(): string} | null | undefined): any {
-    return object ? object.toString() : object;
+  serialize(object: {toString(options?: {fractionalSecondDigits?: number}): string} | null | undefined): any {
+    if (!object) {
+      return object;
+    }
+
+    if (TIME_BEARING_TYPES.some((type) => object instanceof (type as unknown as abstract new (...args: any[]) => unknown))) {
+      return object.toString({fractionalSecondDigits: 3});
+    }
+
+    return object.toString();
   }
 }
 


### PR DESCRIPTION
## Information

| Q                       | A
| ----------------------- | ---
| Bug fix / enhancement   | enhancement
| Breaking change         | behavioral (serialized precision), see below

## Description

`TemporalMapper` currently serializes every `Temporal.*` value with a bare `toString()`. For the time-bearing types (`Instant`, `ZonedDateTime`, `PlainDateTime`, `PlainTime`), `toString()` emits **whatever precision the value carries — up to nanoseconds**:

```ts
Temporal.Instant.from("2024-01-15T14:30:00.195360107Z").toString();
// "2024-01-15T14:30:00.195360107Z"
```

That diverges from the wire format JSON consumers have always gotten from `Date#toISOString()` (always **milliseconds**), and leaks sub-millisecond noise into API responses / OpenAPI `date-time` fields.

## Change

Serialize the four time-bearing types with `{ fractionalSecondDigits: 3 }`, so they always render exactly three fractional digits — millisecond precision, extra digits truncated — matching `Date#toISOString()`:

```ts
// after
Temporal.Instant.from("2024-01-15T14:30:00.195360107Z") -> "2024-01-15T14:30:00.195Z"
Temporal.Instant.from("2024-01-15T14:30:00Z")           -> "2024-01-15T14:30:00.000Z"
```

Date-only types (`PlainDate`, `PlainYearMonth`, `PlainMonthDay`) and `Duration` keep their default `toString()`: the option is meaningless for date-only values and would wrongly force a seconds component onto durations (`PT1H` -> `PT1H0.000S`).

## Note on precision

This is intentionally opinionated toward the common JSON/`date-time` convention (milliseconds). If a use case needs full nanosecond precision, this could later be made configurable via a schema option; happy to follow up if maintainers prefer that shape.

## Tests

- `TemporalMapper.spec` extended: ms truncation for the time-bearing types, `.000` for whole seconds, and unchanged output for date-only / `Duration`.
- Full `@tsed/json-mapper` suite passes (178).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporal values with time components are now serialized consistently with exactly millisecond precision.
  * Sub-millisecond precision is truncated for instants, times, date-times, and zoned date-times.
  * Date-only and duration values retain their standard serialization format.

* **Tests**
  * Expanded coverage to verify precision handling and formatting across supported Temporal value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->